### PR TITLE
fix: Update frame range when write node is selected

### DIFF
--- a/job_bundle_output_tests/frame/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/frame/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - /normalized/job/bundle/dir/frame.nk
+  outputs:
+    directories:
+    - /normalized/cwd
+  referencedPaths: []

--- a/job_bundle_output_tests/frame/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/frame/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Frames
+  value: 3-7
+- name: NukeScriptFile
+  value: /normalized/job/bundle/dir/frame.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/frame/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/frame/expected_job_bundle/template.yaml
@@ -1,0 +1,128 @@
+specificationVersion: jobtemplate-2023-09
+name: frame.nk
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400

--- a/job_bundle_output_tests/frame/scene/frame.deadline_render_settings.json
+++ b/job_bundle_output_tests/frame/scene/frame.deadline_render_settings.json
@@ -1,0 +1,17 @@
+{
+ "name": "frame.nk",
+ "description": "",
+ "override_frame_range": false,
+ "frame_list": "1-100",
+ "write_node_selection": "Write1",
+ "view_selection": "",
+ "is_proxy_mode": false,
+ "input_filenames": [],
+ "input_directories": [],
+ "output_directories": [],
+ "timeouts_enabled": true,
+ "on_run_timeout_seconds": 518400,
+ "on_enter_timeout_seconds": 86400,
+ "on_exit_timeout_seconds": 3600,
+ "include_adaptor_wheels": false
+}

--- a/job_bundle_output_tests/frame/scene/frame.nk
+++ b/job_bundle_output_tests/frame/scene/frame.nk
@@ -1,0 +1,78 @@
+#! /Applications/Nuke15.0v4/Nuke15.0v4.app/Contents/MacOS/libnuke-15.0.4.dylib -nx
+#write_info Write1 file:"ColorBars.png" format:"2048 1556 1" chans:":rgba.red:rgba.green:rgba.blue:" framerange:"1 100" fps:"0" colorspace:"default (sRGB)" datatype:"8 bit" transfer:"unknown" views:"main" colorManagement:"Nuke"
+version 15.0 v4
+define_window_layout_xml {<?xml version="1.0" encoding="UTF-8"?>
+<layout version="1.0">
+    <window x="0" y="38" w="1512" h="916" maximized="1" screen="0">
+        <splitter orientation="1">
+            <split size="40"/>
+            <dock id="" hideTitles="1" activePageId="Toolbar.1">
+                <page id="Toolbar.1"/>
+            </dock>
+            <split size="849" stretch="1"/>
+            <splitter orientation="2">
+                <split size="526"/>
+                <dock id="" activePageId="Viewer.1">
+                    <page id="Viewer.1"/>
+                </dock>
+                <split size="370"/>
+                <dock id="" activePageId="DAG.1">
+                    <page id="DAG.1"/>
+                    <page id="Curve Editor.1"/>
+                    <page id="DopeSheet.1"/>
+                </dock>
+            </splitter>
+            <split size="615"/>
+            <dock id="" activePageId="Properties.1" focus="true">
+                <page id="Properties.1"/>
+                <page id="uk.co.thefoundry.backgroundrenderview.1"/>
+                <page id="Scenegraph.1"/>
+            </dock>
+        </splitter>
+    </window>
+</layout>
+}
+Root {
+ inputs 0
+ name /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/frame/scene/frame.nk
+ format "2048 1556 0 0 2048 1556 1 2K_Super_35(full-ap)"
+ proxy_type scale
+ proxy_format "1024 778 0 0 1024 778 1 1K_Super_35(full-ap)"
+ colorManagement Nuke
+ workingSpaceLUT linear
+ monitorLut sRGB
+ monitorOutLUT rec709
+ int8Lut sRGB
+ int16Lut sRGB
+ logLut Cineon
+ floatLut linear
+}
+ColorBars {
+ inputs 0
+ name ColorBars1
+ xpos -195
+ ypos -157
+}
+Write {
+ file ColorBars.png
+ file_type png
+ first 3
+ last 7
+ use_limit true
+ checkHashOnRead false
+ ocioColorspace scene_linear
+ display default
+ view sRGB
+ name Write1
+ selected true
+ xpos -195
+ ypos -83
+}
+Viewer {
+ frame_range 1-100
+ monitorOutNDISenderName "Nuke - frame - Viewer1"
+ monitorOutOutputTransform rec709
+ name Viewer1
+ xpos -195
+ ypos -57
+}


### PR DESCRIPTION
This is the same PR from https://github.com/aws-deadline/deadline-cloud-for-nuke/pull/154
The commit was merged in during release window, so got reverted. The PR is to re-merge the changes back. 

### What was the problem/requirement? (What/Why)

When write node is selected, incorrect frame range were exported in parameters

### What was the solution? (How)

- When override frame is selected, override the frame
- When write node is selected with limit_range checked (without override), write node's frame applied
- When write node is selected without limit_range checked (without override), project settings frame applied
- When no specific write node is selected, project settings frame applied

### What is the impact of this change?
- Based on the customers' setting, right frame range is selected as explained above

### How was this change tested?
- Opened Nuke with the following setting: 
```
Project setting frame: 1-4
Write1 node frame: 1-10
Override when selected with frame: 4
```
Verified the following: 
```
All write nodes, without frame override —> 1 - 4 
All write nodes, with frame override —> 4 
All write nodes, without frame override —> 1 - 4

Write1, with limitRange, without frame override —> 1 - 10 
Write1, with limitRange, with frame override —> 4
Write1, with limitRange, without frame override —> 1- 10 

Write1, without limitRange, without frame override —> 1- 4
Write1, without limitRange, with frame override —> 4 
Write1, without limitRange, without frame override —> 1 - 4 

```
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
```

Timestamp: 2024-08-12T14:01:24.012286-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-08-12T14:01:25.055533-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-08-12T14:01:26.720246-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-08-12T14:01:27.757395-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2024-08-12T14:01:29.360422-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-08-12T14:01:30.340508-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2024-08-12T14:01:33.469925-07:00

```


### Was this change documented?
No

### Is this a breaking change?
This is fix. 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
