### PR TITLE
chore: Upgrade deadline-cloud to 0.49.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.48.*",
+    "deadline == 0.49.*",
     "openjd-adaptor-runtime >= 0.7,< 0.9",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

New release of deadline-cloud.

### What was the solution? (How)

Updated the `deadline-cloud` dependency to `0.49.*`

### What is the impact of this change?

Consume the latest changes and stay up to date.

### How was this change tested?



### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-11-19T11:23:23.871968-06:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2024-11-19T11:23:25.060634-06:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2024-11-19T11:23:26.519724-06:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2024-11-19T11:23:27.989879-06:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2024-11-19T11:23:28.801012-06:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2024-11-19T11:23:29.646785-06:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2024-11-19T11:25:03.236283-06:00

```

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
