### PR TITLE
docs: use correct AWS Deadline shelf name

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,7 @@ WARNING: This workflow installs additional Python packages into your Nuke's pyth
 4. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke` to install the Nuke Submitter in edit mode.
 5. Run `set NUKE_PATH=C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke\src` to put the `menu.py` file in the path Nuke searches for menu extensions.
 6. Run `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` to enable the job bundle debugging support. This enables a menu item you can use to run the tests from the `job_bundle_output_tests` directory.
-7. Run `.\Nuke<version>.exe` to run Nuke. The Nuke submitter should be available in the Thinkbox menu.
+7. Run `.\Nuke<version>.exe` to run Nuke. The Nuke submitter should be available in the AWS Deadline menu.
 
 ## Application Interface Adaptor Development Workflow
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The development.md file had the wrong shelf name for where the submitter is in Nuke
### What was the solution? (How)
Fixed it
### What is the impact of this change?
More accurate docs
### How was this change tested?
`hatch run fmt && hatch run lint`, docs only change
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, docs only change

### Was this change documented?
It is a docs change
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
