### PR TITLE
chore: rename submission menus

### DIFF
--- a/src/menu.py
+++ b/src/menu.py
@@ -19,11 +19,11 @@ try:
     )
 
     menu_bar = nuke.menu("Nuke")
-    thinkbox_menu = menu_bar.addMenu("&Thinkbox")
-    thinkbox_menu.addCommand("Submit Nuke To Deadline Cloud", show_nuke_render_submitter_noargs, "")
+    aws_deadline_menu = menu_bar.addMenu("&AWS Deadline")
+    aws_deadline_menu.addCommand("Submit to Deadline Cloud", show_nuke_render_submitter_noargs, "")
     # Set the environment variable DEADLINE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
     if os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
-        thinkbox_menu.addCommand(
+        aws_deadline_menu.addCommand(
             "Run Nuke Submitter Job Bundle Output Tests...",
             run_render_submitter_job_bundle_output_test,
             "",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We aren't consistent with the naming of our menu items between integrations.
### What was the solution? (How)
Update the Nuke menu items to match the consistent naming we are aiming for.
### What is the impact of this change?
Consistency
### How was this change tested?
Launched Nuke before and after the changes and verified the menus updated and functioned.
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, doesn't seem like it would be required for this.

### Was this change documented?
Yes
### Is this a breaking change?
No