### PR TITLE
fix: Add OCIO configuration to Job Environments

### DIFF
--- a/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
@@ -3,6 +3,8 @@ parameterValues:
   value: 1-100
 - name: NukeScriptFile
   value: /normalized/job/bundle/dir/ocio.nk
+- name: OCIOConfigPath
+  value: /normalized/job/bundle/dir/config.ocio
 - name: ProxyMode
   value: 'false'
 - name: deadline:targetTaskRunStatus

--- a/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
@@ -16,6 +16,11 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Nuke script file to render.
+- name: OCIOConfigPath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The directory containing OCIO config files used by this job.
 - name: Frames
   type: STRING
   description: The frames to render. E.g. 1-3,8,11-15
@@ -126,3 +131,15 @@ steps:
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
         timeout: 518400
+jobEnvironments:
+- name: Add OCIO Path to Environment Variable
+  script:
+    actions:
+      onEnter:
+        command: '{{Env.File.Enter}}'
+    embeddedFiles:
+    - name: Enter
+      type: TEXT
+      runnable: true
+      data: "#!/bin/bash\n    echo 'openjd_env: OCIO={{Param.OCIOConfigPath}}'\n \
+        \   "

--- a/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
   type: PATH
   objectType: FILE
   dataFlow: IN
-  description: The directory containing OCIO config files used by this job.
+  description: The OCIO config file used by this job.
 - name: Frames
   type: STRING
   description: The frames to render. E.g. 1-3,8,11-15
@@ -133,13 +133,5 @@ steps:
         timeout: 518400
 jobEnvironments:
 - name: Add OCIO Path to Environment Variable
-  script:
-    actions:
-      onEnter:
-        command: '{{Env.File.Enter}}'
-    embeddedFiles:
-    - name: Enter
-      type: TEXT
-      runnable: true
-      data: "#!/bin/bash\n    echo 'openjd_env: OCIO={{Param.OCIOConfigPath}}'\n \
-        \   "
+  variables:
+    OCIO: '{{Param.OCIOConfigPath}}'

--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -58,8 +58,8 @@ class NukeClient(_ClientInterface):
                 os.makedirs(output_dir)
 
         def verify_ocio_config():
-            """If using a custom OCIO config, update the internal search paths if necessary"""
-            if nuke_ocio.is_custom_config_enabled():
+            """If using an OCIO config, update the internal search paths if necessary"""
+            if nuke_ocio.is_OCIO_enabled():
                 self._map_ocio_config()
 
         nuke.addBeforeRender(verify_ocio_config)

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -95,27 +95,24 @@ def get_scene_asset_references() -> AssetReferences:
                 for search_path in ocio_config_search_paths:
                     asset_references.input_directories.add(search_path)
             else:
-                nuke.alert(
-                    "OCIO config file specified(%s) is not an existing file." % ocio_config_path
+                raise DeadlineOperationError(
+                    "OCIO config file specified(%s) is not an existing file. Please check and update the config file before proceeding."
+                    % ocio_config_path
                 )
 
     return asset_references
 
 
 def get_ocio_config_path() -> Optional[str]:
-    ocio_config_path = None
-
     # if using a custom OCIO environment variable
     if nuke_ocio.is_env_config_enabled():
-        ocio_config_path = nuke_ocio.get_env_config_path()
+        return nuke_ocio.get_env_config_path()
+    elif nuke_ocio.is_custom_config_enabled():
+        return nuke_ocio.get_custom_config_path()
+    elif nuke_ocio.is_stock_config_enabled():
+        return nuke_ocio.get_stock_config_path()
     else:
-        print("here?")
-        # if using a custom OCIO config file
-        if nuke_ocio.is_custom_config_enabled():
-            ocio_config_path = nuke_ocio.get_custom_config_path()
-        elif nuke_ocio.is_stock_config_enabled():
-            ocio_config_path = nuke_ocio.get_stock_config_path()
-    return ocio_config_path
+        return None
 
 
 def find_all_write_nodes() -> set:

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -128,19 +128,7 @@ def _add_ocio_path_to_job_template(job_template: dict[str, Any]) -> None:
         0,
         {
             "name": "Add OCIO Path to Environment Variable",
-            "script": {
-                "actions": {"onEnter": {"command": "{{Env.File.Enter}}"}},
-                "embeddedFiles": [
-                    {
-                        "name": "Enter",
-                        "type": "TEXT",
-                        "runnable": True,
-                        "data": """#!/bin/bash
-    echo 'openjd_env: OCIO={{Param.OCIOConfigPath}}'
-    """,
-                    }
-                ],
-            },
+            "variables": {"OCIO": "{{Param.OCIOConfigPath}}"},
         },
     )
 
@@ -289,8 +277,12 @@ def _get_parameter_values(
     # Set the OCIO config path value
     if nuke_ocio.is_OCIO_enabled():
         ocio_config_path = get_ocio_config_path()
-        parameter_values.append({"name": "OCIOConfigPath", "value": ocio_config_path})
-
+        if ocio_config_path:
+            parameter_values.append({"name": "OCIOConfigPath", "value": ocio_config_path})
+        else:
+            raise DeadlineOperationError(
+                "OCIO is enabled but OCIO config file is not specified. Please check and update the config file before proceeding."
+            )
     if settings.include_adaptor_wheels:
         wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
         parameter_values.append({"name": "AdaptorWheels", "value": wheels_path})

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -29,7 +29,7 @@ parameterDefinitions:
   type: PATH
   objectType: FILE
   dataFlow: IN
-  description: The directory containing OCIO config files used by this job.
+  description: The OCIO config file used by this job.
 - name: Frames
   type: STRING
   description: The frames to render. E.g. 1-3,8,11-15

--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -25,6 +25,11 @@ parameterDefinitions:
     label: Gizmo Directory
   description: The directory containing Nuke Gizmo files used by this job.
   default: './gizmos'
+- name: OCIOConfigPath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The directory containing OCIO config files used by this job.
 - name: Frames
   type: STRING
   description: The frames to render. E.g. 1-3,8,11-15

--- a/src/deadline/nuke_util/ocio.py
+++ b/src/deadline/nuke_util/ocio.py
@@ -4,9 +4,38 @@ from __future__ import annotations
 
 import os
 from pathlib import PurePath
+from typing import Optional
 
 import nuke
 import PyOpenColorIO as OCIO
+
+
+def is_env_config_enabled() -> bool:
+    """True if the OCIO environment variable is specified"""
+    return "OCIO" in os.environ
+
+
+def get_env_config_path() -> Optional[str]:
+    """This is the path to the custom OCIO config used by the OCIO env var."""
+    return os.environ.get("OCIO")
+
+
+def is_stock_config_enabled() -> bool:
+    """True if the script is using a custom OCIO config"""
+    return (
+        nuke.root().knob("colorManagement").value() == "OCIO"
+        and nuke.root().knob("OCIO_config").value() != "custom"
+    )
+
+
+def get_stock_config_path() -> str:
+    """This is the path to the UI defined OCIO config file."""
+    return os.path.abspath(nuke.root().knob("OCIOConfigPath").getEvaluatedValue())
+
+
+def is_OCIO_enabled() -> bool:
+    """Nuke is set to use OCIO."""
+    return nuke.root().knob("colorManagement").value() == "OCIO"
 
 
 def is_custom_config_enabled() -> bool:
@@ -19,7 +48,7 @@ def is_custom_config_enabled() -> bool:
 
 def get_custom_config_path() -> str:
     """This is the path to the custom OCIO config used by the script"""
-    return nuke.root().knob("customOCIOConfigPath").getEvaluatedValue()
+    return os.path.abspath(nuke.root().knob("customOCIOConfigPath").getEvaluatedValue())
 
 
 def create_config_from_file(ocio_config_path: str) -> OCIO.Config:

--- a/src/deadline/nuke_util/ocio.py
+++ b/src/deadline/nuke_util/ocio.py
@@ -21,7 +21,7 @@ def get_env_config_path() -> Optional[str]:
 
 
 def is_stock_config_enabled() -> bool:
-    """True if the script is using a custom OCIO config"""
+    """True if the script is using a default OCIO config"""
     return (
         nuke.root().knob("colorManagement").value() == "OCIO"
         and nuke.root().knob("OCIO_config").value() != "custom"

--- a/test/unit/deadline_submitter_for_nuke/test_ocio.py
+++ b/test/unit/deadline_submitter_for_nuke/test_ocio.py
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+from deadline.nuke_submitter.deadline_submitter_for_nuke import (
+    _add_ocio_path_to_job_template,
+    _remove_ocio_path_from_job_template,
+)
+
+
+def test_add__dir_to_job_template():
+    job_template = {
+        "parameterDefinitions": [],
+        "steps": [
+            {
+                "name": "Render",
+                "stepEnvironments": [
+                    {
+                        "name": "OtherEnv",
+                    },
+                ],
+            }
+        ],
+    }
+
+    _add_ocio_path_to_job_template(job_template)
+
+    expected_environment = {
+        "name": "Add OCIO Path to Environment Variable",
+        "script": {
+            "actions": {"onEnter": {"command": "{{Env.File.Enter}}"}},
+            "embeddedFiles": [
+                {
+                    "name": "Enter",
+                    "type": "TEXT",
+                    "runnable": True,
+                    "data": """#!/bin/bash
+    echo 'openjd_env: OCIO={{Param.OCIOConfigPath}}'
+    """,
+                }
+            ],
+        },
+    }
+
+    assert len(job_template["jobEnvironments"]) == 1
+    assert job_template["jobEnvironments"][0] == expected_environment
+
+
+def test_remove_ocio_path_from_job_template():
+    job_template = {"parameterDefinitions": [{"name": "OCIOConfigPath", "type": "PATH"}]}
+
+    _remove_ocio_path_from_job_template(job_template)
+    expected_job_template: dict = {"parameterDefinitions": []}
+
+    assert len(job_template["parameterDefinitions"]) == 0
+    assert job_template == expected_job_template

--- a/test/unit/deadline_submitter_for_nuke/test_ocio.py
+++ b/test/unit/deadline_submitter_for_nuke/test_ocio.py
@@ -26,19 +26,7 @@ def test_add__dir_to_job_template():
 
     expected_environment = {
         "name": "Add OCIO Path to Environment Variable",
-        "script": {
-            "actions": {"onEnter": {"command": "{{Env.File.Enter}}"}},
-            "embeddedFiles": [
-                {
-                    "name": "Enter",
-                    "type": "TEXT",
-                    "runnable": True,
-                    "data": """#!/bin/bash
-    echo 'openjd_env: OCIO={{Param.OCIOConfigPath}}'
-    """,
-                }
-            ],
-        },
+        "variables": {"OCIO": "{{Param.OCIOConfigPath}}"},
     }
 
     assert len(job_template["jobEnvironments"]) == 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- There are 3 ways to set OCIO configuration in Nuke: environment variable, custom config, and default config that is defined in Nuke already. The original implementation only took care of custom config. We want to handle when customer set their OCIO configuration in environment variable or default config. 

### What was the solution? (How)
- When OCIO is enabled, check the configuration path for all three options, then set the path via JobEnvironment in JobTemplate. 
 
### What is the impact of this change?
- When environment variable is set, the path will be set with environment variable 
- When custom config is set, the path will be set with custom config
- When default config is set, the path will be set with default config 
 
### How was this change tested?
- Submitted the job with OCIO setup, and verified it rendered successfully 
- Submitted the above job with different OCIO setup, verified it rendered successfully, and verified the output looks different in color scheme 
- Submitted the job with OCIO environment variable, and verified it rendered successfully 

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-09-16T22:51:08.146094-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-09-16T22:51:08.578900-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-09-16T22:51:08.968215-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-09-16T22:51:09.358968-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2024-09-16T22:51:09.757446-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-09-16T22:51:10.157282-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2024-09-16T22:51:13.578587-07:00

```

### Was this change documented?
No 

### Is this a breaking change?
No - In Nuke, environment variable takes precedence over other ocio configurations. (Ex. When OCIO environment variable is set, updating custom config in UI is disabled with the message: `OCIO environment variable is set. Setting OCIO configs from within Nuke will be disabled.`)

The existing user who uses custom config will continue to work. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
