### PR TITLE
fix: Add timeout for Nuke jobs on EnvEnter/Exit

### DIFF
--- a/src/deadline/nuke_submitter/default_nuke_job_template.yaml
+++ b/src/deadline/nuke_submitter/default_nuke_job_template.yaml
@@ -108,6 +108,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
         onExit:
           command: NukeAdaptor
           args:
@@ -117,6 +118,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Nuke adaptor's environment enter and exit actions did not have timeout values specified in the job template. This could lead to situations where if the environment enter or exit gets stuck (and the first layer of timeouts doesn't work), the worker agent would not enforce any timeout.

### What was the solution? (How)

Added timeout values of 600 seconds (10 minutes) to both the environment enter and exit actions in the Nuke job template. This provides enough time for the server and Nuke to start/stop with an additional buffer, similar to the approach used in other packages like Cinema 4D.

### What is the impact of this change?

This change improves the reliability of Nuke jobs by ensuring that environment enter and exit actions have proper timeout handling. If these actions get stuck, the worker agent will now enforce the timeout and prevent jobs from hanging indefinitely.

### How was this change tested?

The change was tested by running the formatting and linting checks, which passed successfully. The timeout values are consistent with the approach used in  other packages (e.g., Cinema 4D).

### Was this change documented?

No additional documentation was needed as this is an internal implementation detail that doesn't affect the user-facing API or behavior. The timeout values are set to reasonable defaults that don't require user configuration.

### Is this a breaking change?

No, this is not a breaking change. It adds timeout values where they were previously missing but doesn't change any existing functionality or interfaces.
