### PR TITLE
fix: include deadline-cloud in the adaptor packaging script

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -68,6 +68,7 @@ mkdir -p $BINDIR
 if [ $SOURCE = 1 ]; then
     # In source mode, openjd-adaptor-runtime-for-python must be alongside this adaptor source
     RUNTIME_INSTALLABLE=$SCRIPTDIR/../../openjd-adaptor-runtime-for-python
+    CLIENT_INSTALLABLE=$SCRIPTDIR/../../deadline-cloud
     ADAPTOR_INSTALLABLE=$SCRIPTDIR/..
 
     if [ "$CONDA_PLATFORM" = "win-64" ]; then
@@ -76,24 +77,36 @@ if [ $SOURCE = 1 ]; then
         DEPS="pyyaml jsonschema"
     fi
 
-    pip install \
-        --target $PACKAGEDIR \
-        --platform $PYPI_PLATFORM \
-        --python-version $PYTHON_VERSION \
-        --ignore-installed \
-        --only-binary=:all: \
-        $DEPS
+    for DEP in $DEPS; do
+        pip install \
+            --target $PACKAGEDIR \
+            --platform $PYPI_PLATFORM \
+            --python-version $PYTHON_VERSION \
+            --ignore-installed \
+            --only-binary=:all: \
+            $DEP
+    done
+
     pip install \
         --target $PACKAGEDIR \
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
         --no-deps \
-        $RUNTIME_INSTALLABLE \
-        $ADAPTOR_INSTALLABLE
+        $RUNTIME_INSTALLABLE
+
+    # Install these two at the same time otherwise they overwrite eachother
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
 else
     # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
     RUNTIME_INSTALLABLE=openjd-adaptor-runtime-for-python
+    CLIENT_INSTALLABLE=deadline
     ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
 
     pip install \
@@ -103,13 +116,15 @@ else
         --ignore-installed \
         --only-binary=:all: \
         $RUNTIME_INSTALLABLE
+
+    # Install these two at the same time otherwise they overwrite eachother
     pip install \
         --target $PACKAGEDIR \
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
         --no-deps \
-        $ADAPTOR_INSTALLABLE
+        $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
 fi
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Adaptor now has a dependency on deadline-cloud.

### What was the solution? (How)
Include deadline-cloud in the Adaptor packaging script.

### What is the impact of this change?
The archive is correct now. 

### How was this change tested?
Ran locally and generated the package.
