### PR TITLE
feat! Create a script to build adaptor package artifacts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,12 +109,12 @@ You can run the adaptor on your local workstation. This approach does not contai
 
    ```bash
    # Path mapping disabled
-   NukeAdaptor run --init-data file://init-data.yaml --run-data file://run-data.yaml
+   nuke-openjd run --init-data file://init-data.yaml --run-data file://run-data.yaml
 
    #path mapping enabled
-   NukeAdaptor run --init-data file://init-data.yaml --run-data file://run-data.yaml --path-mapping-rules file://path-mapping.yaml
+   nuke-openjd run --init-data file://init-data.yaml --run-data file://run-data.yaml --path-mapping-rules file://path-mapping.yaml
    ```
 
-   NOTE: The NukeAdaptor expects that the Nuke executable is named `nuke` and is set on the PATH. If this is not the case, you can set the `NUKE_ADAPTOR_NUKE_EXECUTABLE` environment variable to the path to the Nuke executable.
+   NOTE: The nuke-openjd binary expects that the Nuke executable is named `nuke` and is set on the PATH. If this is not the case, you can set the `NUKE_ADAPTOR_NUKE_EXECUTABLE` environment variable to the path to the Nuke executable.
 
 4. The result will be written based on the output specified on the write node, taking any path mapping into account.

--- a/job_bundle_output_tests/cwd-path/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/cwd-path/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,6 @@ parameterValues:
   value: /normalized/job/bundle/dir/cwd-path.nk
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/cwd-path/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cwd-path/expected_job_bundle/template.yaml
@@ -59,12 +59,6 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
-- name: TelemetryOptOut
-  type: STRING
-  default: 'false'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -84,7 +78,6 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
-          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/group-read/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/group-read/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,6 @@ parameterValues:
   value: /normalized/job/bundle/dir/group-read.nk
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/group-read/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/group-read/expected_job_bundle/template.yaml
@@ -58,12 +58,6 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
-- name: TelemetryOptOut
-  type: STRING
-  default: 'false'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -83,7 +77,6 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
-          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,6 @@ parameterValues:
   value: /normalized/job/bundle/dir/multi-load-save.nk
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
@@ -61,12 +61,6 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
-- name: TelemetryOptOut
-  type: STRING
-  default: 'false'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -86,7 +80,6 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
-          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,6 @@ parameterValues:
   value: /normalized/job/bundle/dir/noise-saver.nk
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
@@ -59,12 +59,6 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
-- name: TelemetryOptOut
-  type: STRING
-  default: 'false'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -84,7 +78,6 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
-          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,6 @@ parameterValues:
   value: /normalized/job/bundle/dir/ocio.nk
 - name: ProxyMode
   value: 'false'
-- name: TelemetryOptOut
-  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
@@ -59,12 +59,6 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
-- name: TelemetryOptOut
-  type: STRING
-  default: 'false'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -84,7 +78,6 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
-          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,12 @@ requires-python = ">=3.7"
 
 dependencies = [
     "deadline == 0.37.*",
-    "openjd-adaptor-runtime == 0.3.*",
+    "openjd-adaptor-runtime == 0.4.*",
 ]
 
 [project.scripts]
+nuke-openjd = "deadline.nuke_adaptor.NukeAdaptor:main"
+# The binary name 'NukeAdaptor' is deprecated.
 NukeAdaptor = "deadline.nuke_adaptor.NukeAdaptor:main"
 
 [tool.hatch.build]
@@ -126,7 +128,7 @@ source = [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 73
+fail_under = 72
 
 [tool.semantic_release]
 # Can be removed or set to true once we are v1

--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+set -xeou pipefail
+
+APP=nuke
+ADAPTOR_NAME=deadline-cloud-for-$APP
+
+# This script generates an tar.gz artifact from $ADAPTOR_NAME and its dependencies
+# that can be used to create a package for running the adaptor.
+
+SCRIPTDIR=$(realpath $(dirname $0))
+
+SOURCE=0
+# Python 3.11 is for https://vfxplatform.com/ CY2024
+PYTHON_VERSION=3.11
+CONDA_PLATFORM=linux-64
+TAR_BASE=
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    --source) SOURCE=1 ; shift ;;
+    --platform) CONDA_PLATFORM="$2" ; shift 2 ;;
+    --python) PYTHON_VERSION="$2" ; shift 2 ;;
+    --tar-base) TAR_BASE="$2" ; shift 2 ;;
+    *) echo "Unexpected option: $1"; exit 1 ;;
+  esac
+done
+
+if [ "$CONDA_PLATFORM" = "linux-64" ]; then
+    PYPI_PLATFORM=manylinux2014_x86_64
+elif [ "$CONDA_PLATFORM" = "win-64" ]; then
+    PYPI_PLATFORM=win_amd64
+elif [ "$CONDA_PLATFORM" = "osx-64" ]; then
+    PYPI_PLATFORM=macosx_10_9_x86_64
+else
+    echo "Unknown Conda operating system option --platform $CONDA_PLATFORM"
+    exit 1
+fi
+
+if [ "$TAR_BASE" = "" ]; then
+    TAR_BASE=$SCRIPTDIR/../$APP-openjd-py$PYTHON_VERSION-$CONDA_PLATFORM
+fi
+
+# Create a temporary prefix
+WORKDIR=$(mktemp -d adaptor-pkg.XXXXXXXXXX)
+function cleanup_workdir {
+    echo "Cleaning up $WORKDIR"
+    rm -rf $WORKDIR
+}
+trap cleanup_workdir EXIT
+
+PREFIX=$WORKDIR/prefix
+
+if [ "$CONDA_PLATFORM" = "win-64" ]; then
+    BINDIR=$PREFIX/Library/bin
+    PACKAGEDIR=$PREFIX/Library/opt/$ADAPTOR_NAME
+else
+    BINDIR=$PREFIX/bin
+    PACKAGEDIR=$PREFIX/opt/$ADAPTOR_NAME
+fi
+
+
+mkdir -p $PREFIX
+mkdir -p $PACKAGEDIR
+mkdir -p $BINDIR
+
+# Install the adaptor into the virtual env
+if [ $SOURCE = 1 ]; then
+    # In source mode, openjd-adaptor-runtime-for-python must be alongside this adaptor source
+    RUNTIME_INSTALLABLE=$SCRIPTDIR/../../openjd-adaptor-runtime-for-python
+    ADAPTOR_INSTALLABLE=$SCRIPTDIR/..
+
+    if [ "$CONDA_PLATFORM" = "win-64" ]; then
+        DEPS="pyyaml jsonschema pywin32"
+    else
+        DEPS="pyyaml jsonschema"
+    fi
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --only-binary=:all: \
+        $DEPS
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $RUNTIME_INSTALLABLE \
+        $ADAPTOR_INSTALLABLE
+else
+    # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime-for-python
+    ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --only-binary=:all: \
+        $RUNTIME_INSTALLABLE
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $ADAPTOR_INSTALLABLE
+fi
+
+
+# Remove the submitter code
+rm -r $PACKAGEDIR/deadline/*_submitter
+
+# Remove the bin dir if there is one
+if [ -d $PACKAGEDIR/bin ]; then
+    rm -r $PACKAGEDIR/bin
+fi
+
+PYSCRIPT="from pathlib import Path
+import sys
+reentry_exe = Path(sys.argv[0]).absolute()
+sys.path.append(str(reentry_exe.parent.parent / \"opt\" / \"$ADAPTOR_NAME\"))
+from deadline.${APP}_adaptor.${APP^}Adaptor.__main__ import main
+sys.exit(main(reentry_exe=reentry_exe))
+"
+
+cat <<EOF > $BINDIR/$APP-openjd
+#!/usr/bin/env python3.11
+$PYSCRIPT
+EOF
+
+# Temporary
+cp $BINDIR/$APP-openjd $BINDIR/${APP^}Adaptor
+
+chmod u+x $BINDIR/$APP-openjd $BINDIR/${APP^}Adaptor
+
+if [ $CONDA_PLATFORM = "win-64" ]; then
+    # Install setuptools to get cli-64.exe
+    mkdir -p $WORKDIR/tmp
+    pip install \
+        --target $WORKDIR/tmp \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        setuptools
+
+    # Use setuptools' cli-64.exe to define the entry point
+    cat <<EOF > $BINDIR/$APP-openjd-script.py
+#!C:\\Path\\To\\Python.exe
+$PYSCRIPT
+EOF
+    cp $WORKDIR/tmp/setuptools/cli-64.exe $BINDIR/$APP-openjd.exe
+fi
+
+# Everything between the first "-" and the next "+" is the package version number
+PACKAGEVER=$(cd $PACKAGEDIR; echo deadline_cloud_for*)
+PACKAGEVER=${PACKAGEVER#*-}
+PACKAGEVER=${PACKAGEVER%+*}
+echo "Package version number is $PACKAGEVER"
+
+# Create the tar artifact
+GIT_TIMESTAMP="$(env TZ=UTC git log -1 --date=iso-strict-local --format="%ad")"
+pushd $PREFIX
+# See https://reproducible-builds.org/docs/archives/ for information about
+# these options
+#tar --mtime=$GIT_TIMESTAMP \
+#     --sort=name \
+#     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+#    --owner=0 --group=0 --numeric-owner \
+#    -cf $TAR_BASE .
+# TODO Switch to the above command once the build environment has tar version > 1.28
+tar --owner=0 --group=0 --numeric-owner \
+    -cf $TAR_BASE-$PACKAGEVER.tar.gz .
+sha256sum $TAR_BASE-$PACKAGEVER.tar.gz
+popd

--- a/src/deadline/nuke_adaptor/NukeAdaptor/__main__.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/__main__.py
@@ -1,34 +1,37 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-import logging as _logging
-import sys as _sys
+import logging
+import sys
+import typing
+import pathlib
 
-from openjd.adaptor_runtime import EntryPoint as _EntryPoint
+from openjd.adaptor_runtime import EntryPoint
 
 from .adaptor import NukeAdaptor
 
 __all__ = ["main"]
-_logger = _logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
-def main() -> None:
+def main(reentry_exe: typing.Optional[pathlib.Path] = None) -> int:
     """
     Entry point for the Nuke Adaptor
     """
     _logger.info("About to start the NukeAdaptor")
 
-    package_name = vars(_sys.modules[__name__])["__package__"]
+    package_name = vars(sys.modules[__name__])["__package__"]
     if not package_name:
         raise RuntimeError(f"Must be run as a module. Do not run {__file__} directly")
 
     try:
-        _EntryPoint(NukeAdaptor).start()
+        EntryPoint(NukeAdaptor).start(reentry_exe=reentry_exe)
     except Exception as e:
         _logger.error(f"Entrypoint failed: {e}")
-        _sys.exit(1)
+        return 1
 
     _logger.info("Done NukeAdaptor main")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -42,8 +42,8 @@ class NukeClient(_HTTPClientInterface):
     Client for that runs in Nuke for the Nuke Adaptor
     """
 
-    def __init__(self, socket_path: str) -> None:
-        super().__init__(socket_path=socket_path)
+    def __init__(self, server_path: str) -> None:
+        super().__init__(server_path=server_path)
         self.actions.update(NukeHandler().action_dict)
 
         def ensure_output_dir():
@@ -143,21 +143,21 @@ class NukeClient(_HTTPClientInterface):
 
 
 def main():
-    socket_path = os.environ.get("NUKE_ADAPTOR_SOCKET_PATH")
-    if not socket_path:
+    server_path = os.environ.get("NUKE_ADAPTOR_SERVER_PATH")
+    if not server_path:
         raise OSError(
             "NukeClient cannot connect to the Adaptor because the environment variable "
-            "NUKE_ADAPTOR_SOCKET_PATH does not exist"
+            "NUKE_ADAPTOR_SERVER_PATH does not exist"
         )
 
-    if not os.path.exists(socket_path):
+    if not os.path.exists(server_path):
         raise OSError(
             "NukeClient cannot connect to the Adaptor because the socket at the path defined by "
-            "the environment variable NUKE_ADAPTOR_SOCKET_PATH does not exist. Got: "
-            f"{os.environ['NUKE_ADAPTOR_SOCKET_PATH']}"
+            "the environment variable NUKE_ADAPTOR_SERVER_PATH does not exist. Got: "
+            f"{os.environ['NUKE_ADAPTOR_SERVER_PATH']}"
         )
 
-    client = NukeClient(socket_path)
+    client = NukeClient(server_path)
     client.poll()
 
 

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -57,12 +57,6 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
-- name: TelemetryOptOut
-  type: STRING
-  default: 'false'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:
@@ -82,7 +76,6 @@ steps:
           continue_on_error: {{Param.ContinueOnError}}
           proxy: {{Param.ProxyMode}}
           script_file: '{{Param.NukeScriptFile}}'
-          telemetry_opt_out: {{Param.TelemetryOptOut}}
           write_nodes:
           - '{{Param.WriteNode}}'
           views:

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -231,7 +231,16 @@ def _run_job_bundle_output_test(test_dir: str, dcc_scene_file: str, report_fh, m
             contents = contents.replace(tempdir, "/normalized/job/bundle/dir")
             contents = contents.replace(tempdir.replace("\\", "/"), "/normalized/job/bundle/dir")
 
+            # Windows corner case
+            contents = contents.replace("C:\\tmp\\", "/tmp/")
+            contents = contents.replace("C:\\tmp", "/tmp")
+            contents = contents.replace("C:/tmp", "/tmp")
+
             if os.getcwd() != "/":
+                contents = contents.replace(os.getcwd() + "\\", "/normalized/cwd/")
+                contents = contents.replace(
+                    os.getcwd().replace("\\", "/") + "\\", "/normalized/cwd/"
+                )
                 contents = contents.replace(os.getcwd(), "/normalized/cwd")
             else:
                 # Mac specific cases

--- a/test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py
@@ -31,7 +31,6 @@ def init_data() -> dict:
         "write_nodes": ["Write1", "Write2", "Write3"],
         "views": ["left", "right"],
         "script_file": "/path/to/some/nukescript.nk",
-        "telemetry_opt_out": True,
     }
 
 
@@ -59,7 +58,7 @@ class TestNukeAdaptor_on_start:
     ) -> None:
         """Tests that on_start completes without error"""
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         adaptor.on_start()
 
     @patch("time.sleep")
@@ -80,7 +79,7 @@ class TestNukeAdaptor_on_start:
         socket_mock = PropertyMock(
             side_effect=[None, None, None, "/tmp/9999", "/tmp/9999", "/tmp/9999"]
         )
-        type(mock_server.return_value).socket_path = socket_mock
+        type(mock_server.return_value).server_path = socket_mock
 
         # WHEN
         adaptor.on_start()
@@ -149,7 +148,7 @@ class TestNukeAdaptor_on_start:
         """
         # GIVEN
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         new_timeout = 0.01
 
         with patch.object(adaptor, "_NUKE_START_TIMEOUT_SECONDS", new_timeout), pytest.raises(
@@ -181,7 +180,7 @@ class TestNukeAdaptor_on_start:
         """
         # GIVEN
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
 
         with pytest.raises(RuntimeError) as exc_info:
             # WHEN
@@ -205,7 +204,7 @@ class TestNukeAdaptor_on_start:
         # GIVEN
         mock_actions_queue.__len__.return_value = 0
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
 
         # WHEN
         adaptor.on_start()
@@ -241,7 +240,7 @@ class TestNukeAdaptor_on_start:
         }
         mock_actions_queue.__len__.return_value = 0
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         expected_action_names_queued = init_data.keys() & _NUKE_INIT_KEYS | set(_FIRST_NUKE_ACTIONS)
 
         # WHEN
@@ -290,7 +289,7 @@ class TestNukeAdaptor_on_run:
         """Tests that on_run waits for completion"""
         # GIVEN
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         # First side_effect value consumed by setter
         is_rendering_mock = PropertyMock(side_effect=[None, True, False])
         NukeAdaptor._is_rendering = is_rendering_mock
@@ -333,7 +332,7 @@ class TestNukeAdaptor_on_run:
         mock_nuke_is_running.side_effect = [True, True, True, False, False]
         mock_logging_subprocess.return_value.returncode = 1
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         adaptor.on_start()
 
         # WHEN
@@ -366,7 +365,7 @@ class TestNukeAdaptor_on_run:
         """Tests that on_run waits for completion"""
         # GIVEN
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         # First side_effect value consumed by setter
         mock_nuke_is_running.side_effect = [True]
         run_data = {"bad": "schema"}
@@ -396,7 +395,7 @@ class TestNukeAdaptor_on_stop:
     ) -> None:
         # GIVEN
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         is_rendering_mock = PropertyMock(return_value=False)
         NukeAdaptor._is_rendering = is_rendering_mock
         adaptor.on_start()
@@ -498,7 +497,7 @@ class TestNukeAdaptor_on_cleanup:
     ) -> None:
         # GIVEN
         adaptor = NukeAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         is_rendering_mock = PropertyMock(return_value=False)
         NukeAdaptor._is_rendering = is_rendering_mock
 

--- a/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
@@ -30,14 +30,14 @@ class TestNukeClient:
         mock_handler.return_value.action_dict = handler_action_dict
 
         # WHEN
-        client = NukeClient(socket_path="/tmp/9999")
+        client = NukeClient(server_path="/tmp/9999")
 
         # THEN
         mock_handler.assert_called_once()
         assert handler_action_dict.items() <= client.actions.items()
 
     @patch("deadline.nuke_adaptor.NukeClient.nuke_client.os.path.exists")
-    @patch.dict(os.environ, {"NUKE_ADAPTOR_SOCKET_PATH": "9999"})
+    @patch.dict(os.environ, {"NUKE_ADAPTOR_SERVER_PATH": "9999"})
     @patch("deadline.nuke_adaptor.NukeClient.NukeClient.poll")
     @patch("deadline.nuke_adaptor.NukeClient.nuke_client._HTTPClientInterface")
     def test_main(self, mock_httpclient: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
@@ -63,12 +63,12 @@ class TestNukeClient:
         # THEN
         assert str(exc_info.value) == (
             "NukeClient cannot connect to the Adaptor because the environment variable "
-            "NUKE_ADAPTOR_SOCKET_PATH does not exist"
+            "NUKE_ADAPTOR_SERVER_PATH does not exist"
         )
         mock_poll.assert_not_called()
 
     @patch("deadline.nuke_adaptor.NukeClient.nuke_client.os.path.exists")
-    @patch.dict(os.environ, {"NUKE_ADAPTOR_SOCKET_PATH": "/a/path/that/does/not/exist"})
+    @patch.dict(os.environ, {"NUKE_ADAPTOR_SERVER_PATH": "/a/path/that/does/not/exist"})
     @patch("deadline.nuke_adaptor.NukeClient.NukeClient.poll")
     def test_main_server_socket_not_exist(self, mock_poll: Mock, mock_exists: Mock) -> None:
         """Tests that the main method raises an OSError if the server socket does not exist"""
@@ -83,8 +83,8 @@ class TestNukeClient:
         mock_exists.assert_called_once_with("/a/path/that/does/not/exist")
         assert str(exc_info.value) == (
             "NukeClient cannot connect to the Adaptor because the socket at the path defined by "
-            "the environment variable NUKE_ADAPTOR_SOCKET_PATH does not exist. Got: "
-            f"{os.environ['NUKE_ADAPTOR_SOCKET_PATH']}"
+            "the environment variable NUKE_ADAPTOR_SERVER_PATH does not exist. Got: "
+            f"{os.environ['NUKE_ADAPTOR_SERVER_PATH']}"
         )
         mock_poll.assert_not_called()
 
@@ -95,7 +95,7 @@ class TestNukeClient:
         Test that nuke closes and exits on client.close()
         """
         # GIVEN
-        client = NukeClient(socket_path="/tmp/9999")
+        client = NukeClient(server_path="/tmp/9999")
 
         # WHEN
         client.close()
@@ -111,7 +111,7 @@ class TestNukeClient:
         Test that nuke closes and exits on client.graceful_shutdown
         """
         # GIVEN
-        client = NukeClient(socket_path="/tmp/9999")
+        client = NukeClient(server_path="/tmp/9999")
 
         # WHEN
         client.graceful_shutdown(1, Mock())
@@ -127,7 +127,7 @@ class TestNukeClient:
         Test that the ensure_output_dir handle which is run before each render works properly
         """
         # GIVEN
-        NukeClient(socket_path="/tmp/9999")
+        NukeClient(server_path="/tmp/9999")
         mock_os.path.isdir.return_value = is_dir
         ensure_output_dir = nuke.addBeforeRender.call_args[0][0]
 
@@ -192,7 +192,7 @@ class TestNukeClient:
     ):
         # GIVEN
         mocked_path_class.side_effect = new_path_class
-        client = NukeClient(socket_path="/tmp/9999")
+        client = NukeClient(server_path="/tmp/9999")
         mock_map_path.return_value = client_mapped
         mock_path_mapping_rules.return_value = rules
 
@@ -261,7 +261,7 @@ class TestNukeClient:
     ):
         # GIVEN
         mocked_path_class.side_effect = new_path_class
-        client = NukeClient(socket_path="/tmp/9999")
+        client = NukeClient(server_path="/tmp/9999")
         mock_map_path.return_value = client_mapped
         mock_path_mapping_rules.return_value = rules
 
@@ -307,7 +307,7 @@ class TestNukeClient:
             )
 
             temp_socket_file = tempfile.TemporaryFile()
-            client = NukeClient(socket_path=temp_socket_file.name)
+            client = NukeClient(server_path=temp_socket_file.name)
 
             # WHEN
             client._map_ocio_config()


### PR DESCRIPTION
* The breaking change is due to updating the adaptor runtime dependency to 0.4

### What was the problem/requirement? (What/Why)

We have designed a new structure for how we lay out application interface adaptors into packages. In order to simplify the packaging step, we'll put a script that generates an artifact with that layout into each adaptor git repo.

In order to perform the layout we wanted, I needed to modify the adaptor runtime. Those changes are in https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/69

The adaptor runtime dependency was out of date, After updating, it required changes from a socket_path to a server_path parameter.

### What was the solution? (How)

- Create a script to build adaptor packaging artifacts that follow the structure we designed
- Also deprecate the binary name NukeAdaptor, and add the name nuke-openjd
- Update the adaptor runtime dependency to 0.4, and fix up socket path into server path
- Update the submitter to provide both Rez and Conda packages metadata. The Rez package names are the same for now to keep backwards compatibility.

### What is the impact of this change?

The repo has a script that can generate a .tar archive containing a prefix layout of the adaptor python library and its dependencies, along with an entry point.

### How was this change tested?

The generated .tar archive was used to create a package, and that was tested on a Deadline Cloud farm.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes.

```

Timestamp: 2024-02-09T13:02:36.991298-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2024-02-09T13:02:38.047223-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2024-02-09T13:02:38.939765-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-02-09T13:02:40.019139-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2024-02-09T13:02:41.064548-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-02-09T13:02:44.283227-08:00
```

### Was this change documented?

No

### Is this a breaking change?

Yes, it updates the openjd adaptor runtime dependency which had a breaking change.
