### PR TITLE
fix: Fix job bundle tests for Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .venv
 /htmlcov
 .vscode
+.idea
 .attach_pid*
 /build
 *_version.py

--- a/job_bundle_output_tests/ocio/scene/config.ocio
+++ b/job_bundle_output_tests/ocio/scene/config.ocio
@@ -1,4 +1,4 @@
-ocio_profile_version: 2.1
+ocio_profile_version: 2.0
 
 environment:
   {}

--- a/job_bundle_output_tests/ocio/scene/ocio.nk
+++ b/job_bundle_output_tests/ocio/scene/ocio.nk
@@ -1,6 +1,6 @@
-#! /opt/nuke/Nuke14.0v5/libnuke-14.0.5.so -nx
+#! /opt/nuke/Nuke13.2v4/libnuke-13.2.4.so -nx
 #write_info Write1 file:"output/output_%04d.png" format:"2048 1556 1" chans:":rgba.red:rgba.green:rgba.blue:" framerange:"1 100" fps:"0" colorspace:"matte_paint" datatype:"8 bit" transfer:"unknown" views:"main" colorManagement:"OCIO"
-version 14.0 v5
+version 13.2 v4
 define_window_layout_xml {<?xml version="1.0" encoding="UTF-8"?>
 <layout version="1.0">
     <window x="0" y="27" w="1512" h="848" maximized="1" screen="0">

--- a/test/unit/deadline_submitter_for_nuke/test_job_bundle_output_test_runner.py
+++ b/test/unit/deadline_submitter_for_nuke/test_job_bundle_output_test_runner.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
 from unittest.mock import patch
 
 from deadline.nuke_submitter.job_bundle_output_test_runner import (
     _get_dcc_scene_file_extension,
     _open_dcc_scene_file,
     _close_dcc_scene_file,
+    _sort,
 )
 
 
@@ -34,3 +36,22 @@ def test_close_dcc_scene_file(mock_script_close):
 
     # THEN
     mock_script_close.assert_called_once()
+
+
+test_sort_params = [
+    ({}, []),
+    ({"list": ["n2", "n1", "n3"]}, [("list", ["n1", "n2", "n3"])]),
+    (
+        {"name": "test_name", "list": ["n2", "n1", "n3"]},
+        [("list", ["n1", "n2", "n3"]), ("name", "test_name")],
+    ),
+]
+
+
+@pytest.mark.parametrize("test_dict, expected_dict", test_sort_params)
+def test_sort(test_dict, expected_dict):
+    # WHEN
+    result = _sort(test_dict)
+
+    # THEN
+    assert expected_dict == result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job Bundle Output Test failed all tests on MacOS.

### What was the solution? (How)
- downgrade nuke file version to support Nuke13
- downgrade ocio version to support Nuke13
- fix content conversion when `os.getcwd` returns `/` on MacOS
- ignore list ordering in yaml files when comparing outputs.

### What is the impact of this change?
No impact to customer

### How was this change tested?
Ran job output bundle tests in Nuke13.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Three out of four tests passed. It's unclear where one test was picking up RezPackages values for parameters, but that may be related to versions of deadline-cloud-for-nuke being tested, not issue with the test runner. 
```
Timestamp: 2023-10-12T13:56:59.943428-07:00
Running job bundle output test: /Users/tincheng/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2023-10-12T13:57:00.598594-07:00
Running job bundle output test: /Users/tincheng/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2023-10-12T13:57:01.162885-07:00
Running job bundle output test: /Users/tincheng/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2023-10-12T13:57:01.688055-07:00
Running job bundle output test: /Users/tincheng/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -5,6 +5,8 @@
   value: /normalized/job/bundle/dir/cwd-path.nk
 - name: ProxyMode
   value: 'false'
+- name: RezPackages
+  value: nuke-13 deadline_cloud_for_nuke
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

Failed 1 tests, succeeded 3.
Timestamp: 2023-10-12T13:57:05.278912-07:00
```

### Was this change documented?
N

### Is this a breaking change?
N