### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -8,6 +8,10 @@ on:
       branch:
         required: false
         type: string
+      tag:
+        required: false
+        type: string
+
 
 jobs:
   Test:
@@ -20,3 +24,4 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      ref: ${{inputs.tag}}

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -17,15 +17,8 @@ concurrency:
   group: release
 
 jobs:
-  UnitTests:
-    name: Unit Tests
-    uses: ./.github/workflows/code_quality.yml
-    with:
-      branch: mainline
-
   Bump:
     name: Version Bump
-    needs: UnitTests
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     secrets: inherit
     with:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,5 +1,5 @@
 name: "Release: Publish"
-run-name: "Release: ${{ github.event.head_commit.message }}"
+run-name: "Release: ${{ github.event.head_commit.message || inputs.tag }}"
 
 on:
   push:
@@ -7,20 +7,83 @@ on:
       - mainline
     paths:
       - CHANGELOG.md
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: Specify a tag to re-run a release.
 
 concurrency:
   group: release
 
+permissions:
+  contents: read
+
 jobs:
-  Publish:
-    name: Publish Release
+  TagRelease:
+    uses: aws-deadline/.github/.github/workflows/reusable_tag_release.yml@mainline
+    secrets: inherit
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+
+  UnitTests:
+    needs: [TagRelease]
+    name: Unit and Integration Tests
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
+  PreRelease:
+      needs: [TagRelease, UnitTests]
+      uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
+      permissions:
+        id-token: write
+        contents: write
+      secrets: inherit
+      with:
+          tag: ${{ needs.TagRelease.outputs.tag }}
+
+  BuildAndStageInstallers:
+    needs: [TagRelease, PreRelease]
+    uses: aws-deadline/.github/.github/workflows/reusable_build_and_stage_installers.yml@mainline
+    secrets: inherit
     permissions:
       id-token: write
-      contents: write
-    uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
+      contents: read
     with:
-      installer_oses: "['Linux', 'Windows', 'MacOS']"
-    secrets: inherit
+      project_name: ${{ github.event.repository.name }}
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      oses: "['Linux', 'Windows', 'MacOS']"
+
+  IsCondaReady:
+    needs: BuildAndStageInstallers
+    runs-on: ubuntu-latest
+    environment: release
+    name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
+    steps:
+      - run: |
+         :
+
+  Release:
+      needs: [TagRelease, IsCondaReady]
+      uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
+      secrets: inherit
+      permissions:
+        id-token: write
+        contents: write
+      with:
+          tag: ${{ needs.TagRelease.outputs.tag }}
+  
+  Publish:
+      needs: [TagRelease, Release]
+      uses: aws-deadline/.github/.github/workflows/reusable_publish_python.yml@mainline
+      permissions:
+        id-token: write
+      secrets: inherit
+      with:
+          tag: ${{ needs.TagRelease.outputs.tag }}
+          
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
   PublishToPyPI:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There are changes to the [re-usable workflows](https://github.com/aws-deadline/.github/pull/39).

### What was the solution? (How)
1. Updated `code_quality.yml` to accept tags as inputs, and moved the Unit Tests from the `release_bump.yml` to the `release_publish.yml` workflow.
2. The `release_publish.yml` workflow automatically starts after a ChangeLog PR has been merged. We used the new `reusable_tag_release.yml` workflow to create a new tag. We validate the tag has not been released and the author of the associated commit. The workflow can be re-run, specifying an existing tag.
3. Building and Staging the installer has been moved to its own workflow.

### What is the impact of this change?
More modular workflows, added automation.

### How was this change tested?

Workflows were tested using Blender Repository:https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/15218951005


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*