### PR TITLE
feat: Added support for including gizmos in job bundle

### DIFF
--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -15,13 +15,13 @@ from typing import (
 # so that importing just the adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import (  # type: ignore[import]
-        HTTPClientInterface as _HTTPClientInterface,
+        ClientInterface as _ClientInterface,
         PathMappingRule,
     )
     from nuke_adaptor.NukeClient.nuke_handler import NukeHandler  # type: ignore[import]
 except ImportError:
     from openjd.adaptor_runtime_client import (
-        HTTPClientInterface as _HTTPClientInterface,
+        ClientInterface as _ClientInterface,
         PathMappingRule,
     )
     from deadline.nuke_adaptor.NukeClient.nuke_handler import NukeHandler
@@ -37,7 +37,7 @@ except ImportError:
     from deadline.nuke_util import ocio as nuke_ocio
 
 
-class NukeClient(_HTTPClientInterface):
+class NukeClient(_ClientInterface):
     """
     Client for that runs in Nuke for the Nuke Adaptor
     """

--- a/src/deadline/nuke_submitter/data_classes.py
+++ b/src/deadline/nuke_submitter/data_classes.py
@@ -36,6 +36,8 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     on_enter_timeout_seconds: int = field(default=86400, metadata={"sticky": True})  # 1 day
     on_exit_timeout_seconds: int = field(default=3600, metadata={"sticky": True})  # 1 hour
 
+    include_gizmos_in_job_bundle: bool = field(default=False, metadata={"sticky": True})
+
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 from pathlib import Path
 from typing import Any, Optional
 import yaml  # type: ignore[import]
@@ -78,7 +79,70 @@ def _set_timeouts(template: dict[str, Any], settings: RenderSubmitterUISettings)
         _handle_step(step)
 
 
-def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
+def _add_gizmos_to_job_bundle(job_bundle_path: Path, nodes: list[nuke.Node]) -> Optional[Path]:
+    gizmo_paths = [Path(node.filename()) for node in nodes if isinstance(node, nuke.Gizmo)]
+    if not gizmo_paths:
+        return None
+    gizmo_dir = job_bundle_path / "gizmos"
+    gizmo_dir.mkdir(parents=True, exist_ok=True)
+    for gizmo_path in gizmo_paths:
+        shutil.copy(gizmo_path, gizmo_dir / gizmo_path.name)
+    return gizmo_dir
+
+
+def _add_gizmo_dir_to_job_template(job_template: dict[str, Any], relative_gizmo_dir: Path) -> None:
+    if "parameterDefinitions" not in job_template:
+        job_template["parameterDefinitions"] = []
+
+    job_template["parameterDefinitions"].append(
+        {
+            "name": "GizmoDir",
+            "type": "PATH",
+            "description": "The directory containing Nuke Gizmo files used by this job.",
+            "default": str(relative_gizmo_dir),
+            "objectType": "DIRECTORY",
+            "dataFlow": "IN",
+            "userInterface": {"control": "CHOOSE_DIRECTORY", "label": "Gizmo Directory"},
+        }
+    )
+
+    render_step = None
+    for step in job_template["steps"]:
+        if step["name"] == "Render":
+            render_step = step
+            break
+    if render_step is None:
+        raise RuntimeError("No 'Render' step found in the job template")
+
+    if "stepEnvironments" not in render_step:
+        render_step["stepEnvironments"] = []
+
+    # This needs to be prepended rather than appended
+    # as it must run before the "Nuke" environment.
+    render_step["stepEnvironments"].insert(
+        0,
+        {
+            "name": "AddGizmoPathsToNukePath",
+            "script": {
+                "actions": {"onEnter": {"command": "{{Env.File.Enter}}"}},
+                "embeddedFiles": [
+                    {
+                        "name": "Enter",
+                        "type": "TEXT",
+                        "runnable": True,
+                        "data": """#!/bin/bash
+echo 'openjd_env: NUKE_PATH=$NUKE_PATH:{{Param.GizmoDir}}'
+""",
+                    }
+                ],
+            },
+        },
+    )
+
+
+def _get_job_template(
+    settings: RenderSubmitterUISettings, relative_gizmo_dir: Optional[Path]
+) -> dict[str, Any]:
     # Load the default Nuke job template, and then fill in scene-specific
     # values it needs.
     with open(Path(__file__).parent / "default_nuke_job_template.yaml") as f:
@@ -91,6 +155,11 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
 
     # Set the timeouts for each action:
     _set_timeouts(job_template, settings)
+
+    # Add Gizmo directory to NUKE_PATH if we copied
+    # any gizmos to the job bundle.
+    if settings.include_gizmos_in_job_bundle and relative_gizmo_dir:
+        _add_gizmo_dir_to_job_template(job_template, relative_gizmo_dir)
 
     # Get a map of the parameter definitions for easier lookup
     parameter_def_map = {param["name"]: param for param in job_template["parameterDefinitions"]}
@@ -316,7 +385,13 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
                 raise DeadlineOperationError(message)
 
         job_bundle_path = Path(job_bundle_dir)
-        job_template = _get_job_template(settings)
+        gizmo_dir = (
+            _add_gizmos_to_job_bundle(job_bundle_path, list(nuke.allNodes(recurseGroups=True)))
+            if settings.include_gizmos_in_job_bundle
+            else None
+        )
+        relative_gizmo_dir = gizmo_dir.relative_to(job_bundle_path) if gizmo_dir else None
+        job_template = _get_job_template(settings, relative_gizmo_dir)
 
         # If "HostRequirements" is provided, inject it into each of the "Step"
         if host_requirements:

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -84,6 +84,10 @@ class SceneSettingsWidget(QWidget):
         timeouts_lyt = QGridLayout(self.timeouts_box)
         lyt.addWidget(self.timeouts_box, 5, 0, 1, -1)
 
+        self.gizmos_checkbox = QCheckBox("Include Gizmos In Job Bundle", self)
+        self.gizmos_checkbox.setChecked(True)
+        lyt.addWidget(self.gizmos_checkbox, 6, 0)
+
         def create_timeout_row(label, tooltip, row):
             qlabel = QLabel(label)
             qlabel.setToolTip(tooltip)
@@ -244,6 +248,8 @@ class SceneSettingsWidget(QWidget):
         settings.on_run_timeout_seconds = self.on_run_timeout_seconds
         settings.on_enter_timeout_seconds = self.on_enter_timeout_seconds
         settings.on_exit_timeout_seconds = self.on_exit_timeout_seconds
+
+        settings.include_gizmos_in_job_bundle = self.gizmos_checkbox.isChecked()
 
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()

--- a/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
@@ -13,7 +13,7 @@ from test.unit.mock_stubs import MockOCIOConfig
 import nuke
 import pytest
 from openjd.adaptor_runtime_client import (
-    HTTPClientInterface,
+    ClientInterface,
     PathMappingRule,
 )
 
@@ -39,8 +39,8 @@ class TestNukeClient:
     @patch("deadline.nuke_adaptor.NukeClient.nuke_client.os.path.exists")
     @patch.dict(os.environ, {"NUKE_ADAPTOR_SERVER_PATH": "9999"})
     @patch("deadline.nuke_adaptor.NukeClient.NukeClient.poll")
-    @patch("deadline.nuke_adaptor.NukeClient.nuke_client._HTTPClientInterface")
-    def test_main(self, mock_httpclient: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
+    @patch("deadline.nuke_adaptor.NukeClient.nuke_client._ClientInterface")
+    def test_main(self, mock_client: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
         """Tests that the main method starts the nuke client polling method"""
         # GIVEN
         mock_exists.return_value = True
@@ -141,6 +141,7 @@ class TestNukeClient:
         else:
             mock_os.makedirs.assert_called_once_with(mock_os.path.dirname.return_value)
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX path mapping not implemented on Windows")
     @pytest.mark.parametrize(
         "path, client_mapped, expected_mapped, new_path_class, rules",
         [
@@ -176,8 +177,8 @@ class TestNukeClient:
     )
     @patch.object(nuke, "addFilenameFilter")
     @patch.object(nuke_client_mod, "Path")
-    @patch.object(HTTPClientInterface, "map_path")
-    @patch.object(HTTPClientInterface, "path_mapping_rules")
+    @patch.object(ClientInterface, "map_path")
+    @patch.object(ClientInterface, "path_mapping_rules")
     def test_map_path(
         self,
         mock_path_mapping_rules: Mock,
@@ -245,8 +246,8 @@ class TestNukeClient:
     )
     @patch.object(nuke, "addFilenameFilter")
     @patch.object(nuke_client_mod, "Path")
-    @patch.object(HTTPClientInterface, "map_path")
-    @patch.object(HTTPClientInterface, "path_mapping_rules")
+    @patch.object(ClientInterface, "map_path")
+    @patch.object(ClientInterface, "path_mapping_rules")
     def test_recursive_map_path(
         self,
         mock_path_mapping_rules: Mock,
@@ -272,6 +273,7 @@ class TestNukeClient:
         mock_addfilenamefilter.assert_called_once_with(client.map_path)
         assert mapped == expected_mapped
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX path mapping not implemented on Windows")
     @patch.dict(os.environ, {"NUKE_TEMP_DIR": "/var/tmp/nuke_temp_dir"})
     @patch(
         "deadline.nuke_util.ocio.get_custom_config_path",

--- a/test/unit/deadline_submitter_for_nuke/test_gizmos.py
+++ b/test/unit/deadline_submitter_for_nuke/test_gizmos.py
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pathlib
+
+from deadline.nuke_submitter.deadline_submitter_for_nuke import (
+    _add_gizmo_dir_to_job_template,
+)
+
+
+def test_add_gizmo_dir_to_job_template():
+    job_template = {
+        "parameterDefinitions": [],
+        "steps": [
+            {
+                "name": "Render",
+                "stepEnvironments": [
+                    {
+                        "name": "OtherEnv",
+                    },
+                ],
+            }
+        ],
+    }
+
+    relative_gizmo_path = pathlib.Path("gizmos")
+    _add_gizmo_dir_to_job_template(job_template, relative_gizmo_path)
+
+    assert len(job_template["parameterDefinitions"]) == 1
+    expected_definition = {
+        "name": "GizmoDir",
+        "type": "PATH",
+        "description": "The directory containing Nuke Gizmo files used by this job.",
+        "default": "gizmos",
+        "objectType": "DIRECTORY",
+        "dataFlow": "IN",
+        "userInterface": {"control": "CHOOSE_DIRECTORY", "label": "Gizmo Directory"},
+    }
+    assert job_template["parameterDefinitions"][0] == expected_definition
+
+    expected_environment = {
+        "name": "AddGizmoPathsToNukePath",
+        "script": {
+            "actions": {"onEnter": {"command": "{{Env.File.Enter}}"}},
+            "embeddedFiles": [
+                {
+                    "name": "Enter",
+                    "type": "TEXT",
+                    "runnable": True,
+                    "data": """#!/bin/bash
+echo 'openjd_env: NUKE_PATH=$NUKE_PATH:{{Param.GizmoDir}}'
+""",
+                }
+            ],
+        },
+    }
+    assert len(job_template["steps"][0]["stepEnvironments"]) == 2
+    assert job_template["steps"][0]["stepEnvironments"][0] == expected_environment

--- a/test/unit/nuke_util/test_ocio.py
+++ b/test/unit/nuke_util/test_ocio.py
@@ -109,6 +109,7 @@ def test_create_config_from_file(
     create_from_file.assert_called_once_with(custom_ocio_config_path)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Does not run on Windows")
 def test_config_has_absolute_search_paths(ocio_config: MockOCIOConfig) -> None:
     # GIVEN
     expected = True


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Nuke gizmos are saved groups of nodes that can be re-used. They are stored in `.gizmo` files. These files must be on the `NUKE_PATH` in order to be used. If a user submits a nuke script that references gizmos and the gizmos are not otherwise installed on the worker, the render will fail when it tries to load the gizmos.

### What was the solution? (How)

While generating the job bundle, we search the scene for gizmo nodes and collect their file paths. We copy all the utilized gizmos to the job bundle in a `gizmos/` sub directory. We then add a path parameter to the job template referencing this sub directory. We then add a step environment to the Render step _before_ the environment that starts nuke which adds the path mapped gizmos directory to `NUKE_PATH`. There is a checkbox in the submission GUI to disable this if desired.

The reason we copy the gizmo files to the job bundle is that the files are small, and putting them all in one directory rather than uploading each one as individual job attachments and adding each path mapped directory to the `NUKE_PATH` makes the job template more complex.  

### What is the impact of this change?

Users will be able to submit gizmos with their Nuke jobs.

### How was this change tested?

I submitted a job for a nuke script that used gizmos and verified that it rendered correctly. I also verified that if the option is turned off gizmos are not copied and the step environment and parameter are not added. I also added a unit test for the unit testable code.

Also,  some of the unit tests do not run on Windows, so I have disabled them on Windows.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```log

Timestamp: 2024-06-27T10:48:11.644393-05:00
Running job bundle output test: C:\Users\evans\Development\deadline-cloud-client\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2024-06-27T10:48:13.029584-05:00
Running job bundle output test: C:\Users\evans\Development\deadline-cloud-client\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2024-06-27T10:48:14.994729-05:00
Running job bundle output test: C:\Users\evans\Development\deadline-cloud-client\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-06-27T10:48:16.213881-05:00
Running job bundle output test: C:\Users\evans\Development\deadline-cloud-client\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2024-06-27T10:48:18.216164-05:00
Running job bundle output test: C:\Users\evans\Development\deadline-cloud-client\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 5 total.
Timestamp: 2024-06-27T10:48:25.738289-05:00
```

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
