### PR TITLE
fix: incorrect package name in create adaptor script

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -105,7 +105,7 @@ if [ $SOURCE = 1 ]; then
         $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
 else
     # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
-    RUNTIME_INSTALLABLE=openjd-adaptor-runtime-for-python
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime
     CLIENT_INSTALLABLE=deadline
     ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The repository name is being referenced for a pip installation instead of the package name

### What was the solution? (How)
Update the script to `openjd-adaptor-runtime`

### What is the impact of this change?
fixes the scripts PyPi mode.

### How was this change tested?
Confirmed the script ran successfully
`./create_adaptor_packaging_artifact.sh`

### Was this change documented?
No

### Is this a breaking change?
No