### PR TITLE
fix: Include nuke_util dir in installer

### DIFF
--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -17,6 +17,7 @@
                     <filterEvaluationLogic>or</filterEvaluationLogic>
                     <onPackingFilterList>
                         <fileNameFilter pattern="*/deadline/nuke_submitter/*" logic="matches" patternType="glob"/>
+                        <fileNameFilter pattern="*/deadline/nuke_util/*" logic="matches" patternType="glob"/>
                         <fileNameFilter pattern="*/menu.py" logic="matches" patternType="glob"/>
                     </onPackingFilterList>
                 </distributionDirectory>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The latest nuke installer doesn't include the nuke_util dir, which causes the plugin to fail to load

### What was the solution? (How)
Include the nuke_util dir in the installer

### What is the impact of this change?
Those relying on the installer for Nuke job submissions will be unblocked

### How was this change tested?

Will publish new installers once merged and released

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, doesn't impact job bundle tests, as tests don't use the installer.

### Was this change documented?
no

### Is this a breaking change?
no
