### PR TITLE
chore: Bump Deadline version 0.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.34.*",
+    "deadline == 0.36.*",
     "openjd-adaptor-runtime == 0.3.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

### What was the solution? (How)
Bumping submitter/adaptors to newest (0.36.0) version of Deadline Cloud library
### What is the impact of this change?
Submitter/adaptors use newest (0.36.0) version of Deadline Cloud library
### How was this change tested?
ran `hatch clean && hatch build && hatch run test`
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
no, only change is bumping dependency version 

### Was this change documented?
no
### Is this a breaking change?
yes