### PR TITLE
fix: include description on submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ __pycache__/
 dependency_bundle
 **/test_job_bundle/
 **/test-job-bundle-results.txt
+.DS_Store
+dev_install
+.exe
+.run
+

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -63,8 +63,10 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
     with open(Path(__file__).parent / "default_nuke_job_template.yaml") as f:
         job_template = yaml.safe_load(f)
 
-    # Set the job's name
+    # Set the job's name and description
     job_template["name"] = settings.name
+    if settings.description:
+        job_template["description"] = settings.description
 
     # Get a map of the parameter definitions for easier lookup
     parameter_def_map = {param["name"]: param for param in job_template["parameterDefinitions"]}

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -170,13 +170,14 @@ def run_render_submitter_job_bundle_output_test():
                 report_fh.write(f"Failed {count_failed} tests, succeeded {count_succeeded}.\n")
                 nuke.alert(
                     "Some Job Bundle Tests Failed\n\n"
-                    f"Failed {count_failed} tests, succeeded {count_succeeded}.\n"
-                    f"See the file {test_job_bundle_results_file} for a full report.",
+                    f"Failed {count_failed} tests, succeeded {count_succeeded}.\n\n"
+                    f'See the file "{test_job_bundle_results_file}" for a full report.',
                 )
             else:
                 report_fh.write(f"All tests passed, ran {count_succeeded} total.\n")
                 nuke.message(
-                    f"All Job Bundle Tests Passed\n\nRan {count_succeeded} tests in total.",
+                    f"All Job Bundle Tests Passed\n\nRan {count_succeeded} tests in total.\n\n"
+                    f'See the file "{test_job_bundle_results_file}" for a full report.',
                 )
             report_fh.write(f"Timestamp: {_timestamp_string()}\n")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Nuke jobs didn't have descriptions even though users were filling them out

### What was the solution? (How)

use the descriptions!

### What is the impact of this change?

we get descriptions!

### How was this change tested?

ran nuke locally and verified we're now adding the description to the job templates we create when it exists

no desc: 
<img width="184" alt="image" src="https://github.com/casillas2/deadline-cloud-for-nuke/assets/60796713/015126f3-67ec-44f4-aef3-cd22837b218d">


desc: 
<img width="172" alt="image" src="https://github.com/casillas2/deadline-cloud-for-nuke/assets/60796713/3ac4b195-6051-4326-bc90-b29526265739">


### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-02-12T17:44:55.395150-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-02-12T17:44:56.233188-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-02-12T17:44:57.007767-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-02-12T17:44:57.974480-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-02-12T17:44:58.633976-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-02-12T17:45:01.249600-06:00
```

### Was this change documented?

N/A

### Is this a breaking change?

Nope