### PR TITLE
test: change hatch matrix definition to be consistent

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -20,7 +20,7 @@ lint = [
   "typing",
 ]
 
-[[envs.test.matrix]]
+[[envs.all.matrix]]
 python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]


### PR DESCRIPTION
QOL fix which makes it so that we define the hatch matrix using the name `all` across all our repos. This was previous inconsistent between `all` and `test`. 

For instance, makes it so that you can run tests against all python versions by running the command

```
hatch run all:test
```


Signed-off-by: Samuel Anderson <119458760+AWS-Samuel@users.noreply.github.com>