### PR TITLE
fix: Handle case where Deadline Cloud Submitter is opened from unsaved scene

### DIFF
--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -22,7 +22,10 @@ JOB_ID_REGEX = re.compile(r"^job-[0-9a-z]{32}$")
 
 def get_nuke_script_file() -> str:
     """Gets the nuke script file (.nk)"""
-    return normpath(nuke.root().knob("name").value())
+    script_path = nuke.root().knob("name").value()
+    if script_path:
+        return normpath(script_path)
+    return ""
 
 
 def get_project_path() -> str:

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -184,8 +184,14 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
     render_settings.frame_list = str(nuke.root().frameRange())
     render_settings.is_proxy_mode = nuke.root().proxy()
 
+    script_path = get_nuke_script_file()
+    if not script_path:
+        raise DeadlineOperationError(
+            "The Nuke Script is not saved to disk. Please save it before opening the submitter dialog."
+        )
+
     # Load the sticky settings
-    render_settings.load_sticky_settings(get_nuke_script_file())
+    render_settings.load_sticky_settings(script_path)
 
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Opening up the Deadline Cloud Submitter from a blank script presented the following error:
```
Exception caught:
Traceback (most recent call last):
  File "/home/rocky/git/deadline-cloud/src/deadline/client/ui/__init__.py", line 38, in gui_error_handler
    yield
  File "/home/rocky/git/deadline-cloud-for-nuke/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py", line 36, in show_nuke_render_submitter_noargs
    return show_nuke_render_submitter(mainwin)
  File "/home/rocky/git/deadline-cloud-for-nuke/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py", line 188, in show_nuke_render_submitter
    render_settings.load_sticky_settings(get_nuke_script_file())
  File "/home/rocky/git/deadline-cloud-for-nuke/src/deadline/nuke_submitter/data_classes.py", line 38, in load_sticky_settings
    sticky_settings_filename = Path(scene_filename).with_suffix(
  File "/opt/nuke/Nuke14.0v5/lib/python3.9/pathlib.py", line 903, in with_suffix
    raise ValueError("%r has an empty name" % (self,))
ValueError: PosixPath('.') has an empty name
```

### What was the solution? (How)
If the script name is empty, present the user with an error.

### What is the impact of this change?
Handle the case where user opens the deadline cloud submitter from an unsaved script.

### How was this change tested?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2023-09-20T22:37:07.916822+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2023-09-20T22:37:08.247677+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2023-09-20T22:37:08.443511+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

Timestamp: 2023-09-20T22:37:08.650688+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2023-09-20T22:37:11.037997+00:00
```

### Was this change documented?
No, bug fix.

### Is this a breaking change?
No