### PR TITLE
feat(deps)!: update openjd-adaptor-runtime to 0.5

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest {args:test/unit/*}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.37.*",
-    "openjd-adaptor-runtime == 0.4.*",
+    "deadline == 0.38.*",
+    "openjd-adaptor-runtime == 0.5.*",
 ]
 
 [project.scripts]
@@ -72,15 +72,13 @@ module = ["nuke.*","PySide2.*","PyOpenColorIO.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
-ignore = [
-  "E501",
-]
 line-length = 100
 
-[tool.ruff.isort]
-known-first-party = [
-  "deadline_worker_agent"
-]
+[tool.ruff.lint]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["deadline_worker_agent"]
 
 [tool.black]
 line-length = 100

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,9 +1,9 @@
-deadline-cloud-test-fixtures ~= 0.2.0
+deadline-cloud-test-fixtures == 0.5.*
+black == 24.*
 coverage[toml] == 7.*
-pytest ~= 7.4
-pytest-cov ~= 4.1
-pytest-xdist ~= 3.5
-twine ~= 4.0
-mypy ~= 1.8
-black ~= 23.12
-ruff ~= 0.1.11
+mypy == 1.*
+pytest == 8.*
+pytest-cov == 4.*
+pytest-xdist == 3.*
+ruff == 0.3.*
+twine == 5.*

--- a/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
             pass
 
 
-from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators
+from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators, SemanticVersion
 from openjd.adaptor_runtime_client import Action
 from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
@@ -87,6 +87,10 @@ class NukeAdaptor(Adaptor):
     # Output tracking for progress handling
     _curr_output: int = 1
     _total_outputs: int = 1
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:
@@ -474,9 +478,9 @@ class NukeAdaptor(Adaptor):
         deadline_util_namespace_dir = os.path.dirname(os.path.dirname(deadline.nuke_util.__file__))
         python_path_addition = f"{openjd_namespace_dir}{os.pathsep}{deadline_adaptor_namespace_dir}{os.pathsep}{deadline_util_namespace_dir}"
         if "PYTHONPATH" in os.environ:
-            os.environ[
-                "PYTHONPATH"
-            ] = f"{os.environ['PYTHONPATH']}{os.pathsep}{python_path_addition}"
+            os.environ["PYTHONPATH"] = (
+                f"{os.environ['PYTHONPATH']}{os.pathsep}{python_path_addition}"
+            )
         else:
             os.environ["PYTHONPATH"] = python_path_addition
 


### PR DESCRIPTION
Run is no longer the default adaptor action

### What was the problem/requirement? (What/Why)

Needed to update to the latest openjd adaptor runtime

### What was the solution? (How)

Updated, and added a SemVer for the openjd interface

### What is the impact of this change?

Our unversioned API is now versioned

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?
Yes, nothing to do on the customer's side unless they wrote custom job templates that don't specify an action and expected `run` to happen.