### PR TITLE
feat(adaptor)!: Update Nuke environment variable to NUKE_EXECUTABLE

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,6 +182,6 @@ You can run the adaptor on your local workstation. This approach does not contai
    nuke-openjd run --init-data file://init-data.yaml --run-data file://run-data.yaml --path-mapping-rules file://path-mapping.yaml
    ```
 
-   NOTE: The nuke-openjd binary expects that the Nuke executable is named `nuke` and is set on the PATH. If this is not the case, you can set the `NUKE_ADAPTOR_NUKE_EXECUTABLE` environment variable to the path to the Nuke executable.
+   NOTE: The nuke-openjd binary expects that the Nuke executable is named `nuke` and is set on the PATH. If this is not the case, you can set the `NUKE_EXECUTABLE` environment variable to the path to the Nuke executable.
 
 4. The result will be written based on the output specified on the write node, taking any path mapping into account.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ The Nuke Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that 
 * sticky rendering, where the application stays open between tasks,
 * path mapping, that enables cross-platform rendering
 
-Jobs created by the submitter use this adaptor by default.
+Jobs created by the submitter use this adaptor by default, and that both the installed adaptor
+and the Nuke executable be available on the PATH of the user that will be running your jobs.
+
+Or you can set the `NUKE_EXECUTABLE` to point to the Nuke executable.
 
 ### Getting Started
 
@@ -49,13 +52,13 @@ For more information on the commands the OpenJD adaptor runtime provides, see [h
 
 ## Versioning
 
-This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its
 initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
 versions will increment during this initial development stage, they are described below:
 
-1. The MAJOR version is currently 0, indicating initial development. 
-2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
-3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
+1. The MAJOR version is currently 0, indicating initial development.
+2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
+3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API.
 
 ## Security
 

--- a/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
@@ -432,7 +432,7 @@ class NukeAdaptor(Adaptor):
             FileNotFoundError: If the nuke_client.py file could not be found.
             KeyError: If a configuration for the given platform and version does not exist.
         """
-        nuke_exe = os.environ.get("NUKE_ADAPTOR_NUKE_EXECUTABLE", "nuke")
+        nuke_exe = os.environ.get("NUKE_EXECUTABLE", "nuke")
         regexhandler = RegexHandler(self.regex_callbacks)
 
         # Add the Open Job Description namespace directory to PYTHONPATH, so that adaptor_runtime_client


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The assumption that the executable `nuke` exists on the PATH doesn't always make sense, often it is easier to specify the version of NUKE to use by explicit path and using an environment variable is an easy way to do this for customers.
### What was the solution? (How)
We have defined a new environment variable `NUKE_EXECUTABLE` which follows the naming from 
[`deadline-cloud-for-cinema-4d`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py#L298) of `<EXE_NAME>_EXECUTABLE`
### What is the impact of this change?
Breaking change as we changed the name of the existing environment variable.

### How was this change tested?

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

### Was this change documented?
Updated the documentation in README.md and DEVELOPMENT.md
### Is this a breaking change?
Yes
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
