### PR TITLE
fix: libtoml -> tomllib in depsBundle.py

### DIFF
--- a/depsBundle.py
+++ b/depsBundle.py
@@ -22,7 +22,7 @@ def _get_project_dict() -> dict[str, Any]:
             sys.path.insert(0, toml_env)
             import toml
     else:
-        import libtoml as toml
+        import tomllib as toml
 
     with open("pyproject.toml") as pyproject_toml:
         return toml.load(pyproject_toml)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We used the wrong package name for python 3.11
### What was the solution? (How)

Use `tomllib`, ref: https://docs.python.org/3/library/tomllib.html
### What is the impact of this change?
We can run `depsBundle.py` in python 3.11
### How was this change tested?

I imported `tomllib` in 3.11:

```
(24-02-08 19:56:44) % python -c "import tomllib"

(24-02-08 19:56:47) % python -c "import libtoml"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'libtoml'
```

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No because this does not affect integration code.

### Was this change documented?

No

### Is this a breaking change?
No