### PR TITLE
feat: Support macOS installer for Nuke by fixing user installation path

### DIFF
--- a/installer/DeadlineCloudForNuke.xml
+++ b/installer/DeadlineCloudForNuke.xml
@@ -171,7 +171,19 @@
                         <compareText logic="equals" text="${installscope}" value="user"/>
                     </conditionRuleList>
                     <actionList>
-                        <setInstallerVariable name="installdirprefix" value="${user_home_directory}"/>
+                        <if>
+                            <conditionRuleList>
+                                <platformTest type="osx"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <!-- macOS: Install to user's .nuke directory -->
+                                <setInstallerVariable name="installdir" value="${user_home_directory}/.nuke"/>
+                            </actionList>
+                            <elseActionList>
+                                <!-- Windows/Linux: Use standard user path -->
+                                <setInstallerVariable name="installdirprefix" value="${user_home_directory}"/>
+                            </elseActionList>
+                        </if>
                     </actionList>
                     <elseActionList>
                         <setInstallerVariable name="installdirprefix" value="${platform_install_prefix}"/>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our standard DCC installation path was not working for Nuke Submitters on Mac. We had to use one of the designated paths by Nuke documentation for custom plugins: https://learn.foundry.com/nuke/developers/160/pythondevguide/installing_plugins.html. Since system installation for mac is disabled on the combined installer level, this PR only handles user installation. 

### What was the solution? (How)

For mac install the submitter to `~/user/.nuke` path

### What is the impact of this change?

Correctly loads Deadline Cloud submitter on mac for Nuke DCC

### How was this change tested?

Manual testing. Rebuild the installer and made sure it installs in the correct path. Then used the submitter to submit various nuke jobs and verified that they would complete successfully. Can confirm that the Deadline submitter appears normally now without having to open nuke from the terminal.

<img width="549" alt="image" src="https://github.com/user-attachments/assets/aa126a80-a800-4535-842f-32e4e541edc6" />


### Was this change documented?

No, changes to our documentation will be performed in subsequent PRs.

### Is this a breaking change?

No.