### PR TITLE
fix: submitter should stay on top of main Nuke window

### DIFF
--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -39,7 +39,7 @@ def show_nuke_render_submitter_noargs() -> "SubmitJobToDeadlineDialog":
         app = QApplication.instance()
         mainwin = [widget for widget in app.topLevelWidgets() if isinstance(widget, QMainWindow)][0]
     with gui_error_handler("Error opening Amazon Deadline Cloud Submitter", mainwin):
-        return show_nuke_render_submitter(mainwin)
+        return show_nuke_render_submitter(mainwin, f=Qt.Tool)
 
 
 def _get_deadline_telemetry_client() -> TelemetryClient:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
All child windows in Nuke should always show on top of main DCC window. Sometimes launching the submitter would bring it under the main window.

### What was the solution? (How)
Pass appropriate Qt Flag

### What is the impact of this change?
users will see the submitter window, and it will behave in a standard way

### How was this change tested?
Ran the code win Nuke 14, also passed unit tests.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, unrelated to job submission.

### Was this change documented?
No

### Is this a breaking change?
No