### PR TITLE
fix: ensure continue_on_error is always passed to NukeHandler and set…

### DIFF
--- a/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 import jsonschema  # type: ignore
-from typing import Callable, cast
+from typing import Callable
 
 from deadline.client.api import get_deadline_cloud_library_telemetry_client, TelemetryClient
 from openjd.adaptor_runtime._version import version as openjd_adaptor_version
@@ -111,7 +111,7 @@ class NukeAdaptor(Adaptor):
         Returns:
             bool: True if the behavior is to continue on errors. False otherwise.
         """
-        return cast(bool, self.init_data.get("continue_on_error", True))
+        return True  # Temporarily continue_on_error by default until we have an option for it on the GUI submitter
 
     @property
     def _nuke_is_running(self) -> bool:
@@ -219,6 +219,9 @@ class NukeAdaptor(Adaptor):
         Args:
             match (re.Match): The match object from the regex pattern that was matched the message
         """
+        # Always log the error
+        _logger.error(f"Nuke encountered an error: {match.group(0)}")
+
         if not self.continue_on_error:
             self._exc_info = RuntimeError(f"Nuke Encountered an Error: {match.group(0)}")
 
@@ -468,11 +471,14 @@ class NukeAdaptor(Adaptor):
         Client will request and perform. The action must be present in the _FIRST_NUKE_ACTIONS or
         _NUKE_INIT_KEYS set to be added to the action queue.
         """
+        # Always set continue_on_error to True first
+        self._action_queue.enqueue_action(Action("continue_on_error", {"continue_on_error": True}))
+
         for name in _FIRST_NUKE_ACTIONS:
             self._action_queue.enqueue_action(Action(name, {name: self.init_data[name]}))
 
         for name in _NUKE_INIT_KEYS:
-            if name in self.init_data:
+            if name in self.init_data and name != "continue_on_error":
                 self._action_queue.enqueue_action(Action(name, {name: self.init_data[name]}))
 
     def _get_deadline_telemetry_client(self):

--- a/test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py
@@ -223,11 +223,16 @@ class TestNukeAdaptor_on_start:
 
         # THEN
         calls = mock_actions_queue.enqueue_action.call_args_list
-        for _call, name in zip(calls[: len(_FIRST_NUKE_ACTIONS)], _FIRST_NUKE_ACTIONS):
+        # First action should be continue_on_error
+        assert calls[0].args[0].name == "continue_on_error"
+        # Then check the rest of the first actions
+        for _call, name in zip(calls[1 : 1 + len(_FIRST_NUKE_ACTIONS)], _FIRST_NUKE_ACTIONS):
             assert _call.args[0].name == name, f"Action: {name} missing from first actions"
+        # Skip continue_on_error in _NUKE_INIT_KEYS since we already added it first
+        init_keys = [key for key in _NUKE_INIT_KEYS if key != "continue_on_error"]
         for _call, name in zip(
-            calls[len(_FIRST_NUKE_ACTIONS) : len(_FIRST_NUKE_ACTIONS) + len(_NUKE_INIT_KEYS)],
-            _NUKE_INIT_KEYS,
+            calls[1 + len(_FIRST_NUKE_ACTIONS) :],
+            init_keys,
         ):
             assert _call.args[0].name == name, f"Action: {name} missing from init actions"
 
@@ -661,7 +666,6 @@ class TestNukeAdaptor_on_cleanup:
         ("Eddy[ERROR] - Something terrible happened", 3),
     ]
 
-    @pytest.mark.parametrize("continue_on_error", [True, False])
     @pytest.mark.parametrize("stdout, regex_index", handle_error_params)
     @patch("deadline.nuke_adaptor.NukeAdaptor.adaptor.NukeAdaptor.update_status")
     @patch.object(NukeAdaptor, "_is_rendering", new_callable=PropertyMock(return_value=True))
@@ -671,12 +675,10 @@ class TestNukeAdaptor_on_cleanup:
         mock_update_status: Mock,
         stdout: str,
         regex_index: int,
-        continue_on_error: bool,
         init_data: dict,
     ) -> None:
         # GIVEN
         ERROR_CALLBACK_INDEX = 3
-        init_data["continue_on_error"] = continue_on_error
         adaptor = NukeAdaptor(init_data)
         regex_callbacks = adaptor.regex_callbacks
         error_regex = regex_callbacks[ERROR_CALLBACK_INDEX].regex_list[regex_index]
@@ -687,11 +689,8 @@ class TestNukeAdaptor_on_cleanup:
 
         # THEN
         assert match
-        if continue_on_error:
-            assert adaptor._exc_info is None
-        else:
-            assert isinstance(adaptor._exc_info, RuntimeError)
-            assert str(adaptor._exc_info) == f"Nuke Encountered an Error: {stdout}"
+        # Since continue_on_error is always True now, _exc_info should always be None
+        assert adaptor._exc_info is None
 
     @pytest.mark.parametrize(
         "version_string, expected_version",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Artists need the ability to continue rendering even when Nuke encounters non-critical errors in the graph. Previously, any error in Nuke would cause the 
adaptor to abort the render, which is not always desirable. This behavior differs from Deadline 10, which has an option to continue on errors.

The requirement was to implement similar functionality in the Deadline Cloud for Nuke adaptor, allowing renders to continue despite encountering errors in 
the Nuke graph.


### What was the solution? (How)

The solution implements a continue_on_error flag that is now always set to True by default. This is done by:

1. Hardcoding the continue_on_error property to return True (temporarily until we have a GUI option)
2. Adding the continue_on_error action at the beginning of the action queue
3. Enhancing the _handle_error method to always log errors but only raise exceptions if continue_on_error is False
4. Simplifying error handling in the on_run method

### What is the impact of this change?

This change allows Nuke renders to continue even when encountering errors in the graph, which is a significant usability improvement for artists. They no 
longer need to fix all potential errors in their Nuke scripts before submission.

The impact is positive for users who want to continue rendering despite non-critical errors, which is a common workflow requirement.

### How was this change tested?

The change was tested by:
1. Creating Nuke scripts with intentional errors (missing file read nodes)
2. Submitting these scripts to Deadline Cloud
3. Verifying that the render continues despite the errors
4. Checking that errors are properly logged but don't cause job failure

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

All tests passed successfully.

### Was this change documented?

Yes, the change is documented in the code with comments explaining the behavior of continue_on_error. We will also update the user documentation to reflect
this new behavior.

### Is this a breaking change?

No, this is not a breaking change. It enhances the functionality without breaking existing workflows. The default behavior is now more permissive (
continuing on errors), which aligns with user expectations from Deadline 10.
