### PR TITLE
chore: update README.md with follow-able command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,20 @@ This package provides a Nuke plugin that creates jobs for AWS Deadline Cloud usi
 
 To install the submitter manually, you can use pip.
 
+For Windows,
+```sh
+pip install deadline-cloud-for-nuke -t %USERPROFILE%/deadline-cloud-for-nuke
+```
+
+For Linux and MacOS:
 ```sh
 pip install deadline-cloud-for-nuke -t ~/deadline-cloud-for-nuke
 ```
-Please note that target directory is `~/deadline-cloud-for-nuke` in the example, but you can choose any other directorys that you'd prefer.
+Please note that target directory is `~/deadline-cloud-for-nuke` in Mac/Linux or `C:\Users\username/deadline-cloud-for-nuke` in Windows in the example, but you can choose any other directories that you'd prefer.
 
 For Windows,
 ```sh
-set NUKE_PATH=%NUKE_PATH%;~/deadline-cloud-for-nuke/deadline/nuke_submitter
+set NUKE_PATH=%NUKE_PATH%;%USERPROFILE%/deadline-cloud-for-nuke/deadline/nuke_submitter
 ```
 
 For Linux and MacOS:

--- a/README.md
+++ b/README.md
@@ -29,20 +29,23 @@ This package provides a Nuke plugin that creates jobs for AWS Deadline Cloud usi
 To install the submitter manually, you can use pip.
 
 ```sh
-$ pip install deadline-cloud-for-nuke -t target-directory
+pip install deadline-cloud-for-nuke -t ~/deadline-cloud-for-nuke
 ```
+Please note that target directory is `~/deadline-cloud-for-nuke` in the example, but you can choose any other directorys that you'd prefer.
 
 For Windows,
 ```sh
-$ set NUKE_PATH=%NUKE_PATH%;<target-directory>/deadline/nuke_submitter
+set NUKE_PATH=%NUKE_PATH%;~/deadline-cloud-for-nuke/deadline/nuke_submitter
 ```
 
 For Linux and MacOS:
 ```sh
-$ export NUKE_PATH=${NUKE_PATH}:<target-directory>/deadline/nuke_submitter
+export NUKE_PATH=${NUKE_PATH}:~/deadline-cloud-for-nuke/deadline/nuke_submitter
 ```
 
 After installation and within the same terminal, run `Nuke<version>` executable. The Nuke submitter should now be available in the AWS Deadline menu.
+
+For Mac, Nuke executable will be somewhere in `/Applications/Nuke15.0v4/Nuke15.0v4.app/Contents/MacOS` directory.
 
 NOTE: If you want the submitter available outside of this shell, consider using `NUKE_PATH` as an environment variable rather than a shell variable.
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The previous PR #152 had some comments that would help customer experience in installation

### What was the solution? (How)
Address comments 

### What is the impact of this change?
Customers will get some ideas how/where Nuke is installed in Mac OS. Also, when installing the submitter, customers will be able to copy and paste the command. 

### How was this change tested?

```
- `hatch build`
- `pip install dist/deadline_cloud_for_nuke-0.18.4.post4+g8b8bb17-py3-none-any.whl -t ~/deadline-cloud-for-nuke` 
- `export NUKE_PATH=~/deadline-cloud-for-nuke/src/deadline/nuke_submitter`
- `./Nuke15.0 `
```
Verified that Nuke has Submitter option on top

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-09-17T20:30:13.673943-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-09-17T20:30:14.075840-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-09-17T20:30:14.479238-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-09-17T20:30:14.858712-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2024-09-17T20:30:15.255162-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-09-17T20:30:15.657983-07:00
Running job bundle output test: /Users/chaejung/Desktop/submitter/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2024-09-17T20:30:23.120486-07:00
```

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
