### PR TITLE
chore: add semantic commit parser options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,27 @@ fail_under = 72
 major_on_zero = false
 tag_format = "{version}"
 
+[tool.semantic_release.commit_parser_options]
+allowed_tags = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "style",
+    "refactor",
+    "test",
+]
+minor_tags = []
+patch_tags = [
+  "chore",
+  "feat",
+  "fix",
+  "refactor",
+]
+
 [tool.semantic_release.publish]
 upload_to_vcs_release = false
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release workflow is not versioning as expected because we are missing the commit parser options

### What was the solution? (How)
Add commit parser options to the pyproject.toml file

### What is the impact of this change?
Fix release process versioning

### How was this change tested?
Copied from a repository that is versioning properly.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
