### PR TITLE
feat: Adding telemetry events for adaptor and submitter actions

### DIFF
--- a/job_bundle_output_tests/cwd-path/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/cwd-path/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/cwd-path.nk
 - name: ProxyMode
   value: 'false'
+- name: TelemetryOptOut
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/cwd-path/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cwd-path/expected_job_bundle/template.yaml
@@ -59,6 +59,12 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: TelemetryOptOut
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -78,6 +84,7 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
+          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/group-read/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/group-read/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/group-read.nk
 - name: ProxyMode
   value: 'false'
+- name: TelemetryOptOut
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/group-read/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/group-read/expected_job_bundle/template.yaml
@@ -58,6 +58,12 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: TelemetryOptOut
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -77,6 +83,7 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
+          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/multi-load-save.nk
 - name: ProxyMode
   value: 'false'
+- name: TelemetryOptOut
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
@@ -61,6 +61,12 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: TelemetryOptOut
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -80,6 +86,7 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
+          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/noise-saver.nk
 - name: ProxyMode
   value: 'false'
+- name: TelemetryOptOut
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
@@ -59,6 +59,12 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: TelemetryOptOut
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -78,6 +84,7 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
+          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/ocio.nk
 - name: ProxyMode
   value: 'false'
+- name: TelemetryOptOut
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
@@ -59,6 +59,12 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: TelemetryOptOut
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -78,6 +84,7 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
+          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/src/deadline/nuke_adaptor/NukeAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/schemas/init_data.schema.json
@@ -16,6 +16,7 @@
                 "type": "string"
             }
         },
+        "telemetry_opt_out": { "type" : "boolean" },
         "script_file": { "type": "string" }
     },
     "required": [

--- a/src/deadline/nuke_submitter/data_classes.py
+++ b/src/deadline/nuke_submitter/data_classes.py
@@ -26,6 +26,7 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     write_node_selection: str = field(default="", metadata={"sticky": True})
     view_selection: str = field(default="", metadata={"sticky": True})
     is_proxy_mode: bool = field(default=False, metadata={"sticky": True})
+    is_telemetry_opted_out: bool = field(default=False, metadata={"sticky": True})
 
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -57,6 +57,12 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: TelemetryOptOut
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -76,6 +82,7 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
+          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There currently exists no submitter specific telemetry events for Nuke for neither the submitter nor adaptor. Because of this, there is a lack of visibility into user behavior on the submitter, and a general lack of visibility around the versioning of the DCC a user is running on either their workstation, or as a worker.

### What was the solution? (How)
Using deadline-cloud's telemetry library to record appropriate events and adding information when needed. Existing information regarding telemetry session-id can be used to aggregate metrics in the future. One caveat that was needed in this solution was the ability to respect telemetry opt-out. The adaptor running on the workers didn't respect the opt-out flag that I thought would have been set by the worker agent from this [PR](https://github.com/casillas2/deadline-cloud-worker-agent), so instead I'm passing in an optional parameter to take it from the workstation. Another possible change is the versioning information for the adaptor as right now, it's simply trying to obtain it from the environment variables passed in from Rez, but this isn't guaranteed and can likely be standardized across all integrations.

### What is the impact of this change?
There will be metrics for Nuke specifically showing when users open up the submitter UI and when the adaptor is running on a worker and what version(s) their running.

### How was this change tested?
Against the alpha telemetry endpoint. I can see and verify that all the information added is present in CloudWatch.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Ran it and encountered the same error as the last merged PR where a new RezPackages field is getting inserted. Regarding the new field for telemetry opt out, looks fine otherwise. Will maybe take a look after this if I have bandwidth.
```

Timestamp: 2023-10-17T14:15:42.511358-07:00
Running job bundle output test: /Volumes/workplace/bealine-clients/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2023-10-17T14:15:42.962052-07:00
Running job bundle output test: /Volumes/workplace/bealine-clients/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2023-10-17T14:15:43.336982-07:00
Running job bundle output test: /Volumes/workplace/bealine-clients/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2023-10-17T14:15:43.740735-07:00
Running job bundle output test: /Volumes/workplace/bealine-clients/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test failed, found differences
Missing files: ['test-job-bundle-results.txt']
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -3,10 +3,12 @@
   value: 1-100
 - name: NukeScriptFile
   value: /normalized/job/bundle/dir/ocio.nk
+- name: TelemetryOptOut
+  value: 'false'
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
+- name: RezPackages
+  value: nuke-13 deadline_cloud_for_nuke
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

Timestamp: 2023-10-17T14:15:44.132550-07:00
Running job bundle output test: /Volumes/workplace/bealine-clients/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -3,10 +3,12 @@
   value: 1-100
 - name: NukeScriptFile
   value: /normalized/job/bundle/dir/cwd-path.nk
+- name: TelemetryOptOut
+  value: 'false'
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
+- name: RezPackages
+  value: nuke-13 deadline_cloud_for_nuke
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

Failed 2 tests, succeeded 3.
Timestamp: 2023-10-17T14:15:51.118660-07:00

```

### Was this change documented?
N/A

### Is this a breaking change?
No - shouldn't be, deadline-cloud changes have already been merged in and released and the opt-out flag should be optional