### PR TITLE
Fix depsBundle.sh zip name

### DIFF
--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -3,10 +3,10 @@ set -xeuo pipefail
 
 python depsBundle.py
 
-rm -f dependency_bundle/deadline_submitter_for_nuke-deps-windows.zip
-rm -f dependency_bundle/deadline_submitter_for_nuke-deps-linux.zip
-rm -f dependency_bundle/deadline_submitter_for_nuke-deps-macos.zip
+rm -f dependency_bundle/deadline_cloud_for_nuke_submitter-deps-windows.zip
+rm -f dependency_bundle/deadline_cloud_for_nuke_submitter-deps-linux.zip
+rm -f dependency_bundle/deadline_cloud_for_nuke_submitter-deps-macos.zip
 
-cp dependency_bundle/deadline_submitter_for_nuke-deps.zip dependency_bundle/deadline_submitter_for_nuke-deps-windows.zip
-cp dependency_bundle/deadline_submitter_for_nuke-deps.zip dependency_bundle/deadline_submitter_for_nuke-deps-linux.zip
-cp dependency_bundle/deadline_submitter_for_nuke-deps.zip dependency_bundle/deadline_submitter_for_nuke-deps-macos.zip
+cp dependency_bundle/deadline_cloud_for_nuke_submitter-deps.zip dependency_bundle/deadline_cloud_for_nuke_submitter-deps-windows.zip
+cp dependency_bundle/deadline_cloud_for_nuke_submitter-deps.zip dependency_bundle/deadline_cloud_for_nuke_submitter-deps-linux.zip
+cp dependency_bundle/deadline_cloud_for_nuke_submitter-deps.zip dependency_bundle/deadline_cloud_for_nuke_submitter-deps-macos.zip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.19.*",
+    "deadline == 0.20.*",
     "openjobio == 0.8.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
dependency bundle is failing to build

### What was the solution? (How)
changes depsBundle.sh zip names to the expected name generated by depsBundle.py

### What is the impact of this change?
Fixes installer build

### How was this change tested?
```
hatch run lint
hatch run test
./depsBundle.sh
```

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, this is a pipeline related change.

### Was this change documented?
N/A

### Is this a breaking change?
No

