### PR TITLE
fix!: Update the rez package name from deadline_nuke to deadline_cloud_for_nuke

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,7 +71,7 @@ your build of the adaptor for the one in the service.
    ...
    $ ls ./wheels
    openjobio-<version>-py3-none-any.whl
-   deadline_nuke-<version>-py3-none-any.whl  deadline-<version>-py3-none-any.whl
+   deadline_cloud_for_nuke-<version>-py3-none-any.whl  deadline-<version>-py3-none-any.whl
    ```
 3. Open the Nuke integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This
    option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`.

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
@@ -16,4 +16,4 @@ parameterValues:
 - name: NukeVersion
   value: 13.2v4
 - name: RezPackages
-  value: nuke-13 deadline_nuke
+  value: nuke-13 deadline_cloud_for_nuke

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
@@ -73,7 +73,7 @@ parameters:
     control: LINE_EDIT
     label: Rez Packages
   description: A space-separated list of Rez packages to install
-  default: nuke-13 deadline_nuke
+  default: nuke-13 deadline_cloud_for_nuke
 environments:
 - name: Rez
   description: Initializes and destroys the Rez environment for the job.

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
@@ -16,4 +16,4 @@ parameterValues:
 - name: NukeVersion
   value: 13.2v4
 - name: RezPackages
-  value: nuke-13 deadline_nuke
+  value: nuke-13 deadline_cloud_for_nuke

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
@@ -71,7 +71,7 @@ parameters:
     control: LINE_EDIT
     label: Rez Packages
   description: A space-separated list of Rez packages to install
-  default: nuke-13 deadline_nuke
+  default: nuke-13 deadline_cloud_for_nuke
 environments:
 - name: Rez
   description: Initializes and destroys the Rez environment for the job.

--- a/src/deadline/nuke_submitter/data_classes/submission.py
+++ b/src/deadline/nuke_submitter/data_classes/submission.py
@@ -30,7 +30,7 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     )
     description: str = field(default="")
     override_rez_packages: bool = field(default=True)
-    rez_packages: str = field(default="nuke-13 deadline_nuke")
+    rez_packages: str = field(default="nuke-13 deadline_cloud_for_nuke")
 
     override_frame_range: bool = field(default=False)
     frame_list: str = field(default_factory=lambda: str(nuke.root().frameRange()))

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -135,10 +135,10 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
         wheels_path_package_names = {
             path.split("-", 1)[0] for path in os.listdir(wheels_path) if path.endswith(".whl")
         }
-        if wheels_path_package_names != {"openjobio", "deadline", "deadline_nuke"}:
+        if wheels_path_package_names != {"openjobio", "deadline", "deadline_cloud_for_nuke"}:
             raise RuntimeError(
                 "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory contains the wrong wheels:\n"
-                + "Expected: openjobio, deadline, and deadline_nuke\n"
+                + "Expected: openjobio, deadline, and deadline_cloud_for_nuke\n"
                 + f"Actual: {wheels_path_package_names}"
             )
 

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -69,7 +69,7 @@ parameters:
     control: LINE_EDIT
     label: Rez Packages
   description: A space-separated list of Rez packages to install
-  default: nuke-13 deadline_nuke
+  default: nuke-13 deadline_cloud_for_nuke
 environments:
 - name: Rez
   description: Initializes and destroys the Rez environment for the job.


### PR DESCRIPTION
BREAKING-CHANGE: Changes the name of the expected rez nuke adaptor package.

### What was the problem/requirement? (What/Why)

Rez package name for Nuke submitter/adaptor is wrong.

### What was the solution? (How)

Fix it.

### What is the impact of this change?

More polish.

### How was this change tested?

Ran the job bundle output tests

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Running job bundle output test: C:/Users/markw/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Running job bundle output test: C:/Users/markw/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

All tests passed, ran 2 total.
```

### Was this change documented?

No

### Is this a breaking change?

Yes