### PR TITLE
fix: prevent menu clash with Deadline10

### DIFF
--- a/src/menu.py
+++ b/src/menu.py
@@ -20,7 +20,7 @@ try:
 
     menu_bar = nuke.menu("Nuke")
     thinkbox_menu = menu_bar.addMenu("&Thinkbox")
-    thinkbox_menu.addCommand("Submit Nuke To Deadline", show_nuke_render_submitter_noargs, "")
+    thinkbox_menu.addCommand("Submit Nuke To Deadline Cloud", show_nuke_render_submitter_noargs, "")
     # Set the environment variable DEADLINE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
     if os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
         thinkbox_menu.addCommand(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had the same menu item as Deadline10 in Nuke

### What was the solution? (How)

Make it more specific

### What is the impact of this change?

You can have both installed at the same time

### How was this change tested?

N/A

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A, different menu item

### Was this change documented?

N/A

### Is this a breaking change?

No
