### PR TITLE
feat: Handle different OCIO configs in adapter

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,12 +50,71 @@ will work on Linux or MacOS if you modify the path references as appropriate.
 WARNING: This workflow installs additional Python packages into your Nuke's python distribution. You may need to run the Command Prompt in Administrative mode if your current user does not have permission to write on Nuke's site-package folder.
 
 1. Create a development location within which to do your git checkouts. For example `~/deadline-clients`. Clone packages from this directory with commands like `git clone git@github.com:aws-deadline/deadline-cloud-for-nuke.git`. You'll also want the `deadline-cloud` repo.
-2. Switch to your Nuke directory, like `cd "C:\Program Files\Nuke15.0v2"`.
-3. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud` to install the AWS Deadline Cloud Client Library in edit mode.
-4. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke` to install the Nuke Submitter in edit mode.
-5. Run `set NUKE_PATH=C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke\src\deadline\nuke_submitter` to put the `menu.py` file in the path Nuke searches for menu extensions.
-6. Run `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` to enable the job bundle debugging support. This enables a menu item you can use to run the tests from the `job_bundle_output_tests` directory.
-7. Run `.\Nuke<version>.exe` to run Nuke. The Nuke submitter should be available in the AWS Deadline menu.
+1. Switch to your Nuke directory, like `cd "C:\Program Files\Nuke15.0v2"`.
+
+   Windows (update the path as needed):
+   ```
+   cd "C:\Program Files\Nuke15.0v2"
+   ```
+
+   Mac (update the path as needed):
+   ```
+   cd /Applications/Nuke15.0v4/Nuke15.0v4.app/Contents/MacOS
+   ```
+1. Install the AWS Deadline Cloud Client Library in edit mode.
+
+   Windows (update the path as needed):
+   ```
+   .\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud
+   ```
+
+   Mac (update the path as needed):
+   ```
+   ./python -m pip install -e /Users/<username>/dev/deadline-clients/deadline-cloud
+   ```
+1. Run `.\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke` to install the Nuke Submitter in edit mode.
+
+   Windows (update the path as needed):
+   ```
+   .\python -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke
+   ```
+
+   Mac (update the path as needed):
+   ```
+   ./python -m pip install -e /Users/<username>/dev/deadline-clients/deadline-cloud-for-nuke
+   ```
+1. Put the `menu.py` file in the path Nuke searches for menu extensions. If you have already set your `NUKE_PATH` environment variable, append these paths to it instead of replacing it.
+
+   Windows (update the paths as needed):
+   ```
+   set NUKE_PATH=C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke\src\deadline\nuke_submitter:C:\Users\<username>\deadline-clients\deadline-cloud-for-nuke\src
+   ```
+
+   Mac (update the paths as needed):
+   ```
+   export NUKE_PATH=/Users/<username>/dev/deadline-clients/deadline-cloud-for-nuke/src/deadline/nuke_submitter:/Users/<username>/dev/deadline-clients/deadline-cloud-for-nuke/src
+   ```
+1. Set the `DEADLINE_ENABLE_DEVELOPER_OPTIONS` environment variable to `true` to enable the job bundle debugging support. This enables a menu item you can use to run the tests from the `job_bundle_output_tests` directory.
+
+   Windows:
+   ```
+   set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true
+   ```
+
+   Mac:
+   ```
+   export DEADLINE_ENABLE_DEVELOPER_OPTIONS=true
+   ```
+1. Run Nuke. The Nuke submitter should be available in the AWS Deadline menu.
+   Windows:
+   ```
+   .\Nuke<version>.exe
+   ```
+
+   Mac:
+   ```
+   ./Nuke<version>
+   ```
 
 ## Application Interface Adaptor Development Workflow
 

--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -117,7 +117,7 @@ class NukeClient(_ClientInterface):
 
     def _map_ocio_config(self):
         """If the OCIO config contains absolute search paths, apply path mapping rules and create a new config"""
-        ocio_config_path = nuke_ocio.get_custom_config_path()
+        ocio_config_path = nuke_ocio.get_ocio_config_path()
         ocio_config = nuke_ocio.create_config_from_file(ocio_config_path)
         if nuke_ocio.config_has_absolute_search_paths(ocio_config):
             # make all search paths absolute since the new config will be saved in the nuke temp dir

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -7,7 +7,6 @@ import re
 from collections.abc import Generator
 from os.path import commonpath, dirname, join, normpath, samefile
 from sys import platform
-from typing import Optional
 import nuke
 
 from deadline.client.job_bundle.submission import AssetReferences
@@ -83,7 +82,7 @@ def get_scene_asset_references() -> AssetReferences:
 
     if nuke_ocio.is_OCIO_enabled():
         # Determine and add the config file and associated search directories
-        ocio_config_path = get_ocio_config_path()
+        ocio_config_path = nuke_ocio.get_ocio_config_path()
         # Add the references
         if ocio_config_path is not None:
             if os.path.isfile(ocio_config_path):
@@ -101,18 +100,6 @@ def get_scene_asset_references() -> AssetReferences:
                 )
 
     return asset_references
-
-
-def get_ocio_config_path() -> Optional[str]:
-    # if using a custom OCIO environment variable
-    if nuke_ocio.is_env_config_enabled():
-        return nuke_ocio.get_env_config_path()
-    elif nuke_ocio.is_custom_config_enabled():
-        return nuke_ocio.get_custom_config_path()
-    elif nuke_ocio.is_stock_config_enabled():
-        return nuke_ocio.get_stock_config_path()
-    else:
-        return None
 
 
 def find_all_write_nodes() -> set:

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -30,7 +30,6 @@ from .assets import (
     get_nuke_script_file,
     get_scene_asset_references,
     find_all_write_nodes,
-    get_ocio_config_path,
 )
 from .data_classes import RenderSubmitterUISettings
 from .ui.components.scene_settings_tab import SceneSettingsWidget
@@ -276,7 +275,7 @@ def _get_parameter_values(
 
     # Set the OCIO config path value
     if nuke_ocio.is_OCIO_enabled():
-        ocio_config_path = get_ocio_config_path()
+        ocio_config_path = nuke_ocio.get_ocio_config_path()
         if ocio_config_path:
             parameter_values.append({"name": "OCIOConfigPath", "value": ocio_config_path})
         else:

--- a/src/deadline/nuke_util/ocio.py
+++ b/src/deadline/nuke_util/ocio.py
@@ -84,3 +84,22 @@ def update_config_search_paths(ocio_config: OCIO.Config, search_paths: list[str]
 def set_custom_config_path(ocio_config_path: str) -> None:
     """Set the knob on the root settings to update the OCIO config"""
     nuke.root().knob("customOCIOConfigPath").setValue(ocio_config_path)
+
+
+def get_ocio_config_path() -> Optional[str]:
+    """
+    Get the path to the OCIO configurations. Supports:
+        - OCIO environment variable
+        - Custom config
+        - Stock config
+    Returns None if OCIO is not enabled
+    """
+    # if using a custom OCIO environment variable
+    if is_env_config_enabled():
+        return get_env_config_path()
+    elif is_custom_config_enabled():
+        return get_custom_config_path()
+    elif is_stock_config_enabled():
+        return get_stock_config_path()
+    else:
+        return None

--- a/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeClient/test_client.py
@@ -276,7 +276,7 @@ class TestNukeClient:
     @pytest.mark.skipif(os.name == "nt", reason="POSIX path mapping not implemented on Windows")
     @patch.dict(os.environ, {"NUKE_TEMP_DIR": "/var/tmp/nuke_temp_dir"})
     @patch(
-        "deadline.nuke_util.ocio.get_custom_config_path",
+        "deadline.nuke_util.ocio.get_ocio_config_path",
         return_value="/session-dir/ocio/custom_config.ocio",
     )
     @patch(

--- a/test/unit/deadline_submitter_for_nuke/test_assets.py
+++ b/test/unit/deadline_submitter_for_nuke/test_assets.py
@@ -14,7 +14,6 @@ from deadline.nuke_submitter.assets import (
     get_node_file_knob_paths,
     get_node_filenames,
     get_scene_asset_references,
-    get_ocio_config_path,
 )
 
 
@@ -112,44 +111,6 @@ def test_get_scene_asset_references(
         search_path in expected_ocio_config_search_paths
         for search_path in results.input_directories
     )
-
-
-@patch("deadline.nuke_util.ocio.is_env_config_enabled", return_value=True)
-@patch("deadline.nuke_util.ocio.is_custom_config_enabled", return_value=False)
-@patch("deadline.nuke_util.ocio.is_stock_config_enabled", return_value=False)
-@patch(
-    "deadline.nuke_util.ocio.get_env_config_path",
-    return_value="/this/ocio_configs/env_variable_config.ocio",
-)
-@patch(
-    "deadline.nuke_util.ocio.get_custom_config_path",
-    return_value="/this/ocio_configs/custom_config.ocio",
-)
-@patch(
-    "deadline.nuke_util.ocio.get_stock_config_path",
-    return_value="/this/ocio_configs/stock_config.ocio",
-)
-def test_get_ocio_config_path(
-    mock_get_stock_config_path,
-    mock_get_custom_config_path,
-    mock_get_env_config_path,
-    mock_is_stock_config_enabled,
-    mock_is_custom_enabled,
-    mock_is_env_config_enabled,
-):
-    env_variable_ocio_path = get_ocio_config_path()
-    assert env_variable_ocio_path == "/this/ocio_configs/env_variable_config.ocio"
-
-    mock_is_env_config_enabled.return_value = False
-    mock_is_custom_enabled.return_value = True
-    custom_ocio_path = get_ocio_config_path()
-    assert custom_ocio_path == "/this/ocio_configs/custom_config.ocio"
-
-    mock_is_env_config_enabled.return_value = False
-    mock_is_custom_enabled.return_value = False
-    mock_is_stock_config_enabled.return_value = True
-    stock_ocio_path = get_ocio_config_path()
-    assert stock_ocio_path == "/this/ocio_configs/stock_config.ocio"
 
 
 @patch("os.path.isfile", return_value=False)

--- a/test/unit/nuke_util/test_ocio.py
+++ b/test/unit/nuke_util/test_ocio.py
@@ -239,3 +239,41 @@ def test_is_OCIO_enabled(root_node_with_default_ocio, root_node) -> None:
     os.environ["OCIO"] = "not-empty"
     actual = nuke_ocio.is_OCIO_enabled()
     assert expected == actual
+
+
+@patch("deadline.nuke_util.ocio.is_env_config_enabled", return_value=True)
+@patch("deadline.nuke_util.ocio.is_custom_config_enabled", return_value=False)
+@patch("deadline.nuke_util.ocio.is_stock_config_enabled", return_value=False)
+@patch(
+    "deadline.nuke_util.ocio.get_env_config_path",
+    return_value="/this/ocio_configs/env_variable_config.ocio",
+)
+@patch(
+    "deadline.nuke_util.ocio.get_custom_config_path",
+    return_value="/this/ocio_configs/custom_config.ocio",
+)
+@patch(
+    "deadline.nuke_util.ocio.get_stock_config_path",
+    return_value="/this/ocio_configs/stock_config.ocio",
+)
+def test_get_ocio_config_path(
+    mock_get_stock_config_path,
+    mock_get_custom_config_path,
+    mock_get_env_config_path,
+    mock_is_stock_config_enabled,
+    mock_is_custom_enabled,
+    mock_is_env_config_enabled,
+):
+    env_variable_ocio_path = nuke_ocio.get_ocio_config_path()
+    assert env_variable_ocio_path == "/this/ocio_configs/env_variable_config.ocio"
+
+    mock_is_env_config_enabled.return_value = False
+    mock_is_custom_enabled.return_value = True
+    custom_ocio_path = nuke_ocio.get_ocio_config_path()
+    assert custom_ocio_path == "/this/ocio_configs/custom_config.ocio"
+
+    mock_is_env_config_enabled.return_value = False
+    mock_is_custom_enabled.return_value = False
+    mock_is_stock_config_enabled.return_value = True
+    stock_ocio_path = nuke_ocio.get_ocio_config_path()
+    assert stock_ocio_path == "/this/ocio_configs/stock_config.ocio"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to support multiple ways of specifying an OCIO config. The adapter was failing on anything but custom configs.

### What was the solution? (How)
Change the assumptions that `get_custom_config_path` was the best way to get the OCIO config.

### What is the impact of this change?
The adapter supports multiple ways of specifying an OCIO config.

### How was this change tested?
1. Run the adapter with a default config `NUKE_ADAPTOR_NUKE_EXECUTABLE=/Applications/Nuke15.0v4/Nuke15.0v4.app/Contents/MacOS/Nuke15.0 nuke-openjd run --init-data file:///Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/init-data.yaml --run-data file:///Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/run-data.yaml`
2. Run the previous command but with a stock config (in this case I used `aces_1.2`)
3. Run the adapter with an env variable config `OCIO=/Applications/Nuke15.0v4/Nuke15.0v4.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio NUKE_ADAPTOR_NUKE_EXECUTABLE=/Applications/Nuke15.0v4/Nuke15.0v4.app/Contents/MacOS/Nuke15.0 nuke-openjd run --init-data file:///Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/init-data.yaml --run-data file:///Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/run-data.yaml`
4. Run the submitter with the default config. Verify that the job succeeds.
5. Run the submitter with a stock config. Verify that the job succeeds.
6. Run the submitter with the env config. Verify that the job succeeds.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-10-06T15:25:40.036025-07:00
Running job bundle output test: /Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-10-06T15:25:40.836416-07:00
Running job bundle output test: /Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-10-06T15:25:41.552605-07:00
Running job bundle output test: /Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-10-06T15:25:42.259920-07:00
Running job bundle output test: /Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2024-10-06T15:25:42.902532-07:00
Running job bundle output test: /Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-10-06T15:25:43.596009-07:00
Running job bundle output test: /Users/sbanas/dev/deadline-clients/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2024-10-06T15:25:52.870799-07:00

```

### Was this change documented?
No. Is there a place that needs to be updated?

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
