### PR TITLE
chore(deps): bump deadline-cloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.39.*",
+    "deadline == 0.40.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A new version of `deadline-cloud` was released and we should upgrade to it.
### What was the solution? (How)
Upgrade to the latest `deadline-cloud`
### What is the impact of this change?
Upgrade to the latest `deadline-cloud`
### How was this change tested?
hatch build && hatch run test
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-03-14T13:36:54.831149-05:00
Running job bundle output test: C:\Users\<REDACTED>\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2024-03-14T13:36:55.357889-05:00
Running job bundle output test: C:\Users\<REDACTED>\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2024-03-14T13:36:55.570676-05:00
Running job bundle output test: C:\Users\<REDACTED>\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-03-14T13:36:55.869099-05:00
Running job bundle output test: C:\Users\<REDACTED>\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2024-03-14T13:36:57.012912-05:00
Running job bundle output test: C:\Users\<REDACTED>\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-03-14T13:37:37.144674-05:00

```

### Was this change documented?
No
### Is this a breaking change?
No