### PR TITLE
fix: Add optional purpose enum to bundle creation callback.

### DIFF
--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -13,6 +13,7 @@ from deadline.client.job_bundle import deadline_yaml_dump
 from deadline.client.ui import gui_error_handler
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
     SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
 )
 from nuke import Node
 from PySide2.QtCore import Qt  # pylint: disable=import-error
@@ -234,6 +235,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
         queue_parameters: list[dict[str, Any]],
         asset_references: AssetReferences,
         host_requirements: Optional[dict[str, Any]] = None,
+        purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
     ) -> None:
         job_bundle_path = Path(job_bundle_dir)
         job_template = _get_job_template(settings)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Make Nuke submitter compatible with new purpose argument in job bundle creation callback.

### What was the solution? (How)

Import the type and add the optional argument.

### What is the impact of this change?

Make submitter compatible with additional deadline-cloud changes.

### How was this change tested?

Tests pass and it compiles (requires changes in https://github.com/casillas2/deadline-cloud/pull/94

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Minor change

### Was this change documented?

No

### Is this a breaking change?

No
