### PR TITLE
fix: Support for exporting bundle with selected Write node

### DIFF
--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -44,7 +44,8 @@ class SceneSettingsWidget(QWidget):
         for write_node in sorted(
             find_all_write_nodes(), key=lambda write_node: write_node.fullName()
         ):
-            self.write_node_box.addItem(write_node.fullName(), write_node)
+            # Set data value as fullName since this is the value we want to store in the settings
+            self.write_node_box.addItem(write_node.fullName(), write_node.fullName())
 
         lyt.addWidget(QLabel("Write Nodes"), 0, 0)
         lyt.addWidget(self.write_node_box, 0, 1)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Exporting a bundle when a specific write node was selected would result in the following error:

`"toNode() argument 1 must be str, not Node"`

### What was the solution? (How)

Rather than saving the Node in the combobox, only save the node fullName (str). This is the representation the settings and other code expect when querying the `write_node_selection` setting.

### What is the impact of this change?

Users can now export a bundle/submit from a selected Write node

### How was this change tested?

Yes, tested exporting a bundle with "All Write Nodes" selected, also tested exporting a bundle with "Write1" selected. 

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes

```

Timestamp: 2023-10-02T21:11:52.884265+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2023-10-02T21:11:53.152700+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2023-10-02T21:11:53.319364+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

Timestamp: 2023-10-02T21:11:53.472336+00:00
Running job bundle output test: /home/rocky/git/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2023-10-02T21:11:54.977118+00:00

```

### Was this change documented?
N/A bug fix

### Is this a breaking change?
No