### PR TITLE
chore: update supported nuke versions in the installer

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,7 +42,7 @@ will work on Linux or MacOS if you modify the path references as appropriate.
 WARNING: This workflow installs additional Python packages into your Nuke's python distribution. You may need to run the Command Prompt in Administrative mode if your current user does not have permission to write on Nuke's site-package folder.
 
 1. Create a development location within which to do your git checkouts. For example `~/deadline-clients`. Clone packages from this directory with commands like `git clone git@github.com:casillas2/deadline-cloud-for-nuke.git`. You'll also want the `deadline-cloud` repo.
-2. Switch to your Nuke directory, like `cd "C:\Program Files\Nuke13.2v4"`.
+2. Switch to your Nuke directory, like `cd "C:\Program Files\Nuke15.0v2"`.
 3. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud` to install the AWS Deadline Cloud Client Library in edit mode.
 4. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke` to install the Nuke Submitter in edit mode.
 5. Run `set NUKE_PATH=C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke\src` to put the `menu.py` file in the path Nuke searches for menu extensions.

--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_nuke</name>
-    <description>Deadline Cloud for Nuke 13.2-14.0</description>
-    <detailedDescription>Nuke plugin for submitting jobs to AWS Deadline Cloud. Compatible with Nuke 13.2-14.0</detailedDescription>
+    <description>Deadline Cloud for Nuke 14.0-15.0</description>
+    <detailedDescription>Nuke plugin for submitting jobs to AWS Deadline Cloud. Compatible with Nuke 14.0-15.0</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "hatchling.build"
 name = "deadline-cloud-for-nuke"
 dynamic = ["version"]
 readme = "README.md"
-license = ""
-requires-python = ">=3.7"
+license = "Apache-2.0"
+requires-python = ">=3.9"
 
 dependencies = [
     "deadline == 0.45.*",
@@ -68,7 +68,12 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["nuke.*","PySide2.*","PyOpenColorIO.*"]
+module = [
+  "nuke.*",
+  "PySide2.*",
+  "PyOpenColorIO.*",
+  "qtpy.*"
+]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
@@ -166,7 +166,7 @@ class NukeAdaptor(Adaptor):
                 re.compile(".*Error :.*"),
                 re.compile(".*Eddy\\[ERROR\\].*"),
             ]
-            # Capture the major minor group (ie. 13.2), patch version (ie. v1) is an optional subgroup.
+            # Capture the major minor group (ie. 15.0), patch version (ie. v1) is an optional subgroup.
             version_regexes = [re.compile("NukeClient: Nuke Version ([0-9]+.[0-9]+)(v[0-9]+)?")]
             output_complete_regexes = [re.compile(r"Writing .+ took [0-9\.]+ seconds")]
             callback_list.append(RegexCallback(completed_regexes, self._handle_complete))

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -64,8 +64,8 @@ def get_scene_asset_references() -> AssetReferences:
                     # Windows / Linux
                     install_path = dirname(nuke.EXE_PATH)
                     if platform.startswith("darwin"):
-                        # EXE_PATH: /Applications/Nuke13.2v4/Nuke13.2v4.app/Contents/MacOS/Nuke13.2
-                        # INSTALL_PATH: /Applications/Nuke13.2v4/Nuke13.2v4.app
+                        # EXE_PATH: /Applications/Nuke15.0v2/Nuke15.0v2.app/Contents/MacOS/Nuke15.0
+                        # INSTALL_PATH: /Applications/Nuke15.0v2/Nuke15.0v2.app
                         install_path = dirname(dirname(dirname(nuke.EXE_PATH)))
                     try:
                         common_file_path = commonpath((filename, install_path))

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -206,12 +206,18 @@ def _run_job_bundle_output_test(test_dir: str, dcc_scene_file: str, report_fh, m
 
         # Save the Job Bundle
         # Use patching to set the job bundle directory and skip the success messagebox
-        with mock.patch.object(
-            submit_job_to_deadline_dialog,
-            "create_job_history_bundle_dir",
-            return_value=temp_job_bundle_dir,
-        ), mock.patch.object(submit_job_to_deadline_dialog, "QMessageBox"), mock.patch.object(
-            os, "startfile", create=True  # only exists on win. Just create to avoid AttributeError
+        with (
+            mock.patch.object(
+                submit_job_to_deadline_dialog,
+                "create_job_history_bundle_dir",
+                return_value=temp_job_bundle_dir,
+            ),
+            mock.patch.object(submit_job_to_deadline_dialog, "QMessageBox"),
+            mock.patch.object(
+                os,
+                "startfile",
+                create=True,  # only exists on win. Just create to avoid AttributeError
+            ),
         ):
             submitter.on_export_bundle()
         QApplication.processEvents()
@@ -266,11 +272,10 @@ def _run_job_bundle_output_test(test_dir: str, dcc_scene_file: str, report_fh, m
             filtered_diff = []
             if dcmp.diff_files:
                 for file in dcmp.diff_files:
-                    with open(
-                        os.path.join(expected_job_bundle_dir, file), encoding="utf8"
-                    ) as fleft, open(
-                        os.path.join(test_job_bundle_dir, file), encoding="utf8"
-                    ) as fright:
+                    with (
+                        open(os.path.join(expected_job_bundle_dir, file), encoding="utf8") as fleft,
+                        open(os.path.join(test_job_bundle_dir, file), encoding="utf8") as fright,
+                    ):
                         # Convert the yaml to an ordered dict to verify the differences are not caused by ordering.
                         # For example, MacOS creates "/tmp/luts" directory in different order compare to Windows/Linux
                         # NOTE: if there are other diffs in the same file, then the ordering mismatch will still

--- a/test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py
@@ -98,9 +98,10 @@ class TestNukeAdaptor_on_start:
         # GIVEN
         adaptor = NukeAdaptor(init_data)
 
-        with patch.object(adaptor, "_SERVER_START_TIMEOUT_SECONDS", 0.01), pytest.raises(
-            RuntimeError
-        ) as exc_info:
+        with (
+            patch.object(adaptor, "_SERVER_START_TIMEOUT_SECONDS", 0.01),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
             # WHEN
             adaptor.on_start()
 
@@ -157,9 +158,10 @@ class TestNukeAdaptor_on_start:
         mock_server.return_value.server_path = "/tmp/9999"
         new_timeout = 0.01
 
-        with patch.object(adaptor, "_NUKE_START_TIMEOUT_SECONDS", new_timeout), pytest.raises(
-            TimeoutError
-        ) as exc_info:
+        with (
+            patch.object(adaptor, "_NUKE_START_TIMEOUT_SECONDS", new_timeout),
+            pytest.raises(TimeoutError) as exc_info,
+        ):
             # WHEN
             adaptor.on_start()
 
@@ -437,12 +439,14 @@ class TestNukeAdaptor_on_cleanup:
         # GIVEN
         adaptor = NukeAdaptor(init_data)
 
-        with patch(
-            "deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor._nuke_is_running",
-            new_callable=lambda: True,
-        ), patch.object(adaptor, "_NUKE_END_TIMEOUT_SECONDS", 0.01), patch.object(
-            adaptor, "_nuke_client"
-        ) as mock_client:
+        with (
+            patch(
+                "deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor._nuke_is_running",
+                new_callable=lambda: True,
+            ),
+            patch.object(adaptor, "_NUKE_END_TIMEOUT_SECONDS", 0.01),
+            patch.object(adaptor, "_nuke_client") as mock_client,
+        ):
             # WHEN
             adaptor.on_cleanup()
 
@@ -461,12 +465,14 @@ class TestNukeAdaptor_on_cleanup:
         # GIVEN
         adaptor = NukeAdaptor(init_data)
 
-        with patch(
-            "deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor._nuke_is_running",
-            new_callable=lambda: False,
-        ), patch.object(adaptor, "_SERVER_END_TIMEOUT_SECONDS", 0.01), patch.object(
-            adaptor, "_server_thread"
-        ) as mock_server_thread:
+        with (
+            patch(
+                "deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor._nuke_is_running",
+                new_callable=lambda: False,
+            ),
+            patch.object(adaptor, "_SERVER_END_TIMEOUT_SECONDS", 0.01),
+            patch.object(adaptor, "_server_thread") as mock_server_thread,
+        ):
             mock_server_thread.is_alive.return_value = True
             # WHEN
             adaptor.on_cleanup()
@@ -484,12 +490,14 @@ class TestNukeAdaptor_on_cleanup:
         # GIVEN
         adaptor = NukeAdaptor(init_data)
 
-        with patch(
-            "deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor._nuke_is_running",
-            new_callable=lambda: False,
-        ), patch.object(adaptor, "_SERVER_END_TIMEOUT_SECONDS", 0.01), patch.object(
-            adaptor, "_server_thread"
-        ) as mock_server_thread:
+        with (
+            patch(
+                "deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor._nuke_is_running",
+                new_callable=lambda: False,
+            ),
+            patch.object(adaptor, "_SERVER_END_TIMEOUT_SECONDS", 0.01),
+            patch.object(adaptor, "_server_thread") as mock_server_thread,
+        ):
             mock_server_thread.is_alive.side_effect = [True, False]
             # WHEN
             adaptor.on_cleanup()
@@ -689,10 +697,7 @@ class TestNukeAdaptor_on_cleanup:
         "version_string, expected_version",
         [
             ("NukeClient: Nuke Version 14.0v2", "14.0v2"),
-            (
-                "NukeClient: Nuke Version 13.2",
-                "13.2",
-            ),
+            ("NukeClient: Nuke Version 15.0", "15.0"),
         ],
     )
     def test_handle_version(self, init_data: dict, version_string: str, expected_version: str):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Nuke 13.2 is python 3.7 and EOL, so we're no longer officially supporting that version

### What was the solution? (How)

Show the actual supported versions 14 - 15

### What is the impact of this change?

more accurate installers

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Nope - just some text updates.

### Was this change documented?

it IS the documentation

### Is this a breaking change?

nope