### PR TITLE
chore: bump deadline-cloud dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.17.*",
+    "deadline == 0.19.*",
     "openjobio == 0.8.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
deadline-cloud was updated to 0.19.0 and deadline-cloud-for-nuke needs to point to the latest version.

### What was the solution? (How)
Update the version of deadline-cloud required.

### What is the impact of this change?
deadline-cloud-for-nuke uses the latest deadline-cloud

### How was this change tested?
`hatch run fmt && hatch run lint && hatch run test`

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, because of time.

### Was this change documented?
No

### Is this a breaking change?
Possibly yes