### PR TITLE
feat: add ability to configure timeouts in submission UI

### DIFF
--- a/job_bundle_output_tests/cwd-path/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cwd-path/expected_job_bundle/template.yaml
@@ -96,6 +96,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
         onExit:
           command: NukeAdaptor
           args:
@@ -105,6 +106,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
   script:
     embeddedFiles:
     - name: runData
@@ -123,3 +125,4 @@ steps:
         - file://{{ Task.File.runData }}
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400

--- a/job_bundle_output_tests/group-read/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/group-read/expected_job_bundle/template.yaml
@@ -95,6 +95,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
         onExit:
           command: NukeAdaptor
           args:
@@ -104,6 +105,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
   script:
     embeddedFiles:
     - name: runData
@@ -122,3 +124,4 @@ steps:
         - file://{{ Task.File.runData }}
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/template.yaml
@@ -98,6 +98,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
         onExit:
           command: NukeAdaptor
           args:
@@ -107,6 +108,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
   script:
     embeddedFiles:
     - name: runData
@@ -125,3 +127,4 @@ steps:
         - file://{{ Task.File.runData }}
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/template.yaml
@@ -96,6 +96,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
         onExit:
           command: NukeAdaptor
           args:
@@ -105,6 +106,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
   script:
     embeddedFiles:
     - name: runData
@@ -123,3 +125,4 @@ steps:
         - file://{{ Task.File.runData }}
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400

--- a/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
@@ -96,6 +96,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
         onExit:
           command: NukeAdaptor
           args:
@@ -105,6 +106,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
   script:
     embeddedFiles:
     - name: runData
@@ -123,3 +125,4 @@ steps:
         - file://{{ Task.File.runData }}
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400

--- a/src/deadline/nuke_submitter/data_classes.py
+++ b/src/deadline/nuke_submitter/data_classes.py
@@ -31,6 +31,11 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
 
+    timeouts_enabled: bool = field(default=True, metadata={"sticky": True})
+    on_run_timeout_seconds: int = field(default=518400, metadata={"sticky": True})  # 6 days
+    on_enter_timeout_seconds: int = field(default=86400, metadata={"sticky": True})  # 1 day
+    on_exit_timeout_seconds: int = field(default=3600, metadata={"sticky": True})  # 1 hour
+
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -10,11 +10,14 @@ from PySide2.QtWidgets import (  # type: ignore
     QCheckBox,
     QComboBox,
     QGridLayout,
+    QGroupBox,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QSizePolicy,
     QSpacerItem,
     QWidget,
+    QSpinBox,
 )
 
 from ...assets import find_all_write_nodes
@@ -48,31 +51,147 @@ class SceneSettingsWidget(QWidget):
             self.write_node_box.addItem(write_node.fullName(), write_node.fullName())
 
         lyt.addWidget(QLabel("Write Nodes"), 0, 0)
-        lyt.addWidget(self.write_node_box, 0, 1)
+        lyt.addWidget(self.write_node_box, 0, 1, 1, -1)
 
         self.views_box = QComboBox(self)
         self.views_box.addItem("All Views", "")
         for view in sorted(nuke.views()):
             self.views_box.addItem(view, view)
         lyt.addWidget(QLabel("Views"), 1, 0)
-        lyt.addWidget(self.views_box, 1, 1)
+        lyt.addWidget(self.views_box, 1, 1, 1, -1)
 
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
         lyt.addWidget(self.frame_override_chck, 2, 0)
-        lyt.addWidget(self.frame_override_txt, 2, 1)
+        lyt.addWidget(self.frame_override_txt, 2, 1, 1, -1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
 
         self.proxy_mode_check = QCheckBox("Use Proxy Mode", self)
         lyt.addWidget(self.proxy_mode_check, 3, 0)
 
+        self.timeout_checkbox = QCheckBox("Use Timeouts", self)
+        self.timeout_checkbox.setChecked(True)
+        self.timeout_checkbox.clicked.connect(self.activate_timeout_changed)
+        self.timeout_checkbox.setToolTip(
+            "Set a maximum duration for actions from this job. See AWS Deadline Cloud documentation to learn more"
+        )
+        lyt.addWidget(self.timeout_checkbox, 4, 0)
+        self.timeouts_subtext = QLabel("Set a maximum duration for actions from this job")
+        self.timeouts_subtext.setStyleSheet("font-style: italic")
+        lyt.addWidget(self.timeouts_subtext, 4, 1, 1, -1)
+
+        self.timeouts_box = QGroupBox()
+        timeouts_lyt = QGridLayout(self.timeouts_box)
+        lyt.addWidget(self.timeouts_box, 5, 0, 1, -1)
+
+        def create_timeout_row(label, tooltip, row):
+            qlabel = QLabel(label)
+            qlabel.setToolTip(tooltip)
+            timeouts_lyt.addWidget(qlabel, row, 0)
+
+            days_box = QSpinBox(self, minimum=0, maximum=365)
+            days_box.setSuffix(" days")
+            timeouts_lyt.addWidget(days_box, row, 1)
+
+            hours_box = QSpinBox(self, minimum=0, maximum=23)
+            hours_box.setSuffix(" hours")
+            timeouts_lyt.addWidget(hours_box, row, 2)
+
+            minutes_box = QSpinBox(self, minimum=0, maximum=59)
+            minutes_box.setSuffix(" minutes")
+            timeouts_lyt.addWidget(minutes_box, row, 3)
+
+            return qlabel, days_box, hours_box, minutes_box
+
+        def hookup_zero_callback(timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]):
+            def indicate_is_valid_callback(value: int):
+                self.indicate_if_valid(timeout_boxes)
+
+            for timeout_box in timeout_boxes[1:]:
+                timeout_box.valueChanged.connect(indicate_is_valid_callback)
+
+        self.on_run_timeouts = create_timeout_row(
+            label="Render Task Timeout",
+            tooltip="Maximum duration of each action which performs a render. Default is 6 days.",
+            row=0,
+        )
+        hookup_zero_callback(self.on_run_timeouts)
+
+        self.on_enter_timeouts = create_timeout_row(
+            label="Setup Timeout",
+            tooltip="Maximum duration of each action which sets up the job for rendering, such as scene load. Default is 1 day.",
+            row=1,
+        )
+        hookup_zero_callback(self.on_enter_timeouts)
+
+        self.on_exit_timeouts = create_timeout_row(
+            label="Teardown Timeout",
+            tooltip="Maximum duration of action which tears down the setup required for rendering. Default is 1 hour.",
+            row=2,
+        )
+        hookup_zero_callback(self.on_exit_timeouts)
+
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 4, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 6, 0, 1, 2)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 7, 0)
+
+    def indicate_if_valid(self, timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]):
+        if (
+            self._calculate_timeout_seconds(timeout_boxes) == 0
+            and self.timeout_checkbox.isChecked()
+        ):
+            timeout_boxes[0].setStyleSheet("color: red")
+        else:
+            timeout_boxes[0].setStyleSheet("")
+
+        # If the spin box has a value of 1, we should not make the suffix plural.
+        for box in timeout_boxes[1:4]:
+            if box.value() == 1:
+                box.setSuffix(box.suffix().strip("s"))
+            elif not box.suffix().endswith("s"):
+                box.setSuffix(box.suffix() + "s")
+
+    def activate_timeout_changed(self, _=None, warn=True):
+        state = self.timeout_checkbox.checkState()
+        if state == Qt.Unchecked and warn:
+            result = QMessageBox.warning(
+                self,
+                "Warning",
+                "Removing timeouts in your submission can result in a task that runs indefinitely. Are you sure you want to remove timeouts?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if result == QMessageBox.No:
+                self.timeout_checkbox.setChecked(True)
+        for timeout_boxes in (self.on_run_timeouts, self.on_enter_timeouts, self.on_exit_timeouts):
+            for timeout_box in timeout_boxes:
+                timeout_box.setEnabled(state == Qt.Checked)
+            self.indicate_if_valid(timeout_boxes)
+
+    def _calculate_timeout_seconds(
+        self, timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]
+    ):
+        return (
+            timeout_boxes[1].value() * 86400
+            + timeout_boxes[2].value() * 3600
+            + timeout_boxes[3].value() * 60
+        )
+
+    @property
+    def on_run_timeout_seconds(self):
+        return self._calculate_timeout_seconds(self.on_run_timeouts)
+
+    @property
+    def on_enter_timeout_seconds(self):
+        return self._calculate_timeout_seconds(self.on_enter_timeouts)
+
+    @property
+    def on_exit_timeout_seconds(self):
+        return self._calculate_timeout_seconds(self.on_exit_timeouts)
 
     def refresh_ui(self, settings: RenderSubmitterUISettings):
         self.frame_override_chck.setChecked(settings.override_frame_range)
@@ -89,8 +208,26 @@ class SceneSettingsWidget(QWidget):
 
         self.proxy_mode_check.setChecked(settings.is_proxy_mode)
 
+        self.timeout_checkbox.setChecked(settings.timeouts_enabled)
+
+        def _set_timeout(
+            timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox], timeout_seconds: int
+        ):
+            days = timeout_seconds // 86400
+            hours = (timeout_seconds % 86400) // 3600
+            minutes = (timeout_seconds % 3600) // 60
+            timeout_boxes[1].setValue(days)
+            timeout_boxes[2].setValue(hours)
+            timeout_boxes[3].setValue(minutes)
+
+        _set_timeout(self.on_run_timeouts, settings.on_run_timeout_seconds)
+        _set_timeout(self.on_enter_timeouts, settings.on_enter_timeout_seconds)
+        _set_timeout(self.on_exit_timeouts, settings.on_exit_timeout_seconds)
+
         if self.developer_options:
             self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels)
+
+        self.activate_timeout_changed(warn=False)  # don't warn when loading from sticky settings
 
     def update_settings(self, settings: RenderSubmitterUISettings):
         """
@@ -102,6 +239,11 @@ class SceneSettingsWidget(QWidget):
         settings.write_node_selection = self.write_node_box.currentData()
         settings.view_selection = self.views_box.currentData()
         settings.is_proxy_mode = self.proxy_mode_check.isChecked()
+
+        settings.timeouts_enabled = self.timeout_checkbox.isChecked()
+        settings.on_run_timeout_seconds = self.on_run_timeout_seconds
+        settings.on_enter_timeout_seconds = self.on_enter_timeout_seconds
+        settings.on_exit_timeout_seconds = self.on_exit_timeout_seconds
 
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was no mechanism to set timeouts for session/environment actions through the submitter.

### What was the solution? (How)

Add the UI. The default looks like the following:
![image](https://github.com/aws-deadline/deadline-cloud-for-nuke/assets/119458760/a872a842-6669-4cb3-aeea-63bd9528519e)



* Use Timeouts is a sticky setting
* The values of each timeout type are a sticky setting


A warning pops up when deselecting the `Use Timeouts` checkbox

![image](https://github.com/aws-deadline/deadline-cloud-for-nuke/assets/119458760/f2ccf6c1-0a8c-4052-8cdd-a92162f99cb7)


Zero-valued timeouts are not valid, and are highlighted red to help with identification


![image](https://github.com/aws-deadline/deadline-cloud-for-nuke/assets/119458760/96bb7a8c-d46b-4a37-be1a-c90c720d52cd)

- On submission the following error pops up for zero-valued timeouts
![image](https://github.com/aws-deadline/deadline-cloud-for-nuke/assets/119458760/366f1410-b52b-462e-ad13-b155abaf8fd0)

The timeout fields are disabled when the `Use Timeouts`  checkbox is not selected

![image](https://github.com/aws-deadline/deadline-cloud-for-nuke/assets/119458760/3e6c35f0-40da-4a3a-b3a8-279805a0b3c0)
- Additionally, the zero-value validation is disabled when this checkbox is deselected

### What is the impact of this change?

Users can set timeouts in their job and have the corresponding action timeout when the duration has elapsed.

### How was this change tested?

- UI was manually tested
- Submitted a job using these changes and confirmed that the job timed out accordingly

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes, I updated the job bundle output test job templates as the default value for the timeout fields has changed the expected template 


```

Timestamp: 2024-05-14T11:54:56.189556-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2024-05-14T11:54:58.856255-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2024-05-14T11:54:59.780206-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-05-14T11:55:01.078336-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2024-05-14T11:55:02.101071-05:00
Running job bundle output test: C:\Users\samcan\git\deadline\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-05-14T11:55:06.716752-05:00

```

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
