### PR TITLE
chore(deps): bump deadline-cloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.38.*",
+    "deadline == 0.39.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A new version of `deadline-cloud` was released and we should upgrade to it.

### What was the solution? (How)
Upgrade to the latest `deadline-cloud`

### What is the impact of this change?
Upgrade to the latest `deadline-cloud`

### How was this change tested?
- hatch build && hatch run test

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes, they passed

```

Timestamp: 2024-03-07T17:28:59.403391-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2024-03-07T17:29:00.175874-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2024-03-07T17:29:01.127375-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-03-07T17:29:02.965825-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2024-03-07T17:29:04.856105-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-03-07T17:29:08.614209-06:00

```

### Was this change documented?
No

### Is this a breaking change?
No
