### PR TITLE
fix: Mock DeadlineCredentialsStatus.getInstance call in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.30.*",
+    "deadline == 0.31.*",
     "openjd-adaptor-runtime == 0.3.*",
 ]
 

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
-from unittest.mock import MagicMock  # , Mock
+from unittest.mock import MagicMock
 
 # we must mock nuke and UI code
 mock_modules = [

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -21,6 +21,6 @@ for module in mock_modules:
 # Mock the call to DeadlineCredentialsStatus.getInstance that happens at the module level
 # in submit_job_to_deadline_dialog.py. That call is done at the module level to gather the
 # status before the dialog is opened.
-from deadline.client.ui.deadline_credentials_status import DeadlineCredentialsStatus
+from deadline.client.ui.deadline_credentials_status import DeadlineCredentialsStatus  # noqa: E402
 
 DeadlineCredentialsStatus.getInstance = Mock(return_value=None)

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 # we must mock nuke and UI code
 mock_modules = [
@@ -17,3 +17,10 @@ mock_modules = [
 
 for module in mock_modules:
     sys.modules[module] = MagicMock()
+
+# Mock the call to DeadlineCredentialsStatus.getInstance that happens at the module level
+# in submit_job_to_deadline_dialog.py. That call is done at the module level to gather the
+# status before the dialog is opened.
+from deadline.client.ui.deadline_credentials_status import DeadlineCredentialsStatus
+
+DeadlineCredentialsStatus.getInstance = Mock(return_value=None)

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,10 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock  # , Mock
 
 # we must mock nuke and UI code
 mock_modules = [
+    "deadline.client.ui.deadline_credentials_status",
     "nuke",
     "nuke.Node",
     "ui.deadline_submitter",
@@ -17,10 +18,3 @@ mock_modules = [
 
 for module in mock_modules:
     sys.modules[module] = MagicMock()
-
-# Mock the call to DeadlineCredentialsStatus.getInstance that happens at the module level
-# in submit_job_to_deadline_dialog.py. That call is done at the module level to gather the
-# status before the dialog is opened.
-from deadline.client.ui.deadline_credentials_status import DeadlineCredentialsStatus  # noqa: E402
-
-DeadlineCredentialsStatus.getInstance = Mock(return_value=None)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A change in the `deadline-cloud` added a call to a singleton to get it initialized with the module. This call fails when running tests.

### What was the solution? (How)

Mocking the module in the unit tests.

### What is the impact of this change?

NA

### How was this change tested?

Change in tests, it was validated that the tests can now run

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

NA, just applies to unit tests

### Was this change documented?

NA

### Is this a breaking change?

No