### PR TITLE
docs: readme update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,33 @@
 
 
 ### Features
-* Improve telemetry for submitter and adaptor (#103) ([`0811e05`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/0811e0500547326ef9b3d369f1aa3211073c5616))
+* Improve telemetry for submitter and adaptor (#103) ([`0811e05`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/0811e0500547326ef9b3d369f1aa3211073c5616))
 
 ### Bug Fixes
-* include deadline-cloud in the adaptor packaging script (#117) ([`9a72baf`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/9a72baff204d2073c35fdede2dc238c2e6515ee0))
+* include deadline-cloud in the adaptor packaging script (#117) ([`9a72baf`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/9a72baff204d2073c35fdede2dc238c2e6515ee0))
 
 ## 0.17.1 (2024-03-15)
 
 ### Chore
-* update deps deadline-cloud 0.40 (#107) ([`6503f29`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/6503f293c9f9ea7be5a513d84dffd4d4f0c2dc5f))
+* update deps deadline-cloud 0.40 (#107) ([`6503f29`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/6503f293c9f9ea7be5a513d84dffd4d4f0c2dc5f))
 
 
 ## 0.17.0 (2024-03-08)
 
 ### BREAKING CHANGES
-* **deps**: update openjd-adaptor-runtime to 0.5 (#100) ([`b01e7f5`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/b01e7f5a2bdcc0b18a39d63737067143b5a126e2))
+* **deps**: update openjd-adaptor-runtime to 0.5 (#100) ([`b01e7f5`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/b01e7f5a2bdcc0b18a39d63737067143b5a126e2))
 
 
 
 ## 0.16.0 (2024-02-21)
 
 ### BREAKING CHANGES
-* Create a script to build adaptor package artifacts (#85) ([`0039d36`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/0039d3607caa0a441d8f12cd3dd5687f26fb1c02))
+* Create a script to build adaptor package artifacts (#85) ([`0039d36`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/0039d3607caa0a441d8f12cd3dd5687f26fb1c02))
 
 
 ### Bug Fixes
-* include description on submission (#89) ([`13b4a56`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/13b4a56a263d55ef1277711bca8e9a01db78a83a))
-* prevent menu clash with Deadline10 (#86) ([`d5f3d12`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/d5f3d128b1eed20997959aef6b5f5cb5c9fb0f42))
-* use right mode when opening toml file (#83) ([`7097cf3`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/7097cf37ff71ee23bb054348d7a4967c17255c5f))
-* libtoml -&gt; tomllib in depsBundle.py (#82) ([`70b3eaf`](https://github.com/casillas2/deadline-cloud-for-nuke/commit/70b3eafff63722232d9568ff4d8ad1f6b3a7f58f))
+* include description on submission (#89) ([`13b4a56`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/13b4a56a263d55ef1277711bca8e9a01db78a83a))
+* prevent menu clash with Deadline10 (#86) ([`d5f3d12`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/d5f3d128b1eed20997959aef6b5f5cb5c9fb0f42))
+* use right mode when opening toml file (#83) ([`7097cf3`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/7097cf37ff71ee23bb054348d7a4967c17255c5f))
+* libtoml -&gt; tomllib in depsBundle.py (#82) ([`70b3eaf`](https://github.com/aws-deadline/deadline-cloud-for-nuke/commit/70b3eafff63722232d9568ff4d8ad1f6b3a7f58f))
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,12 @@
-# AWS Deadline Cloud for Nuke Development
+# Development documentation
+
+This package provides user interface inside of Nuke for submitting jobs to Deadline Cloud, and
+an adaptor that runs Nuke on render hosts.
+
+This package has two active branches:
+
+- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
+- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
 
 ## `hatch` commands
 
@@ -41,7 +49,7 @@ will work on Linux or MacOS if you modify the path references as appropriate.
 
 WARNING: This workflow installs additional Python packages into your Nuke's python distribution. You may need to run the Command Prompt in Administrative mode if your current user does not have permission to write on Nuke's site-package folder.
 
-1. Create a development location within which to do your git checkouts. For example `~/deadline-clients`. Clone packages from this directory with commands like `git clone git@github.com:casillas2/deadline-cloud-for-nuke.git`. You'll also want the `deadline-cloud` repo.
+1. Create a development location within which to do your git checkouts. For example `~/deadline-clients`. Clone packages from this directory with commands like `git clone git@github.com:aws-deadline/deadline-cloud-for-nuke.git`. You'll also want the `deadline-cloud` repo.
 2. Switch to your Nuke directory, like `cd "C:\Program Files\Nuke15.0v2"`.
 3. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud` to install the AWS Deadline Cloud Client Library in edit mode.
 4. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke` to install the Nuke Submitter in edit mode.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,51 @@
+[![pypi](https://img.shields.io/pypi/v/deadline-cloud-for-nuke.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-nuke)
+[![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-nuke.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-nuke)
+[![license](https://img.shields.io/pypi/l/deadline-cloud-for-nuke.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-nuke/blob/mainline/LICENSE)
+
 # AWS Deadline Cloud for Nuke
 
-This package provides user interface inside of Nuke for submitting jobs to Deadline Cloud, and
-an adaptor that runs Nuke on render hosts.
+AWS Deadline Cloud for Nuke is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within Nuke. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts Nuke's command line interface to support the [OpenJD specification][openjd].
 
-This package has two active branches:
-
-- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
-- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
-
-## Development Process
-
-See [DEVELOPMENT](DEVELOPMENT.md) for information about developing this package.
+[deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
+[deadline-cloud-client]: https://github.com/aws-deadline/deadline-cloud
+[openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki
+[openjd-adaptor-runtime]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+[openjd-adaptor-runtime-lifecycle]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/release/README.md#adaptor-lifecycle
 
 ## Compatibility
 
 This library requires:
 
-1. Python 3.7 or higher; and
-2. Linux, MacOS, or Windows operating system.
+1. Nuke 15,
+1. Python 3.9 or higher; and
+1. Linux, Windows, or a macOS operating system.
+
+## Submitter
+
+This package provides a Nuke plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded comp it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
+
+## Adaptor
+
+The Nuke Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Nuke and feed it commands. This gives the following benefits:
+* a standardized render application interface,
+* sticky rendering, where the application stays open between tasks,
+* path mapping, that enables cross-platform rendering
+
+Jobs created by the submitter use this adaptor by default.
+
+### Getting Started
+
+The adaptor can be installed by the standard python packaging mechanisms:
+```sh
+$ pip install deadline-cloud-for-nuke
+```
+
+After installation it can then be used as a command line tool:
+```sh
+$ nuke-openjd --help
+```
+
+For more information on the commands the OpenJD adaptor runtime provides, see [here][openjd-adaptor-runtime-lifecycle].
 
 ## Versioning
 
@@ -29,25 +57,13 @@ versions will increment during this initial development stage, they are describe
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
 
-## Downloading
-
-You can download this package from:
-- [GitHub releases](https://github.com/casillas2/deadline-cloud-for-nuke/releases)
-
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/aws-deadline/deadline-cloud-for-nuke/blob/release/CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## Telemetry
 
-This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
-
-You can opt out of telemetry data collection by either:
-
-1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
-2. Setting the config file: `deadline config set telemetry.opt_out true`
-
-Note that setting the environment variable supersedes the config file setting.
+See [telemetry](https://github.com/aws-deadline/deadline-cloud-for-nuke/blob/release/docs/telemetry.md) for more information.
 
 ## License
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,10 @@
+# Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.9"
 description = "The submitter and adaptor to enable Nuke support for AWS Deadline Cloud"
+authors = [
+  {name = "Amazon Web Services"},
+]
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -30,6 +33,10 @@ dependencies = [
     "deadline == 0.45.*",
     "openjd-adaptor-runtime == 0.6.*",
 ]
+
+[project.urls]
+Homepage = "https://github.com/aws-deadline/deadline-cloud-for-nuke"
+Source = "https://github.com/aws-deadline/deadline-cloud-for-nuke"
 
 [project.scripts]
 nuke-openjd = "deadline.nuke_adaptor.NukeAdaptor:main"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are preparing for the first public release which includes publishing our distribution artifacts to PyPI. The description of the package on PyPI will include the `README.md` contents of this repository. Any links in the `README.md` that are relative need to be made absolute since they will not resolve correctly on PyPI. When choosing the absolute link, the link must refer to the correct branch (`mainline` vs `release`) depending on the context of the link.

Additionally, once the repository becomes public, visitors will be looking for basic information about the project such as:

*   what is it?
*   what can it be used for?
*   how can it be used and operated?
*   how can people interact with the project?

### What was the solution? (How)

* Wrote it in VSCode with .md rendering
* view in Github rendering

### What is the impact of this change?

Readers landing on our published PyPI and GitHub pages will have a more clear and curated introduction to the project, emphasizing why they might find it important and providing information to help them get started using it and contributing to it.

### How was this change tested?

*   Using Visual Studio Code's markdown preview feature
*   Reviewing GitHub's markdown rendered version

### Was this change documented?

This change is documentation :)

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
