### PR TITLE
fix: add continue on error option to submitter UI

### DIFF
--- a/src/deadline/nuke_submitter/data_classes.py
+++ b/src/deadline/nuke_submitter/data_classes.py
@@ -26,6 +26,7 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     write_node_selection: str = field(default="", metadata={"sticky": True})
     view_selection: str = field(default="", metadata={"sticky": True})
     is_proxy_mode: bool = field(default=False, metadata={"sticky": True})
+    continue_on_error: bool = field(default=False, metadata={"sticky": True})
 
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -273,6 +273,11 @@ def _get_parameter_values(
         {"name": "ProxyMode", "value": "true" if settings.is_proxy_mode else "false"}
     )
 
+    # Set the ContinueOnError parameter default
+    parameter_values.append(
+        {"name": "ContinueOnError", "value": "true" if settings.continue_on_error else "false"}
+    )
+
     # Set the OCIO config path value
     if nuke_ocio.is_OCIO_enabled():
         ocio_config_path = nuke_ocio.get_ocio_config_path()

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -65,7 +65,7 @@ class SceneSettingsWidget(QWidget):
         self.continue_on_error_check.setToolTip(
             "Allow Nuke to continue rendering when it encounters non-fatal errors in the graph"
         )
-        lyt.addWidget(self.continue_on_error_check, 3, 1)
+        lyt.addWidget(self.continue_on_error_check, 4, 0)
 
         self.timeout_checkbox = QCheckBox("Use timeouts", self)
         self.timeout_checkbox.setChecked(True)
@@ -73,17 +73,17 @@ class SceneSettingsWidget(QWidget):
         self.timeout_checkbox.setToolTip(
             "Set a maximum duration for actions from this job. See AWS Deadline Cloud documentation to learn more"
         )
-        lyt.addWidget(self.timeout_checkbox, 4, 0)
+        lyt.addWidget(self.timeout_checkbox, 5, 0)
         self.timeouts_subtext = QLabel("Set a maximum duration for actions from this job")
         self.timeouts_subtext.setStyleSheet("font-style: italic")
-        lyt.addWidget(self.timeouts_subtext, 4, 1, 1, -1)
+        lyt.addWidget(self.timeouts_subtext, 5, 1, 1, -1)
 
         self.timeouts_box = QGroupBox()
         timeouts_lyt = QGridLayout(self.timeouts_box)
-        lyt.addWidget(self.timeouts_box, 5, 0, 1, -1)
+        lyt.addWidget(self.timeouts_box, 6, 0, 1, -1)
 
         self.gizmos_checkbox = QCheckBox("Include gizmos in job bundle", self)
-        lyt.addWidget(self.gizmos_checkbox, 6, 0)
+        lyt.addWidget(self.gizmos_checkbox, 7, 0)
 
         def create_timeout_row(label, tooltip, row):
             qlabel = QLabel(label)
@@ -136,9 +136,9 @@ class SceneSettingsWidget(QWidget):
             self.include_adaptor_wheels = QCheckBox(
                 "Developer option: Include adaptor wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 7, 0, 1, 2)
+            lyt.addWidget(self.include_adaptor_wheels, 8, 0, 1, 2)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 7, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 9, 0)
 
     def indicate_if_valid(self, timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]):
         if (

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -61,6 +61,12 @@ class SceneSettingsWidget(QWidget):
         self.proxy_mode_check = QCheckBox("Use proxy mode", self)
         lyt.addWidget(self.proxy_mode_check, 3, 0)
 
+        self.continue_on_error_check = QCheckBox("Continue on error", self)
+        self.continue_on_error_check.setToolTip(
+            "Allow Nuke to continue rendering when it encounters non-fatal errors in the graph"
+        )
+        lyt.addWidget(self.continue_on_error_check, 3, 1)
+
         self.timeout_checkbox = QCheckBox("Use timeouts", self)
         self.timeout_checkbox.setChecked(True)
         self.timeout_checkbox.clicked.connect(self.activate_timeout_changed)
@@ -223,6 +229,7 @@ class SceneSettingsWidget(QWidget):
             self.views_box.setCurrentIndex(0)
 
         self.proxy_mode_check.setChecked(settings.is_proxy_mode)
+        self.continue_on_error_check.setChecked(settings.continue_on_error)
 
         self.timeout_checkbox.setChecked(settings.timeouts_enabled)
 
@@ -255,6 +262,7 @@ class SceneSettingsWidget(QWidget):
         settings.write_node_selection = self.write_node_box.currentData()
         settings.view_selection = self.views_box.currentData()
         settings.is_proxy_mode = self.proxy_mode_check.isChecked()
+        settings.continue_on_error = self.continue_on_error_check.isChecked()
 
         settings.timeouts_enabled = self.timeout_checkbox.isChecked()
         settings.on_run_timeout_seconds = self.on_run_timeout_seconds


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Nuke graphs can contain 'errors' that are not detrimental to the output of a graph. The current adaptor was always exiting on errors, requiring all errors  to be mitigated in the graph prior to submission - which is not how artists prefer to work. Deadline 10 has the ability to continue on errors, and we  needed to provide similar functionality in Deadline Cloud for Nuke.

### What was the solution? (How)

Added a "Continue on error" checkbox to the submitter UI that allows users to control whether Nuke should continue rendering when it encounters non-fatal errors in the graph. This implementation:
1. Added a continue_on_error field to the RenderSubmitterUISettings class
2. Added a checkbox to the SceneSettingsWidget UI with a helpful tooltip
3. Added code to pass the setting to the job template parameters

### What is the impact of this change?

Artists can now choose whether they want Nuke to continue rendering when it encounters non-fatal errors in the graph, providing a more flexible workflow similar to what was available in Deadline 10.

### How was this change tested?

The changes were tested by manually verifying that:
1. The checkbox appears in the UI
2. The setting is saved as part of the sticky settings
3. The value is correctly passed to the job template parameters


### Was this change documented?

Yes, the checkbox has a tooltip explaining its purpose: "Allow Nuke to continue rendering when it encounters non-fatal errors in the graph"

### Is this a breaking change?
No, this is not a breaking change. It adds a new option that defaults to false, maintaining the current behavior while providing additional functionality.


<img width="536" alt="image" src="https://github.com/user-attachments/assets/5599ec88-e7ce-4a2a-940f-0d437dce9aaa" />

