### PR TITLE
chore: Update deadline-cloud dependency to 0.28.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.27.*",
+    "deadline == 0.28.*",
     "openjd == 0.10.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to upgrade the `deadline-cloud` version to the latest version.

### What was the solution? (How)
Updated `deadline-cloud` version to `0.28.*`

### What is the impact of this change?
Update to latest `deadline-cloud` release

### How was this change tested?
`hatch run lint && hatch run test`

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
N/A
There are two breaking changes, and these do not require running the test.
- [Update get_queue_user_boto3_session to work with default creds](https://github.com/casillas2/deadline-cloud/commit/b9d2a2875ca09dee7f2ffc13f5b951e51a42f802): changed the name of a function that are being used internally, 
- [Change osType to rootPathFormat](https://github.com/casillas2/deadline-cloud/pull/45): changed the name of a field/property in Job Attachments library, which is accessed by the Worker Agent.

### Was this change documented?
No.

### Is this a breaking change?
No.

