### PR TITLE
fix: maintain backward compatibility with NUKE_ADAPTOR_NUKE_EXECUTABLE

### DIFF
--- a/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
+++ b/src/deadline/nuke_adaptor/NukeAdaptor/adaptor.py
@@ -432,7 +432,8 @@ class NukeAdaptor(Adaptor):
             FileNotFoundError: If the nuke_client.py file could not be found.
             KeyError: If a configuration for the given platform and version does not exist.
         """
-        nuke_exe = os.environ.get("NUKE_EXECUTABLE", "nuke")
+        deprecated_env_or_nuke = os.environ.get("NUKE_ADAPTOR_NUKE_EXECUTABLE", "nuke")
+        nuke_exe = os.environ.get("NUKE_EXECUTABLE", deprecated_env_or_nuke)
         regexhandler = RegexHandler(self.regex_callbacks)
 
         # Add the Open Job Description namespace directory to PYTHONPATH, so that adaptor_runtime_client


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A recent change to the nuke executable environment variable made for a breaking change to be pushed.

### What was the solution? (How)

This PR maintains backward compatibility by falling back to the old `NUKE_ADAPTOR_NUKE_EXECUTABLE`

### What is the impact of this change?

Will make the previous breaking change backwards compatible.