### PR TITLE
Add support for Nuke 16

### DIFF
--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_nuke</name>
-    <description>Deadline Cloud for Nuke 14.0-15.0</description>
-    <detailedDescription>Nuke plugin for submitting jobs to AWS Deadline Cloud. Compatible with Nuke 14.0-15.0</detailedDescription>
+    <description>Deadline Cloud for Nuke 14.0-16.0</description>
+    <detailedDescription>Nuke plugin for submitting jobs to AWS Deadline Cloud. Compatible with Nuke 14.0-16.0</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -53,8 +53,8 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_nuke_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Nuke 14.0-15.0
-- Compatible with Nuke 14.0-15.0
+			<value>Deadline Cloud for Nuke 14.0-16.0
+- Compatible with Nuke 14.0-16.0
 - Install the integrated Nuke submitter files to the installation directory
 - Register the plug-in with Nuke by creating or updating the NUKE_PATH environment variable.</value>
 		</stringParameter>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ mypy_path = "src"
 module = [
   "nuke.*",
   "PySide2.*",
+  "PySide6.*",
   "PyOpenColorIO.*",
   "qtpy.*"
 ]

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -18,12 +18,29 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: 
 )
 from deadline.nuke_util import ocio as nuke_ocio
 from nuke import Node
-from PySide2.QtCore import Qt  # pylint: disable=import-error
-from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
-    QApplication,
-    QMainWindow,
-    QMessageBox,
-)
+
+# Handle different Qt imports for different Nuke versions
+try:
+    # For Nuke 16+
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication, QMainWindow, QMessageBox
+except ImportError:
+    try:
+        # For Nuke 13-15
+        from PySide2.QtCore import Qt  # pylint: disable=import-error
+        from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
+            QApplication,
+            QMainWindow,
+            QMessageBox,
+        )
+    except ImportError:
+        # Fallback for older versions
+        from PySide.QtCore import Qt  # pylint: disable=import-error
+        from PySide.QtGui import (
+            QApplication,
+            QMainWindow,
+            QMessageBox,
+        )  # pylint: disable=import-error
 
 from ._version import version, version_tuple as adaptor_version_tuple
 from .assets import (

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -25,22 +25,13 @@ try:
     from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QMainWindow, QMessageBox
 except ImportError:
-    try:
-        # For Nuke 13-15
-        from PySide2.QtCore import Qt  # pylint: disable=import-error
-        from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
-            QApplication,
-            QMainWindow,
-            QMessageBox,
-        )
-    except ImportError:
-        # Fallback for older versions
-        from PySide.QtCore import Qt  # pylint: disable=import-error
-        from PySide.QtGui import (
-            QApplication,
-            QMainWindow,
-            QMessageBox,
-        )  # pylint: disable=import-error
+    # For Nuke 13-15
+    from PySide2.QtCore import Qt  # pylint: disable=import-error
+    from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
+        QApplication,
+        QMainWindow,
+        QMessageBox,
+    )
 
 from ._version import version, version_tuple as adaptor_version_tuple
 from .assets import (

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -31,11 +31,30 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 import nuke
-from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
-    QApplication,
-    QFileDialog,
-    QMainWindow,
-)
+
+# Handle different Qt imports for different Nuke versions
+try:
+    # For Nuke 16+
+    from PySide6.QtWidgets import (
+        QApplication,
+        QFileDialog,
+        QMainWindow,
+    )
+except ImportError:
+    try:
+        # For Nuke 13-15
+        from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
+            QApplication,
+            QFileDialog,
+            QMainWindow,
+        )
+    except ImportError:
+        # Fallback for older versions
+        from PySide.QtGui import (  # pylint: disable=import-error; type: ignore
+            QApplication,
+            QFileDialog,
+            QMainWindow,
+        )
 
 from deadline.client.ui import gui_error_handler
 from deadline.client.ui.dialogs import submit_job_to_deadline_dialog

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -41,20 +41,12 @@ try:
         QMainWindow,
     )
 except ImportError:
-    try:
-        # For Nuke 13-15
-        from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
-            QApplication,
-            QFileDialog,
-            QMainWindow,
-        )
-    except ImportError:
-        # Fallback for older versions
-        from PySide.QtGui import (  # pylint: disable=import-error; type: ignore
-            QApplication,
-            QFileDialog,
-            QMainWindow,
-        )
+    # For Nuke 13-15
+    from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
+        QApplication,
+        QFileDialog,
+        QMainWindow,
+    )
 
 from deadline.client.ui import gui_error_handler
 from deadline.client.ui.dialogs import submit_job_to_deadline_dialog

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -24,38 +24,21 @@ try:
         QSpinBox,
     )
 except ImportError:
-    try:
-        # For Nuke 13-15
-        from PySide2.QtCore import Qt  # type: ignore
-        from PySide2.QtWidgets import (  # type: ignore
-            QCheckBox,
-            QComboBox,
-            QGridLayout,
-            QGroupBox,
-            QLabel,
-            QLineEdit,
-            QMessageBox,
-            QSizePolicy,
-            QSpacerItem,
-            QWidget,
-            QSpinBox,
-        )
-    except ImportError:
-        # Fallback for older versions
-        from PySide.QtCore import Qt  # type: ignore
-        from PySide.QtGui import (  # type: ignore
-            QCheckBox,
-            QComboBox,
-            QGridLayout,
-            QGroupBox,
-            QLabel,
-            QLineEdit,
-            QMessageBox,
-            QSizePolicy,
-            QSpacerItem,
-            QWidget,
-            QSpinBox,
-        )
+    # For Nuke 13-15
+    from PySide2.QtCore import Qt  # type: ignore
+    from PySide2.QtWidgets import (  # type: ignore
+        QCheckBox,
+        QComboBox,
+        QGridLayout,
+        QGroupBox,
+        QLabel,
+        QLineEdit,
+        QMessageBox,
+        QSizePolicy,
+        QSpacerItem,
+        QWidget,
+        QSpinBox,
+    )
 
 from ...assets import find_all_write_nodes
 from ...data_classes import RenderSubmitterUISettings

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -5,20 +5,57 @@ UI widgets for the Scene Settings tab.
 """
 import os
 import nuke
-from PySide2.QtCore import Qt  # type: ignore
-from PySide2.QtWidgets import (  # type: ignore
-    QCheckBox,
-    QComboBox,
-    QGridLayout,
-    QGroupBox,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QSizePolicy,
-    QSpacerItem,
-    QWidget,
-    QSpinBox,
-)
+
+# Handle different Qt imports for different Nuke versions
+try:
+    # For Nuke 16+
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import (
+        QCheckBox,
+        QComboBox,
+        QGridLayout,
+        QGroupBox,
+        QLabel,
+        QLineEdit,
+        QMessageBox,
+        QSizePolicy,
+        QSpacerItem,
+        QWidget,
+        QSpinBox,
+    )
+except ImportError:
+    try:
+        # For Nuke 13-15
+        from PySide2.QtCore import Qt  # type: ignore
+        from PySide2.QtWidgets import (  # type: ignore
+            QCheckBox,
+            QComboBox,
+            QGridLayout,
+            QGroupBox,
+            QLabel,
+            QLineEdit,
+            QMessageBox,
+            QSizePolicy,
+            QSpacerItem,
+            QWidget,
+            QSpinBox,
+        )
+    except ImportError:
+        # Fallback for older versions
+        from PySide.QtCore import Qt  # type: ignore
+        from PySide.QtGui import (  # type: ignore
+            QCheckBox,
+            QComboBox,
+            QGridLayout,
+            QGroupBox,
+            QLabel,
+            QLineEdit,
+            QMessageBox,
+            QSizePolicy,
+            QSpacerItem,
+            QWidget,
+            QSpinBox,
+        )
 
 from ...assets import find_all_write_nodes
 from ...data_classes import RenderSubmitterUISettings


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The only change we need to perform to be compatible with Nuke 16 would be using PySide 6 instead of version 2 that we use for Nuke 14 and Nuke 15.

### What was the solution? (How)

Added logic to default to PySide6 library only when Nuke version is 16, and falls back to our default versions for 14-15 versions.

### What is the impact of this change?

Add support for Nuke 16

### How was this change tested?

Tested it by running the submitter for Nuke 16.

### Was this change documented?

Yes, changed the corresponding values in XML file to display Nuke 16 support

### Is this a breaking change?

Should not be since we fall back to default versions for every other non Nuke 16 version.

