### PR TITLE
fix!: rename install builder component to match other submitters

### DIFF
--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -1,7 +1,7 @@
 <component>
-    <name>nuke_integrated_submitter</name>
-    <description>Integrated submitter for Nuke</description>
-    <detailedDescription>Nuke plugin for submitting work to Deadline</detailedDescription>
+    <name>deadline_cloud_for_nuke</name>
+    <description>Deadline Cloud for Nuke</description>
+    <detailedDescription>Nuke plugin for submitting jobs to Amazon Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -35,7 +35,7 @@
          </folder>
     </folderList>
     <initializationActionList>
-        <setInstallerVariable name="all_components" value="${all_components} nuke_integrated_submitter"/>
+        <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_nuke"/>
 	</initializationActionList>
     <readyToInstallActionList>
 		<setInstallerVariable name="nuke_installdir" value="${installdir}/Submitters/Nuke"/>
@@ -65,10 +65,10 @@
          </if>
 	</readyToInstallActionList>
 	<parameterList>
-		<stringParameter name="nuke_integrated_submitter_summary" ask="0" cliOptionShow="0">
-			<value>Nuke Submitter
+		<stringParameter name="deadline_cloud_for_nuke_summary" ask="0" cliOptionShow="0">
+			<value>Deadline Cloud for Nuke
 - Install the integrated Nuke submitter files to the installation directory
-- Create/update the NUKE_PATH environment variable to point to the integrated Nuke submitter files</value>
+- Register the plug-in with Nuke by creating or updating the NUKE_PATH environment variable.</value>
 		</stringParameter>
 	</parameterList>
     <postInstallationActionList>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

From the deadline cloud submitter installer help menu:
```
 --enable-components <enable-components>     Comma-separated list of components
                                             Default: deadline_client
                                             Allowed: deadline_cloud_for_maya nuke_integrated_submitter
```
note the inconsistencies in the available components

### What was the solution? (How)

make them match!

### What is the impact of this change?

consistency!

### How was this change tested?

N/A, it now looks like https://github.com/casillas2/deadline-cloud-for-maya/blob/mainline/install_builder/deadline-cloud-for-maya.xml

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A

### Was this change documented?

N/A

### Is this a breaking change?

yep, changed how cli option name for installer