### PR TITLE
fix: Update write nodes and views when refeshing the job settings ui

### DIFF
--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -43,20 +43,12 @@ class SceneSettingsWidget(QWidget):
         lyt = QGridLayout(self)
 
         self.write_node_box = QComboBox(self)
-        self.write_node_box.addItem("All Write Nodes", None)
-        for write_node in sorted(
-            find_all_write_nodes(), key=lambda write_node: write_node.fullName()
-        ):
-            # Set data value as fullName since this is the value we want to store in the settings
-            self.write_node_box.addItem(write_node.fullName(), write_node.fullName())
-
+        self._rebuild_write_node_drop_down()
         lyt.addWidget(QLabel("Write Nodes"), 0, 0)
         lyt.addWidget(self.write_node_box, 0, 1, 1, -1)
 
         self.views_box = QComboBox(self)
-        self.views_box.addItem("All Views", "")
-        for view in sorted(nuke.views()):
-            self.views_box.addItem(view, view)
+        self._rebuild_views_drop_down()
         lyt.addWidget(QLabel("Views"), 1, 0)
         lyt.addWidget(self.views_box, 1, 1, 1, -1)
 
@@ -181,6 +173,21 @@ class SceneSettingsWidget(QWidget):
             + timeout_boxes[3].value() * 60
         )
 
+    def _rebuild_write_node_drop_down(self) -> None:
+        self.write_node_box.clear()
+        self.write_node_box.addItem("All Write Nodes", None)
+        for write_node in sorted(
+            find_all_write_nodes(), key=lambda write_node: write_node.fullName()
+        ):
+            # Set data value as fullName since this is the value we want to store in the settings
+            self.write_node_box.addItem(write_node.fullName(), write_node.fullName())
+
+    def _rebuild_views_drop_down(self) -> None:
+        self.views_box.clear()
+        self.views_box.addItem("All Views", "")
+        for view in sorted(nuke.views()):
+            self.views_box.addItem(view, view)
+
     @property
     def on_run_timeout_seconds(self):
         return self._calculate_timeout_seconds(self.on_run_timeouts)
@@ -198,13 +205,19 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
 
+        self._rebuild_write_node_drop_down()
         index = self.write_node_box.findData(settings.write_node_selection)
         if index >= 0:
             self.write_node_box.setCurrentIndex(index)
+        else:
+            self.write_node_box.setCurrentIndex(0)
 
+        self._rebuild_views_drop_down()
         index = self.views_box.findData(settings.view_selection)
         if index >= 0:
             self.views_box.setCurrentIndex(index)
+        else:
+            self.views_box.setCurrentIndex(0)
 
         self.proxy_mode_check.setChecked(settings.is_proxy_mode)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Write nodes and views were not updated in the job settings tab of the submitter dialog.

### What was the solution? (How)

Updated write nodes and views when we call `refresh_ui`

### What is the impact of this change?

Users will be able to select write nodes and views that were created after the first time they opened the submission dialog.

### How was this change tested?

I changed the names of/created new some write nodes and views after having opened the submission dialog. I opened it again and the lists were accurate. I also deleted the one that was currently selected. I opened the dialog again and observed that it had reverted to the "all" option.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, this is purely a GUI change.

### Was this change documented?

No

### Is this a breaking change?

No, this is a fixing change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
