### PR TITLE
fix: Prevent Nuke from opening multiple submitter dialogs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.26.*",
+    "deadline == 0.27.*",
     "openjd == 0.10.*",
 ]
 

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -179,6 +179,8 @@ def _get_parameter_values(
 
 
 def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadlineDialog":
+    global g_submitter_dialog
+
     render_settings = RenderSubmitterUISettings()
 
     # Set the setting defaults that come from the scene

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -26,6 +26,8 @@ from .ui.components.scene_settings_tab import SceneSettingsWidget
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.exceptions import DeadlineOperationError
 
+g_submitter_dialog = None
+
 
 def show_nuke_render_submitter_noargs() -> "SubmitJobToDeadlineDialog":
     with gui_error_handler("Error opening Amazon Deadline Cloud Submitter", None):
@@ -235,18 +237,19 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
     # Match the major version of Nuke in the Rez package list
     nuke_version_major = nuke.env["NukeVersionMajor"]
 
-    submitter_dialog = SubmitJobToDeadlineDialog(
-        job_setup_widget_type=SceneSettingsWidget,
-        initial_job_settings=render_settings,
-        initial_shared_parameter_values={
-            "RezPackages": f"nuke-{nuke_version_major} deadline_cloud_for_nuke"
-        },
-        auto_detected_attachments=auto_detected_attachments,
-        attachments=attachments,
-        on_create_job_bundle_callback=on_create_job_bundle_callback,
-        parent=parent,
-        f=f,
-    )
+    if not g_submitter_dialog:
+        g_submitter_dialog = SubmitJobToDeadlineDialog(
+            job_setup_widget_type=SceneSettingsWidget,
+            initial_job_settings=render_settings,
+            initial_shared_parameter_values={
+                "RezPackages": f"nuke-{nuke_version_major} deadline_cloud_for_nuke"
+            },
+            auto_detected_attachments=auto_detected_attachments,
+            attachments=attachments,
+            on_create_job_bundle_callback=on_create_job_bundle_callback,
+            parent=parent,
+            f=f,
+        )
 
-    submitter_dialog.show()
-    return submitter_dialog
+    g_submitter_dialog.show()
+    return g_submitter_dialog

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -250,6 +250,12 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
             parent=parent,
             f=f,
         )
+    else:
+        g_submitter_dialog.refresh(
+            job_settings=render_settings,
+            auto_detected_attachments=auto_detected_attachments,
+            attachments=attachments,
+        )
 
     g_submitter_dialog.show()
     return g_submitter_dialog

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -211,7 +211,7 @@ def _run_job_bundle_output_test(test_dir: str, dcc_scene_file: str, report_fh, m
         ), mock.patch.object(submit_job_to_deadline_dialog, "QMessageBox"), mock.patch.object(
             os, "startfile", create=True  # only exists on win. Just create to avoid AttributeError
         ):
-            submitter.on_save_bundle()
+            submitter.on_export_bundle()
         QApplication.processEvents()
 
         # Close the DCC scene file

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -34,7 +34,7 @@ class SceneSettingsWidget(QWidget):
         )
 
         self._build_ui()
-        self._configure_settings(initial_settings)
+        self.refresh_ui(initial_settings)
 
     def _build_ui(self):
         lyt = QGridLayout(self)
@@ -73,7 +73,7 @@ class SceneSettingsWidget(QWidget):
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
-    def _configure_settings(self, settings: RenderSubmitterUISettings):
+    def refresh_ui(self, settings: RenderSubmitterUISettings):
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Issue: Bea-15149
Previously, a user could open multiple submitter dialogs. The user should not be able to open more than 1 submitter dialog.

### What was the solution? (How)
If the submitter dialog is already open, refresh the dialog properties (including job attachments). 

### What is the impact of this change?
Better user experience

### How was this change tested?
Job Bundle Output tests were successful

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes, ran tests. Also tested adding/removing read node dependencies and re-opening the Submitter dialog. 

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```
only diff was my Nuke version (I'm using 14v5)

### Was this change documented?

### Is this a breaking change?
This change is dependent on - https://github.com/casillas2/deadline-cloud/pull/35
