### PR TITLE
chore: update codeowners org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @casillas2/Developers
+* @aws-deadline/Developers

--- a/pipeline/CODEOWNERS
+++ b/pipeline/CODEOWNERS
@@ -1,1 +1,1 @@
-* @casillas2/Admin
+* @aws-deadline/Admin


### PR DESCRIPTION
## DO NOT MERGE

### What was the problem/requirement? (What/Why)

org name is changing, the codeowners file needs to be updated

### What was the solution? (How)

update codeowners org to `aws-deadline`

### What is the impact of this change?
someone cannot use the old org name to gain write access.

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?

no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*