### PR TITLE
fix: include adaptor wheels developer option

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -21,7 +21,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -99,12 +99,6 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
                 + f"Actual: {wheels_path_package_names}"
             )
 
-        adaptor_wheels_param = [
-            param
-            for param in override_environment["parameterDefinitions"]
-            if param["name"] == "AdaptorWheels"
-        ][0]
-        adaptor_wheels_param["default"] = str(wheels_path)
         override_adaptor_name_param = [
             param
             for param in override_environment["parameterDefinitions"]
@@ -178,6 +172,9 @@ def _get_parameter_values(
     parameter_values.append(
         {"name": "ProxyMode", "value": "true" if settings.is_proxy_mode else "false"}
     )
+    if settings.include_adaptor_wheels:
+        wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
+        parameter_values.append({"name": "AdaptorWheels", "value": wheels_path})
 
     # Check for any overlap between the job parameters we've defined and the
     # queue parameters. This is an error, as we weren't synchronizing the values
@@ -230,13 +227,6 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
             "nuke-version": nuke.env["NukeVersionString"],
         }
     )
-    render_settings = RenderSubmitterUISettings()
-
-    # Set the setting defaults that come from the scene
-    render_settings.name = Path(get_nuke_script_file()).name
-    render_settings.frame_list = str(nuke.root().frameRange())
-    render_settings.is_proxy_mode = nuke.root().proxy()
-
     script_path = get_nuke_script_file()
     if not script_path:
         raise DeadlineOperationError(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is a developer option to submit adaptor wheels which was failing due to a [change in job attachments](https://github.com/aws-deadline/deadline-cloud/pull/171) which made it so that PATH Job Parameter defaults can't be absolute paths.

The adaptor wheel directory was being added to the job template through a default value which was an absolute path which meant that with this option selected, job submission would fail with an error like:

```
Default PATH 'C:/Users/<USER>/deadlinecloud/deadline-cloud-for-nuke/wheels/' for parameter 'AdaptorWheels' is absolute.
PATH values must be relative, and must resolve within the Job Bundle directory.
```
There was also two other minor problems being addressed in this PR:
- Running `hatch run all:test` was also failing due to the `openjd-adaptor-runtime` not being available for python 3.8. 
- Some duplicate code in `show_nuke_render_submitter()`



### What was the solution? (How)

For the adaptor wheels bug, I changed the PATH to relative, and also set the value through a job parameter instead of as a default value in the job template.

For the hatch matrix issue, I removed the 3.8 version from the hatch matrix. With incompatible dependencies, we weren't testing against 3.8 in our CIs anyway so I don't think this is a noteworthy change.

I've also removed some duplicate code in `show_nuke_render_submitter()`

### What is the impact of this change?

The developer option to include adaptor wheels is functional again which makes it easier to test changes to the adaptor code.

### How was this change tested?

- Submitted adaptor wheels in a job to deadline-cloud and observed the adaptor I submitted being used.
- Unit tests pass

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes

```

Timestamp: 2024-05-14T11:15:33.571746-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2024-05-14T11:15:36.532399-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2024-05-14T11:15:37.396881-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-05-14T11:15:38.536108-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2024-05-14T11:15:39.645976-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-05-14T11:15:43.456980-05:00
```

### Was this change documented?

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
