### PR TITLE
fix: Add default rezPackages + updated deadline dependency to 0.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.31.*",
+    "deadline == 0.32.*",
     "openjd-adaptor-runtime == 0.3.*",
 ]
 

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -277,7 +277,10 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
         g_submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,
             initial_job_settings=render_settings,
-            initial_shared_parameter_values={},
+            # Note: nuke-13 is currently the only nuke rez package available. Hardcoding to nuke-13 for now, but
+            # evenutally this should be set to nuke.env["NukeVersionMajor"] once more versions
+            # are supported.
+            initial_shared_parameter_values={"RezPackages": "nuke-13 deadline_cloud_for_nuke"},
             auto_detected_attachments=auto_detected_attachments,
             attachments=attachments,
             on_create_job_bundle_callback=on_create_job_bundle_callback,

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -278,7 +278,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
             job_setup_widget_type=SceneSettingsWidget,
             initial_job_settings=render_settings,
             # Note: nuke-13 is currently the only nuke rez package available. Hardcoding to nuke-13 for now, but
-            # evenutally this should be set to nuke.env["NukeVersionMajor"] once more versions
+            # the rez version should eventually be set to nuke.env["NukeVersionMajor"] once more versions
             # are supported.
             initial_shared_parameter_values={"RezPackages": "nuke-13 deadline_cloud_for_nuke"},
             auto_detected_attachments=auto_detected_attachments,

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -274,13 +274,13 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
         attachments = AssetReferences()
 
     if not g_submitter_dialog:
+        nuke_version = nuke.env["NukeVersionMajor"]
         g_submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,
             initial_job_settings=render_settings,
-            # Note: nuke-13 is currently the only nuke rez package available. Hardcoding to nuke-13 for now, but
-            # the rez version should eventually be set to nuke.env["NukeVersionMajor"] once more versions
-            # are supported.
-            initial_shared_parameter_values={"RezPackages": "nuke-13 deadline_cloud_for_nuke"},
+            initial_shared_parameter_values={
+                "RezPackages": f"nuke-{nuke_version} deadline_cloud_for_nuke"
+            },
             auto_detected_attachments=auto_detected_attachments,
             attachments=attachments,
             on_create_job_bundle_callback=on_create_job_bundle_callback,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. RezPackage defaults were removed in a previous PR
2. Deadline-cloud dependency was out of date

### What was the solution? (How)
1. Added RezPackage defaults `nuke-13 deadline_cloud_for_nuke`
2. Updated deadling-cloud dependency

### What is the impact of this change?
End user no longer needs to worry about overriding the rez package defaults via the UI

### How was this change tested?
1. Created a new default queue
2. Confirmed that after creating a new scene, rez env is populated correctly.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

### Is this a breaking change?
