### PR TITLE
fix: support spaces in the adaptor override paths

### DIFF
--- a/src/deadline/nuke_submitter/adaptor_override_environment.yaml
+++ b/src/deadline/nuke_submitter/adaptor_override_environment.yaml
@@ -28,7 +28,7 @@ environment:
         set -euo pipefail
 
         echo "The adaptor wheels that are attached to the job:"
-        ls {{Param.AdaptorWheels}}/
+        ls '{{Param.AdaptorWheels}}'
         echo ""
 
         # Create a venv and activate it in this environment
@@ -40,8 +40,8 @@ environment:
         echo ""
 
         echo "Installing adaptor into the venv"
-        pip install {{Param.AdaptorWheels}}/openjd*.whl
-        pip install {{Param.AdaptorWheels}}/deadline*.whl
+        pip install '{{Param.AdaptorWheels}}'/openjd*.whl
+        pip install '{{Param.AdaptorWheels}}'/deadline*.whl
         echo ""
 
         if [ ! -f '{{Session.WorkingDirectory}}/venv/bin/{{Param.OverrideAdaptorName}}' ]; then


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

wheel paths with spaces in it broke due to the ls and pip install commands

### What was the solution? (How)

add quotes from the variable (but not the wildcard globs)

### What is the impact of this change?

Wheel paths with spaces should work

### How was this change tested?

N/A

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, none of them currently reference the developer overrides.

### Was this change documented?

N/A

### Is this a breaking change?

Fixing ;)