### PR TITLE
chore: add supported version to description

### DIFF
--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_nuke</name>
-    <description>Deadline Cloud for Nuke</description>
-    <detailedDescription>Nuke plugin for submitting jobs to Amazon Deadline Cloud.</detailedDescription>
+    <description>Deadline Cloud for Nuke 13.2-14.0</description>
+    <detailedDescription>Nuke plugin for submitting jobs to Amazon Deadline Cloud. Compatible with Nuke 13.2-14.0</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -67,7 +67,8 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_nuke_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Nuke
+			<value>Deadline Cloud for Nuke 13.2-14.0
+- Compatible with Nuke 13.2-14.0
 - Install the integrated Nuke submitter files to the installation directory
 - Register the plug-in with Nuke by creating or updating the NUKE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It was unclear at installation time what version(s) of the DCC the submitter will be available in.
### What was the solution? (How)
Explicitly call out which version(s) of the DCC the submitter will be available in.
### What is the impact of this change?
Less confusion when installing
### How was this change tested?
Built an installer, confirmed wording appeared accurate:
![image](https://github.com/casillas2/deadline-cloud-for-nuke/assets/119458760/8fa8a155-73fe-4435-9ca6-6eb23136381e)


### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, this change does not affect the integration code

### Was this change documented?
No
### Is this a breaking change?
No