### PR TITLE
feat: Added support for including gizmos in job bundle

### DIFF
--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -15,13 +15,13 @@ from typing import (
 # so that importing just the adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import (  # type: ignore[import]
-        HTTPClientInterface as _HTTPClientInterface,
+        ClientInterface as _ClientInterface,
         PathMappingRule,
     )
     from nuke_adaptor.NukeClient.nuke_handler import NukeHandler  # type: ignore[import]
 except ImportError:
     from openjd.adaptor_runtime_client import (
-        HTTPClientInterface as _HTTPClientInterface,
+        ClientInterface as _ClientInterface,
         PathMappingRule,
     )
     from deadline.nuke_adaptor.NukeClient.nuke_handler import NukeHandler
@@ -37,7 +37,7 @@ except ImportError:
     from deadline.nuke_util import ocio as nuke_ocio
 
 
-class NukeClient(_HTTPClientInterface):
+class NukeClient(_ClientInterface):
     """
     Client for that runs in Nuke for the Nuke Adaptor
     """

--- a/src/deadline/nuke_submitter/data_classes.py
+++ b/src/deadline/nuke_submitter/data_classes.py
@@ -36,6 +36,8 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     on_enter_timeout_seconds: int = field(default=86400, metadata={"sticky": True})  # 1 day
     on_exit_timeout_seconds: int = field(default=3600, metadata={"sticky": True})  # 1 hour
 
+    include_gizmos_in_job_bundle: bool = field(default=False, metadata={"sticky": True})
+
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -16,6 +16,15 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Nuke script file to render.
+- name: GizmoDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Gizmo Directory
+  description: The directory containing Nuke Gizmo files used by this job.
+  default: './gizmos'
 - name: Frames
   type: STRING
   description: The frames to render. E.g. 1-3,8,11-15

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -76,6 +76,9 @@ class SceneSettingsWidget(QWidget):
         timeouts_lyt = QGridLayout(self.timeouts_box)
         lyt.addWidget(self.timeouts_box, 5, 0, 1, -1)
 
+        self.gizmos_checkbox = QCheckBox("Include Gizmos In Job Bundle", self)
+        lyt.addWidget(self.gizmos_checkbox, 6, 0)
+
         def create_timeout_row(label, tooltip, row):
             qlabel = QLabel(label)
             qlabel.setToolTip(tooltip)
@@ -127,7 +130,7 @@ class SceneSettingsWidget(QWidget):
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 6, 0, 1, 2)
+            lyt.addWidget(self.include_adaptor_wheels, 7, 0, 1, 2)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 7, 0)
 
@@ -257,6 +260,8 @@ class SceneSettingsWidget(QWidget):
         settings.on_run_timeout_seconds = self.on_run_timeout_seconds
         settings.on_enter_timeout_seconds = self.on_enter_timeout_seconds
         settings.on_exit_timeout_seconds = self.on_exit_timeout_seconds
+
+        settings.include_gizmos_in_job_bundle = self.gizmos_checkbox.isChecked()
 
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()

--- a/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
@@ -13,7 +13,7 @@ from test.unit.mock_stubs import MockOCIOConfig
 import nuke
 import pytest
 from openjd.adaptor_runtime_client import (
-    HTTPClientInterface,
+    ClientInterface,
     PathMappingRule,
 )
 
@@ -39,8 +39,8 @@ class TestNukeClient:
     @patch("deadline.nuke_adaptor.NukeClient.nuke_client.os.path.exists")
     @patch.dict(os.environ, {"NUKE_ADAPTOR_SERVER_PATH": "9999"})
     @patch("deadline.nuke_adaptor.NukeClient.NukeClient.poll")
-    @patch("deadline.nuke_adaptor.NukeClient.nuke_client._HTTPClientInterface")
-    def test_main(self, mock_httpclient: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
+    @patch("deadline.nuke_adaptor.NukeClient.nuke_client._ClientInterface")
+    def test_main(self, mock_client: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
         """Tests that the main method starts the nuke client polling method"""
         # GIVEN
         mock_exists.return_value = True
@@ -141,6 +141,7 @@ class TestNukeClient:
         else:
             mock_os.makedirs.assert_called_once_with(mock_os.path.dirname.return_value)
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX path mapping not implemented on Windows")
     @pytest.mark.parametrize(
         "path, client_mapped, expected_mapped, new_path_class, rules",
         [
@@ -176,8 +177,8 @@ class TestNukeClient:
     )
     @patch.object(nuke, "addFilenameFilter")
     @patch.object(nuke_client_mod, "Path")
-    @patch.object(HTTPClientInterface, "map_path")
-    @patch.object(HTTPClientInterface, "path_mapping_rules")
+    @patch.object(ClientInterface, "map_path")
+    @patch.object(ClientInterface, "path_mapping_rules")
     def test_map_path(
         self,
         mock_path_mapping_rules: Mock,
@@ -245,8 +246,8 @@ class TestNukeClient:
     )
     @patch.object(nuke, "addFilenameFilter")
     @patch.object(nuke_client_mod, "Path")
-    @patch.object(HTTPClientInterface, "map_path")
-    @patch.object(HTTPClientInterface, "path_mapping_rules")
+    @patch.object(ClientInterface, "map_path")
+    @patch.object(ClientInterface, "path_mapping_rules")
     def test_recursive_map_path(
         self,
         mock_path_mapping_rules: Mock,
@@ -272,6 +273,7 @@ class TestNukeClient:
         mock_addfilenamefilter.assert_called_once_with(client.map_path)
         assert mapped == expected_mapped
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX path mapping not implemented on Windows")
     @patch.dict(os.environ, {"NUKE_TEMP_DIR": "/var/tmp/nuke_temp_dir"})
     @patch(
         "deadline.nuke_util.ocio.get_custom_config_path",

--- a/test/unit/deadline_submitter_for_nuke/test_gizmos.py
+++ b/test/unit/deadline_submitter_for_nuke/test_gizmos.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+from deadline.nuke_submitter.deadline_submitter_for_nuke import (
+    _add_gizmo_dir_to_job_template,
+    _remove_gizmo_dir_from_job_template,
+)
+
+
+def test_add_gizmo_dir_to_job_template():
+    job_template = {
+        "parameterDefinitions": [],
+        "steps": [
+            {
+                "name": "Render",
+                "stepEnvironments": [
+                    {
+                        "name": "OtherEnv",
+                    },
+                ],
+            }
+        ],
+    }
+
+    _add_gizmo_dir_to_job_template(job_template)
+
+    expected_environment = {
+        "name": "Add Gizmos to NUKE_PATH",
+        "script": {
+            "actions": {"onEnter": {"command": "{{Env.File.Enter}}"}},
+            "embeddedFiles": [
+                {
+                    "name": "Enter",
+                    "type": "TEXT",
+                    "runnable": True,
+                    "data": """#!/bin/bash
+    echo 'openjd_env: NUKE_PATH=$NUKE_PATH:{{Param.GizmoDir}}'
+    """,
+                }
+            ],
+        },
+    }
+    assert len(job_template["jobEnvironments"]) == 1
+    assert job_template["jobEnvironments"][0] == expected_environment
+
+
+def test_remove_gizmo_dir_from_job_template():
+    job_template = {"parameterDefinitions": [{"name": "GizmoDir", "type": "PATH"}]}
+
+    _remove_gizmo_dir_from_job_template(job_template)
+    expected_job_template: dict = {"parameterDefinitions": []}
+
+    assert len(job_template["parameterDefinitions"]) == 0
+    assert job_template == expected_job_template


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This PR originated from @evanspearman-a 's PR: https://github.com/aws-deadline/deadline-cloud-for-nuke/pull/152
Most of updates are same from the above PR and credits go to @evanspearman-a.  This PR is just to address comments from the above PR. 

### What was the solution? (How)
- Updated default_nuke_job_template.yaml to add Gizmo directory
- Moved Gizmo environment from step to job
- Updated human readable step environments

### What is the impact of this change?
- When Gizmo is enabled, default gizmo path will be in template and gizmo environment will be defined in job environment

### How was this change tested?
- When ExportToBundle with gizmo enabled, verified the template has the gizmo information 
- Submitted colorbars.nk and verified that it has `Launch Add Gizmos to NUKE_PATH` session before launching Nuke 
- Verified that when gizmo is not enabled, those information is not included in template

<img width="1426" alt="Screenshot 2024-08-29 at 3 30 39 PM" src="https://github.com/user-attachments/assets/0fa9f3d4-9311-4b38-84ba-22273c8fbca1">


### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-08-29T15:22:16.581585-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-08-29T15:22:17.641190-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-08-29T15:22:17.965391-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-08-29T15:22:18.309697-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2024-08-29T15:22:18.651177-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-08-29T15:22:18.995647-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2024-08-29T15:22:22.044715-07:00

```

### Was this change documented?
No 

### Is this a breaking change?
No 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
