### PR TITLE
Include menu.py file in distribution.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ include = [
 [tool.hatch.build.targets.wheel]
 packages = [
   "src/deadline",
+  "src/menu.py",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
menu.py was missing from the distribution for deadline-cloud-for-nuke

### What was the solution? (How)
Added it to pyproject.toml

### What is the impact of this change?
Users that rely on the pip install will now get the file

### How was this change tested?
created a distribution and the file was there

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
NO, unrelated change.

### Was this change documented?
No need to.

### Is this a breaking change?
No.