### PR TITLE
refactor!: Some small cleanups and tweaks of developer mode and similar

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,7 +44,7 @@ WARNING: This workflow installs additional Python packages into your Nuke's pyth
    in edit mode.
 6. Run `set NUKE_PATH=C:\Users\<username>\deadline-clients\deadline-nuke\src` to put the `menu.py`
    file in the path Nuke searches for menu extensions.
-7. Run `set DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS=true` to enable the job bundle debugging support.
+7. Run `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` to enable the job bundle debugging support.
    This enables a menu item you can use to run the tests from the `job_bundle_output_tests` directory.
 8. Run `.\Nuke<version>.exe` to run Nuke. The Nuke submitter should be available in the Thinkbox menu.
 
@@ -56,7 +56,7 @@ your build of the adaptor for the one in the service.
 
 1. Use the development location from the Submitter Development Workflow.
    You will need to also check out `openjobio` from git if you do
-   not already have it. Make sure you're running Nuke with `set DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS=true`
+   not already have it. Make sure you're running Nuke with `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true`
    enabled.
 2. Build wheels for `openjobio`, `deadline` and `deadline-nuke`.
    ```
@@ -74,5 +74,5 @@ your build of the adaptor for the one in the service.
    deadline_nuke-<version>-py3-none-any.whl  deadline-<version>-py3-none-any.whl
    ```
 3. Open the Nuke integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This
-   option is only visible when the environment variable `DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS` is set to `true`.
+   option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`.
    Then submit your test job.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.16.*",
+    "deadline == 0.17.*",
     "openjobio == 0.8.*",
 ]
 

--- a/src/deadline/nuke_submitter/adaptor_override_environment.yaml
+++ b/src/deadline/nuke_submitter/adaptor_override_environment.yaml
@@ -4,19 +4,22 @@ parameters:
   type: PATH
   objectType: DIRECTORY
   dataFlow: IN
-  description: A directory that contains wheels for openjobio, deadline, and deadline-nuke.
+  description: A directory that contains wheels for openjobio, deadline, and the overridden adaptor.
+- name: OverrideAdaptorName
+  type: STRING
+  description: The name of the adaptor to override, for example NukeAdaptor or MayaAdaptor.
 environment:
-  name: OverrideNukeAdaptor
+  name: OverrideAdaptor
   description: >
-    Replaces the default NukeAdaptor in the environment's PATH with one from the
-    AdaptorWheels parameter.
+    Replaces the default Adaptor in the environment's PATH with one from the
+    packages in the AdaptorWheels attached directory.
   script:
     actions:
       onEnter:
-        command: '{{ Env.File.Enter }}'
+        command: '{{Env.File.Enter}}'
     embeddedFiles:
     - name: Enter
-      filename: nuke-adaptor-enter.sh
+      filename: override-adaptor-enter.sh
       type: TEXT
       runnable: true
       data: |
@@ -28,19 +31,8 @@ environment:
         ls {{Param.AdaptorWheels}}/
         echo ""
 
-        # Assert that the `python3` command is Nuke's python
-        which python3 | grep -q -i nuke
-
-        # Remove some packages that might have been installed
-        echo "Uninstalling adaptor packages that may be in the Nuke installation"
-        python3 -m pip uninstall deadline-nuke || true
-        python3 -m pip uninstall deadline_nuke || true
-        python3 -m pip uninstall deadline || true
-        python3 -m pip uninstall openjobio || true
-        echo ""
-
         # Create a venv and activate it in this environment
-        echo "Creating Python venv for the NukeAdaptor command"
+        echo "Creating Python venv for the {{Param.OverrideAdaptor}} command"
         /usr/local/bin/python3 -m venv '{{Session.WorkingDirectory}}/venv'
         {{Env.File.InitialVars}}
         . '{{Session.WorkingDirectory}}/venv/bin/activate'
@@ -52,8 +44,8 @@ environment:
         pip install {{Param.AdaptorWheels}}/deadline*.whl
         echo ""
 
-        if [ ! -f '{{Session.WorkingDirectory}}/venv/bin/NukeAdaptor' ]; then
-          echo "The Nuke Adaptor was not installed as expected."
+        if [ ! -f '{{Session.WorkingDirectory}}/venv/bin/{{Param.OverrideAdaptorName}}' ]; then
+          echo "The Override Adaptor {{Param.OverrideAdaptorName}} was not installed as expected."
           exit 1
         fi
     - name: InitialVars

--- a/src/deadline/nuke_submitter/data_classes/submission.py
+++ b/src/deadline/nuke_submitter/data_classes/submission.py
@@ -29,8 +29,8 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
         default_factory=lambda: Path(get_nuke_script_file()).name if get_nuke_script_file() else ""
     )
     description: str = field(default="")
-    override_installation_requirements: bool = field(default=True)
-    installation_requirements: str = field(default="nuke-13 deadline_nuke")
+    override_rez_packages: bool = field(default=True)
+    rez_packages: str = field(default="nuke-13 deadline_nuke")
 
     override_frame_range: bool = field(default=False)
     frame_list: str = field(default_factory=lambda: str(nuke.root().frameRange()))
@@ -41,8 +41,8 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     # settings with defaults
     submitter_name: str = field(default="Nuke")
     initial_status: str = field(default="READY")
-    failed_tasks_limit: int = field(default=100)
-    task_retry_limit: int = field(default=5)
+    max_failed_tasks_count: int = field(default=100)
+    max_retries_per_task: int = field(default=5)
     priority: int = field(default=50)
 
     input_filenames: list[str] = field(default_factory=list)
@@ -56,16 +56,16 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
         return RenderSubmitterSettings(
             name=self.name,
             description=self.description,
-            override_installation_requirements=self.override_installation_requirements,
-            installation_requirements=self.installation_requirements,
+            override_rez_packages=self.override_rez_packages,
+            rez_packages=self.rez_packages,
             override_frame_range=self.override_frame_range,
             frame_list=self.frame_list,
             write_node_selection=_node_to_str(self.write_node_selection),
             view_selection=self.view_selection,
             is_proxy_mode=self.is_proxy_mode,
             initial_status=self.initial_status,
-            failed_tasks_limit=self.failed_tasks_limit,
-            task_retry_limit=self.task_retry_limit,
+            max_failed_tasks_count=self.max_failed_tasks_count,
+            max_retries_per_task=self.max_retries_per_task,
             priority=self.priority,
             input_filenames=self.input_filenames,
             input_directories=self.input_directories,
@@ -76,16 +76,16 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     def apply_saved_settings(self, settings: RenderSubmitterSettings) -> None:
         self.name = settings.name
         self.description = settings.description
-        self.override_installation_requirements = settings.override_installation_requirements
-        self.installation_requirements = settings.installation_requirements
+        self.override_rez_packages = settings.override_rez_packages
+        self.rez_packages = settings.rez_packages
         self.override_frame_range = settings.override_frame_range
         self.frame_list = settings.frame_list
         self.write_node_selection = _str_to_node(settings.write_node_selection)
         self.view_selection = settings.view_selection
         self.is_proxy_mode = settings.is_proxy_mode
         self.initial_status = settings.initial_status
-        self.failed_tasks_limit = settings.failed_tasks_limit
-        self.task_retry_limit = settings.task_retry_limit
+        self.max_failed_tasks_count = settings.max_failed_tasks_count
+        self.max_retries_per_task = settings.max_retries_per_task
         self.priority = settings.priority
         self.input_filenames = settings.input_filenames
         self.input_directories = settings.input_directories
@@ -101,8 +101,8 @@ class RenderSubmitterSettings:  # pylint: disable=too-many-instance-attributes
 
     name: str
     description: str
-    override_installation_requirements: bool
-    installation_requirements: str
+    override_rez_packages: bool
+    rez_packages: str
 
     override_frame_range: bool
     frame_list: str
@@ -111,8 +111,8 @@ class RenderSubmitterSettings:  # pylint: disable=too-many-instance-attributes
     is_proxy_mode: bool
 
     initial_status: str
-    failed_tasks_limit: int
-    task_retry_limit: int
+    max_failed_tasks_count: int
+    max_retries_per_task: int
     priority: int
 
     # settings with defaults

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -30,7 +30,7 @@ class SceneSettingsWidget(QWidget):
         super().__init__(parent=parent)
 
         self.developer_options = (
-            os.environ.get("DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE"
+            os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE"
         )
 
         self._build_ui()

--- a/src/menu.py
+++ b/src/menu.py
@@ -21,8 +21,8 @@ try:
     menu_bar = nuke.menu("Nuke")
     thinkbox_menu = menu_bar.addMenu("&Thinkbox")
     thinkbox_menu.addCommand("Submit Nuke To Deadline", show_nuke_render_submitter_noargs, "")
-    # Set the environment variable DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
-    if os.environ.get("DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
+    # Set the environment variable DEADLINE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
+    if os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
         thinkbox_menu.addCommand(
             "Run Nuke Submitter Job Bundle Output Tests...",
             run_nuke_render_submitter_job_bundle_output_test,


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

While working on the Maya submitter and the deadline client lib, have done a few tweaks to the code in Nuke, and need to update for the breaking change in deadline client lib.

### What was the solution? (How)

- Remove unused INIT_DATA_CONTENTS
- Rename DEADLINE_NUKE_ENABLE_DEVELOPER_OPTIONS to DEADLINE_ENABLE_DEVELOPER_OPTIONS so we can use it consistently across multiple plugins.
- Modify adaptor_override_environment.yaml so that it's not Nuke-specific, and we'll be able to move it to the deadline-cloud package.
- Update installation_requirements to rez_packages, failed_tasks_limit to max_failed_tasks_count, and task_retry_limit to max_retries_per_task, following changes in deadline-cloud.
- Update the codebase for https://github.com/casillas2/deadline-cloud/pull/15
 
### What is the impact of this change?

Cleaner structure, names are consistent with the service.

### How was this change tested?

Loaded Nuke with the modifications, confirmed the dialog worked. Ran the job bundle output tests.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Running job bundle output test: C:/Users/markw/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Running job bundle output test: C:/Users/markw/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

All tests passed, ran 2 total.
```

### Was this change documented?

No

### Is this a breaking change?

Yes, it follows a deadline-cloud breaking change.