### PR TITLE
feat!: update to the 2023-09 job template schema

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,22 +55,22 @@ farm that uses a service-managed fleet. You'll need to perform the following ste
 your build of the adaptor for the one in the service.
 
 1. Use the development location from the Submitter Development Workflow.
-   You will need to also check out `openjobio` from git if you do
+   You will need to also check out `openjd` from git if you do
    not already have it. Make sure you're running Nuke with `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true`
    enabled.
-2. Build wheels for `openjobio`, `deadline` and `deadline-nuke`.
+2. Build wheels for `openjd`, `deadline` and `deadline-nuke`.
    ```
    # If you don't have the build package installed already
    $ pip install build
    ...
    $  mkdir wheels; \
       rm wheels/*; \
-      for dir in ../openjobio ../deadline ../deadline-nuke; \
+      for dir in ../openjd ../deadline ../deadline-nuke; \
         do python -m build --wheel --outdir ./wheels --skip-dependency-check $dir; \
       done
    ...
    $ ls ./wheels
-   openjobio-<version>-py3-none-any.whl
+   openjd-<version>-py3-none-any.whl
    deadline_cloud_for_nuke-<version>-py3-none-any.whl  deadline-<version>-py3-none-any.whl
    ```
 3. Open the Nuke integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This

--- a/depsBundle.py
+++ b/depsBundle.py
@@ -35,8 +35,8 @@ def _get_dependencies(pyproject_dict: dict[str, Any]) -> list[str]:
         raise Exception("pyproject.toml is missing dependencies section")
 
     dependencies = pyproject_dict["project"]["dependencies"]
-    deps_noopenjobio = filter(lambda dep: not dep.startswith("openjobio"), dependencies)
-    return list(map(lambda dep: dep.replace(" ", ""), deps_noopenjobio))
+    deps_noopenjd = filter(lambda dep: not dep.startswith("openjd"), dependencies)
+    return list(map(lambda dep: dep.replace(" ", ""), deps_noopenjd))
 
 
 def _get_package_version_regex(package: str) -> re.Pattern:

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: jobtemplate-2023-09
 name: multi-load-save.nk
-parameters:
+parameterDefinitions:
 - name: NukeScriptFile
   type: PATH
   objectType: FILE
@@ -74,7 +74,7 @@ parameters:
     label: Rez Packages
   description: A space-separated list of Rez packages to install
   default: nuke-13 deadline_cloud_for_nuke
-environments:
+jobEnvironments:
 - name: Rez
   description: Initializes and destroys the Rez environment for the job.
   script:
@@ -159,17 +159,17 @@ environments:
 
         for k, v in put.items():
             print(f"updating {k}={v}")
-            print(f"openjobio_env: {k}={v}")
+            print(f"openjd_env: {k}={v}")
         for k in delete:
-            print(f"openjobio_unset_env: {k}")
+            print(f"openjd_unset_env: {k}")
 steps:
 - name: Render
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
-  environments:
+  stepEnvironments:
   - name: Nuke
     description: Runs Nuke in the background with a script file loaded.
     script:

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: jobtemplate-2023-09
 name: noise-saver.nk
-parameters:
+parameterDefinitions:
 - name: NukeScriptFile
   type: PATH
   objectType: FILE
@@ -72,7 +72,7 @@ parameters:
     label: Rez Packages
   description: A space-separated list of Rez packages to install
   default: nuke-13 deadline_cloud_for_nuke
-environments:
+jobEnvironments:
 - name: Rez
   description: Initializes and destroys the Rez environment for the job.
   script:
@@ -157,17 +157,17 @@ environments:
 
         for k, v in put.items():
             print(f"updating {k}={v}")
-            print(f"openjobio_env: {k}={v}")
+            print(f"openjd_env: {k}={v}")
         for k in delete:
-            print(f"openjobio_unset_env: {k}")
+            print(f"openjd_unset_env: {k}")
 steps:
 - name: Render
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
-  environments:
+  stepEnvironments:
   - name: Nuke
     description: Runs Nuke in the background with a script file loaded.
     script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.20.*",
-    "openjobio == 0.8.*",
+    "deadline == 0.21.*",
+    "openjd == 0.10.*",
 ]
 
 [project.scripts]

--- a/src/deadline/nuke_adaptor/NukeAdaptor/__main__.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/__main__.py
@@ -3,7 +3,7 @@
 import logging as _logging
 import sys as _sys
 
-from openjobio.adaptor_runtime import EntryPoint as _EntryPoint
+from openjd.adaptor_runtime import EntryPoint as _EntryPoint
 
 from .adaptor import NukeAdaptor
 

--- a/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
@@ -10,11 +10,11 @@ import threading
 import time
 from typing import Callable, cast
 
-from openjobio.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators
-from openjobio.adaptor_runtime_client import Action
-from openjobio.adaptor_runtime.process import LoggingSubprocess
-from openjobio.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
-from openjobio.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
+from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators
+from openjd.adaptor_runtime_client import Action
+from openjd.adaptor_runtime.process import LoggingSubprocess
+from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
+from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
 
 _logger = logging.getLogger(__name__)
 
@@ -420,16 +420,16 @@ class NukeAdaptor(Adaptor):
         nuke_exe = "nuke"
         regexhandler = RegexHandler(self.regex_callbacks)
 
-        # Add the OpenJobIO namespace directory to PYTHONPATH, so that adaptor_runtime_client
+        # Add the Open Job Description namespace directory to PYTHONPATH, so that adaptor_runtime_client
         # will be available directly to the nuke client.
-        import openjobio.adaptor_runtime_client
+        import openjd.adaptor_runtime_client
         import deadline.nuke_adaptor
 
-        openjobio_namespace_dir = os.path.dirname(
-            os.path.dirname(openjobio.adaptor_runtime_client.__file__)
+        openjd_namespace_dir = os.path.dirname(
+            os.path.dirname(openjd.adaptor_runtime_client.__file__)
         )
         deadline_namespace_dir = os.path.dirname(os.path.dirname(deadline.nuke_adaptor.__file__))
-        python_path_addition = f"{openjobio_namespace_dir}{os.pathsep}{deadline_namespace_dir}"
+        python_path_addition = f"{openjd_namespace_dir}{os.pathsep}{deadline_namespace_dir}"
         if "PYTHONPATH" in os.environ:
             os.environ[
                 "PYTHONPATH"

--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -11,7 +11,7 @@ from typing import (
     Optional,
 )
 
-# The Nuke Adaptor adds the `openjobio` namespace directory to PYTHONPATH,
+# The Nuke Adaptor adds the `openjd` namespace directory to PYTHONPATH,
 # so that importing just the adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import (  # type: ignore[import]
@@ -20,7 +20,7 @@ try:
     )
     from nuke_adaptor.NukeClient.nuke_handler import NukeHandler  # type: ignore[import]
 except ImportError:
-    from openjobio.adaptor_runtime_client import (
+    from openjd.adaptor_runtime_client import (
         HTTPClientInterface as _HTTPClientInterface,
         PathMappingRule,
     )

--- a/src/deadline/nuke_submitter/adaptor_override_environment.yaml
+++ b/src/deadline/nuke_submitter/adaptor_override_environment.yaml
@@ -1,10 +1,10 @@
-specificationVersion: '2022-09-01'
-parameters:
+specificationVersion: 'jobtemplate-2023-09'
+parameterDefinitions:
 - name: AdaptorWheels
   type: PATH
   objectType: DIRECTORY
   dataFlow: IN
-  description: A directory that contains wheels for openjobio, deadline, and the overridden adaptor.
+  description: A directory that contains wheels for openjd, deadline, and the overridden adaptor.
 - name: OverrideAdaptorName
   type: STRING
   description: The name of the adaptor to override, for example NukeAdaptor or MayaAdaptor.
@@ -40,7 +40,7 @@ environment:
         echo ""
 
         echo "Installing adaptor into the venv"
-        pip install {{Param.AdaptorWheels}}/openjobio*.whl
+        pip install {{Param.AdaptorWheels}}/openjd*.whl
         pip install {{Param.AdaptorWheels}}/deadline*.whl
         echo ""
 
@@ -79,6 +79,6 @@ environment:
 
         for k, v in put.items():
             print(f"updating {k}={v}")
-            print(f"openjobio_env: {k}={v}")
+            print(f"openjd_env: {k}={v}")
         for k in delete:
-            print(f"openjobio_unset_env: {k}")
+            print(f"openjd_unset_env: {k}")

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -110,7 +110,7 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
     job_template["name"] = settings.name
 
     # Get a map of the parameter definitions for easier lookup
-    parameter_def_map = {param["name"]: param for param in job_template["parameters"]}
+    parameter_def_map = {param["name"]: param for param in job_template["parameterDefinitions"]}
 
     # Set the WriteNode parameter allowed values
     parameter_def_map["WriteNode"]["allowedValues"].extend(
@@ -135,33 +135,33 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
         wheels_path_package_names = {
             path.split("-", 1)[0] for path in os.listdir(wheels_path) if path.endswith(".whl")
         }
-        if wheels_path_package_names != {"openjobio", "deadline", "deadline_cloud_for_nuke"}:
+        if wheels_path_package_names != {"openjd", "deadline", "deadline_cloud_for_nuke"}:
             raise RuntimeError(
                 "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory contains the wrong wheels:\n"
-                + "Expected: openjobio, deadline, and deadline_cloud_for_nuke\n"
+                + "Expected: openjd, deadline, and deadline_cloud_for_nuke\n"
                 + f"Actual: {wheels_path_package_names}"
             )
 
         adaptor_wheels_param = [
             param
-            for param in override_environment["parameters"]
+            for param in override_environment["parameterDefinitions"]
             if param["name"] == "AdaptorWheels"
         ][0]
         adaptor_wheels_param["default"] = str(wheels_path)
         override_adaptor_name_param = [
             param
-            for param in override_environment["parameters"]
+            for param in override_environment["parameterDefinitions"]
             if param["name"] == "OverrideAdaptorName"
         ][0]
         override_adaptor_name_param["default"] = "NukeAdaptor"
 
         # There are no parameter conflicts between these two templates, so this works
-        job_template["parameters"].extend(override_environment["parameters"])
+        job_template["parameterDefinitions"].extend(override_environment["parameters"])
 
         # Add the environment to the end of the template's job environments
         if "environments" not in job_template:
-            job_template["environments"] = []
-        job_template["environments"].append(override_environment["environment"])
+            job_template["jobEnvironments"] = []
+        job_template["jobEnvironments"].append(override_environment["environment"])
 
     return job_template
 

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: jobtemplate-2023-09
 name: Default Nuke Job Template
-parameters:
+parameterDefinitions:
 - name: NukeScriptFile
   type: PATH
   objectType: FILE
@@ -70,7 +70,7 @@ parameters:
     label: Rez Packages
   description: A space-separated list of Rez packages to install
   default: nuke-13 deadline_cloud_for_nuke
-environments:
+jobEnvironments:
 - name: Rez
   description: Initializes and destroys the Rez environment for the job.
   script:
@@ -155,17 +155,17 @@ environments:
 
         for k, v in put.items():
             print(f"updating {k}={v}")
-            print(f"openjobio_env: {k}={v}")
+            print(f"openjd_env: {k}={v}")
         for k in delete:
-            print(f"openjobio_unset_env: {k}")
+            print(f"openjd_unset_env: {k}")
 steps:
 - name: Render
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
-  environments:
+  stepEnvironments:
   - name: Nuke
     description: Runs Nuke in the background with a script file loaded.
     script:

--- a/test/deadline_adaptor_for_nuke/unit/NukeClient/test_client.py
+++ b/test/deadline_adaptor_for_nuke/unit/NukeClient/test_client.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 
 import nuke
 import pytest
-from openjobio.adaptor_runtime_client import (
+from openjd.adaptor_runtime_client import (
     HTTPClientInterface,
     PathMappingRule,
 )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The job template schema is being updated prior to launch.

The existing template format is

```json
{
    "specificationVersion": "2022-09-01",
    "parameters": [...],
    "environments": [...],
    "steps": [
        {
            "name": "name",
            "parameterSpace": {
                "parameters": [...]
            },
            "environments": [...],
            "requiredCapabilities": [
                {
                    "name": "amount.worker.vcpu",
                    "min": 2
                },
                {
                    "name": "attr.worker.os.family",
                    "anyOf": ["linux", "macos"]
                },
                ...
            ],
            ...
        }
    ]
}
```

And the new template format will is:
```json
{
    "specificationVersion": "jobtemplate-2023-09",
    "parameterDefinitions": [...],
    "jobEnvironments": [...],
    "steps": [
        {
            "name": "name",
            "parameterSpace": {
                "taskParameterDefinitions": [...]
            },
            "stepEnvironments": [...],
            "hostRequirements": {
                "amounts": [
                    {
                        "name": "amount.worker.vcpu",
                        "min": 2
                    },
                    ...
                ],
                "attributes": [
                    {
                        "name": "attr.worker.os.family",
                        "anyOf": ["linux", "macos"]
                    },
                    ...
                ]
            },
            ...
        }
    ]
}
```

### What was the solution? (How)

Updating the templates encoded in to the submitter, and bumping the dep version of the library.

### What is the impact of this change?

Compatibility with the service going forward.

### How was this change tested?

I have not yet tested it; I'm not at all set up for it. The change is simple, but I wouldn't turn down a volunteer to run it through its paces before we merge.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

Yes, in the template schema

### Is this a breaking change?

Yes.