### PR TITLE
fix: Add default Linux host requirement for Nuke submitter

### DIFF
--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -12,6 +12,7 @@ import nuke
 from deadline.client.api import get_deadline_cloud_library_telemetry_client
 from deadline.client.job_bundle import deadline_yaml_dump
 from deadline.client.ui import gui_error_handler
+from deadline.client.ui.dataclasses import HostRequirements, OsRequirements
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
     SubmitJobToDeadlineDialog,
     JobBundlePurpose,
@@ -459,6 +460,13 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
         rez_packages = f"nuke-{nuke_version} deadline_cloud_for_nuke"
         conda_packages = f"nuke={nuke_version}.* nuke-openjd={adaptor_version}.*"
 
+        # Default to Linux host requirement as Nuke is only supported on Linux for Deadline Cloud service
+        # and is generally less expensive than Windows for all fleet types
+
+        # Create a HostRequirements object with Linux OS
+        os_requirements = OsRequirements(operating_systems=["linux"])
+        default_host_requirements = HostRequirements(os_requirements=os_requirements)
+
         g_submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,
             initial_job_settings=render_settings,
@@ -472,6 +480,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> "SubmitJobToDeadli
             parent=parent,
             f=f,
             show_host_requirements_tab=True,
+            host_requirements=default_host_requirements,
         )
     else:
         g_submitter_dialog.refresh(


### PR DESCRIPTION
This change adds a default Linux host requirement for Nuke job submissions to prevent Windows workers from picking up Nuke jobs, which would fail. Nuke is only supported on Linux for Deadline Cloud service managed fleets and is generally less expensive than Windows for all fleet types.

Issue: #190

### What was the problem/requirement? (What/Why)

Currently, there are no default host requirements for the Nuke submitter. This means that when submitted to a queue connected to both Windows and Linux fleets, either could be assigned to the job. Windows workers are not used for Nuke renders and fail after picking up the job.

### What was the solution? (How)

Added a default host requirement with Linux OS for the Nuke submitter by:
- Importing the necessary dataclasses (HostRequirements, OsRequirements)
- Creating a HostRequirements object with Linux OS requirement
- Passing this object to the SubmitJobToDeadlineDialog constructor

### What is the impact of this change?

Nuke jobs will now default to requiring Linux hosts, preventing Windows workers from picking up these jobs and failing. This improves the user experience by reducing failed jobs and aligns with the fact that Nuke is only supported on Linux for Deadline Cloud service managed fleets.

### How was this change tested?

Manually tested by submitting Nuke jobs and verifying that the Linux host requirement is correctly applied in the job submission dialog and in the resulting job bundle.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not applicable for this change as it doesn't affect the job bundle structure, only adds a default value for an existing field.

### Was this change documented?

The code includes comments explaining the rationale for the default Linux host requirement.

### Is this a breaking change?

No, this is not a breaking change. It adds a sensible default that can still be overridden by users if needed.


<img width="536" alt="Screenshot 2025-03-14 at 3 39 40 PM" src="https://github.com/user-attachments/assets/80bb2e4d-5532-402e-8d85-b9c81a371496" />


