### PR TITLE
fix: use right mode when opening toml file

### DIFF
--- a/depsBundle.py
+++ b/depsBundle.py
@@ -21,10 +21,13 @@ def _get_project_dict() -> dict[str, Any]:
             subprocess.run(toml_install_pip_args, check=True)
             sys.path.insert(0, toml_env)
             import toml
+        mode = "r"
     else:
         import tomllib as toml
 
-    with open("pyproject.toml") as pyproject_toml:
+        mode = "rb"
+
+    with open("pyproject.toml", mode) as pyproject_toml:
         return toml.load(pyproject_toml)
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`tomllib` expects files to be opened in `binary` mode. `toml` expects otherwise.

### What was the solution? (How)

Set the mode depending on the python version.

### What is the impact of this change?

Deps bundle works on 3.11

### How was this change tested?

Referenced houdini https://github.com/casillas2/deadline-cloud-for-houdini/blob/mainline/scripts/_project.py#L23

This is also the only `toml` usage.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, this is not integration code.

### Was this change documented?
No

### Is this a breaking change?
No