### PR TITLE
ci: add gpg signing for build artifacts

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -100,31 +100,30 @@ jobs:
         run: |
           export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
-          hatch build
+          hatch -v build
 
-      # TODO: Uncomment below once the Deadline Cloud PGP key is available
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
-      #     aws-region: us-west-2
-      #     mask-aws-account-id: true
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
 
-      # - name: Import PGP Key
-      #   run: |
-      #     export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
-      #     printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+      - name: Import PGP Key
+        run: |
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
 
-      #     PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
-      #     echo "::add-mask::$PGP_KEY_PASSPHRASE"
-      #     echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+          PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+          echo "::add-mask::$PGP_KEY_PASSPHRASE"
+          echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
 
-      # - name: Sign
-      #   run: |
-      #     for file in dist/*; do
-      #       printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "Open Job Description" --passphrase-fd 0 --output $file.sig --detach-sign $file
-      #       echo "Created signature file for $file"
-      #     done
+      - name: Sign
+        run: |
+          for file in dist/*; do
+            printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "AWS Deadline Cloud" --passphrase-fd 0 --output $file.sig --detach-sign $file
+            echo "Created signature file for $file"
+          done
 
       - name: PushRelease
         env:
@@ -132,6 +131,26 @@ jobs:
         run: |
           git push origin $TAG
           gh release create $TAG dist/* --notes "$RELEASE_NOTES"
+
+  PublishToInternal:
+    needs: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-Publish
+          hide-cloudwatch-logs: true
 
   PublishToRepository:
     needs: Release
@@ -175,7 +194,7 @@ jobs:
           pip install --upgrade twine
 
       - name: Build
-        run: hatch build
+        run: hatch -v build
 
       - name: Publish to Repository
         run: |
@@ -195,23 +214,3 @@ jobs:
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       # - name: Publish to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
-
-  PublishToInternal:
-    needs: Release
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
-      - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
-        with:
-          project-name: ${{ github.event.repository.name }}-Publish
-          hide-cloudwatch-logs: true

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -54,10 +54,10 @@ jobs:
         pip install --upgrade hatch
 
     - name: Run Linting
-      run: hatch run lint
+      run: hatch -v run lint
 
     - name: Run Build
-      run: hatch build
+      run: hatch -v build
 
     - name: Run Tests
       run: hatch run test

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -5,6 +5,6 @@ set -e
 pip install --upgrade pip
 pip install --upgrade hatch
 pip install --upgrade twine
-hatch run codebuild:lint
+hatch -v run codebuild:lint
 hatch run codebuild:test
-hatch run codebuild:build
+hatch -v run codebuild:build


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. We need to uncomment gpg signing now that a key is available to use.
2. Add hatch verbosity so we can see what dependencies are being installed.
3. Move Internal Publish to run first because it has a higher chance of failure.

### What was the solution? (How)
1. uncomment code and add the keys identity
2. Add `-v` flag to build and lint commands
3.  Move PublishToInternal to run before PublishToRepository

### What is the impact of this change?
Artifacts will now be signed

### How was this change tested?
Tested in a development account
```
hatch run lint
hatch run test
hatch run build
```

### Was this change documented?
No

### Is this a breaking change?
No
