### PR TITLE
feat: Add Submitter Callback functions

### DIFF
--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -340,6 +340,15 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                         trace=traceback.format_exc()
                     )
                 )
+
+            if not callback_loader.validate_function_signature(on_pre_submit_callback):
+                raise DeadlineOperationError(
+                    "Python function at {path}:on_pre_submit_callback does not match function signature: {signature}."
+                    .format(
+                        path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
+                        signature=callback_loader.CALLBACK_REFERENCE_SIGNATURE,
+                    )
+                )
             callback_kwargs["on_pre_submit_callback"] = on_pre_submit_callback
 
         if os.path.exists(os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK", "")):
@@ -355,6 +364,14 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                     "Error while loading on_post_submit_callback at {path}. {trace}".format(
                         path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
                         trace=traceback.format_exc()
+                    )
+                )
+            if not callback_loader.validate_function_signature(on_post_submit_callback):
+                raise DeadlineOperationError(
+                    "Python function at {path}:on_post_submit_callback does not match function signature: {signature}."
+                    .format(
+                        path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
+                        signature=callback_loader.CALLBACK_REFERENCE_SIGNATURE,
                     )
                 )
             callback_kwargs["on_post_submit_callback"] = on_post_submit_callback

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -326,19 +326,37 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
 
         callback_kwargs = {}
         if os.path.exists(os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK", "")):
-            on_pre_submit_callback = callback_loader.import_module_function(
-                module_path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
-                module_name="submit_callback",
-                function_name="on_pre_submit_callback",
-            )
+            try:
+                on_pre_submit_callback = callback_loader.import_module_function(
+                    module_path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
+                    module_name="submit_callback",
+                    function_name="on_pre_submit_callback",
+                )
+            except Exception:
+                import traceback
+                raise DeadlineOperationError(
+                    "Error while loading on_pre_submit_callback at {path}. {trace}".format(
+                        path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
+                        trace=traceback.format_exc()
+                    )
+                )
             callback_kwargs["on_pre_submit_callback"] = on_pre_submit_callback
 
         if os.path.exists(os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK", "")):
-            on_post_submit_callback = callback_loader.import_module_function(
-                module_path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
-                module_name="submit_callback",
-                function_name="on_post_submit_callback",
-            )
+            try:
+                on_post_submit_callback = callback_loader.import_module_function(
+                    module_path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
+                    module_name="submit_callback",
+                    function_name="on_post_submit_callback",
+                )
+            except Exception:
+                import traceback
+                raise DeadlineOperationError(
+                    "Error while loading on_post_submit_callback at {path}. {trace}".format(
+                        path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
+                        trace=traceback.format_exc()
+                    )
+                )
             callback_kwargs["on_post_submit_callback"] = on_post_submit_callback
 
 

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -325,10 +325,10 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
         adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
 
         callback_kwargs = {}
-        if os.path.exists(os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK", "")):
+        if os.path.exists(os.environ.get("DEADLINE_NUKE_PRE_SUBMIT_CALLBACK", "")):
             try:
                 on_pre_submit_callback = callback_loader.import_module_function(
-                    module_path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
+                    module_path=os.environ.get("DEADLINE_NUKE_PRE_SUBMIT_CALLBACK"),
                     module_name="submit_callback",
                     function_name="on_pre_submit_callback",
                 )
@@ -336,7 +336,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                 import traceback
                 raise DeadlineOperationError(
                     "Error while loading on_pre_submit_callback at {path}. {trace}".format(
-                        path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
+                        path=os.environ.get("DEADLINE_NUKE_PRE_SUBMIT_CALLBACK"),
                         trace=traceback.format_exc()
                     )
                 )
@@ -345,16 +345,16 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                 raise DeadlineOperationError(
                     "Python function at {path}:on_pre_submit_callback does not match function signature: {signature}."
                     .format(
-                        path=os.environ.get("DEADLINE_PRE_SUBMIT_CALLBACK"),
+                        path=os.environ.get("DEADLINE_NUKE_PRE_SUBMIT_CALLBACK"),
                         signature=callback_loader.CALLBACK_REFERENCE_SIGNATURE,
                     )
                 )
             callback_kwargs["on_pre_submit_callback"] = on_pre_submit_callback
 
-        if os.path.exists(os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK", "")):
+        if os.path.exists(os.environ.get("DEADLINE_NUKE_POST_SUBMIT_CALLBACK", "")):
             try:
                 on_post_submit_callback = callback_loader.import_module_function(
-                    module_path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
+                    module_path=os.environ.get("DEADLINE_NUKE_POST_SUBMIT_CALLBACK"),
                     module_name="submit_callback",
                     function_name="on_post_submit_callback",
                 )
@@ -362,7 +362,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                 import traceback
                 raise DeadlineOperationError(
                     "Error while loading on_post_submit_callback at {path}. {trace}".format(
-                        path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
+                        path=os.environ.get("DEADLINE_NUKE_POST_SUBMIT_CALLBACK"),
                         trace=traceback.format_exc()
                     )
                 )
@@ -370,7 +370,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                 raise DeadlineOperationError(
                     "Python function at {path}:on_post_submit_callback does not match function signature: {signature}."
                     .format(
-                        path=os.environ.get("DEADLINE_POST_SUBMIT_CALLBACK"),
+                        path=os.environ.get("DEADLINE_NUKE_POST_SUBMIT_CALLBACK"),
                         signature=callback_loader.CALLBACK_REFERENCE_SIGNATURE,
                     )
                 )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When working in a studio, we often want to execute local validation of scene files before we allow a submission to the render farm. In other scenarios we may need to modify or transform the scene to prepare if for the render farm.

These two hooks allow for studio specified modification hooks to be optionally run before and after a submission completes.

### What was the solution? (How)
This solution implements an `on_pre_submit_callback` and a `on_post_submit_callback` that take the same parameters as the `on_create_job_bundle_callback`.
The parameters match `on_create_job_bundle_callback` solely to provide flexibility in case the hook needs access to any of the settings of the job.

### What is the impact of this change?
This change relies on [my PR in deadline-cloud](https://github.com/aws-deadline/deadline-cloud/pull/292) which implements  an `on_pre_submit_callback` and a `on_post_submit_callback` parameter and functionality.

This PR just implements loading of the callback from an environment variable
### How was this change tested?

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Have not yet, will do
```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Not currently documented
### Is this a breaking change?
No it is a feature addition


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
