### PR TITLE
feat: Add Custom Settings and Write Node E2E tests

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -39,9 +39,13 @@ test = "pytest --no-cov {args:test/*/integ}"
 [envs.e2e.scripts]
 test = "pytest --no-cov {args:test/*/e2e}"
 
+[envs.squish]
+env-vars = { PYTHONPATH = "{env:PYTHONPATH:}:test/squish/suite_nuke_submitter" }
+
 [envs.squish.scripts]
-deps = "pip install numpy"
-test = "pytest run_squish_test.py::test_basic_workflow"
+deps = "pip install numpy pytest pytest-xdist"
+test = "pytest --override-ini addopts= {args:test/squish/suite_nuke_submitter/run_squish_test.py} -v -n 0"
+
 
 [envs.release]
 detached = true

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -55,8 +55,18 @@ The following Deadline Cloud resources are needed in order to run `tst_verify_se
 ### Basic Workflow Test
 The `basic_workflow` test provides comprehensive end-to-end validation of the basic Nuke submitter workflow. This test consists of two main parts: First, the basic_workflow_gui Squish test automates the UI interaction by launching Nuke, opening a pre-configured script file with a write node, configuring AWS profile and resources, submitting a job to Deadline Cloud, and closing Nuke. Second, the test performs backend validation by verifying the job was successfully submitted to the correct queue, monitoring job completion, downloading the rendered output files, comparing them against reference images to ensure visual accuracy, and handling the cleanup of resource.
 
+### Custom Settings Submission Test
+The `custom_settings` test validates the customization capabilities of the Nuke submitter interface for Deadline Cloud jobs. This test automates the UI interaction by launching Nuke, opening a pre-configured script file, and accessing the submitter interface to configure various job parameters. It sets custom values for job metadata (name and description), performance settings (priority level 75, maximum 3 retries per task, maximum 10 failed tasks), and error handling options (continue on error). After configuring these parameters, the test submits the job and verifies that all custom settings are correctly applied in the submitted job configuration. This ensures that the submitter interface reliably handles non-default parameter configurations and maintains setting integrity throughout the submission process.
+
+### Write Node Selection Tests
+The `write_node_selection` test provides comprehensive validation of the write node selection functionality in the Nuke submitter interface. This test executes two distinct submission scenarios: first submitting a job that targets a single write node ("Write1"), and then submitting another job that processes all write nodes in the script. For each scenario, the test automates the UI interaction by launching Nuke, configuring the AWS profile, selecting the appropriate write node option, and submitting the job. After submission, the test performs backend validation by verifying the jobs were created with correct write node parameters, downloading the rendered outputs, comparing them against reference images with RGB difference tolerance checks, and cleaning up the output files. This ensures that the submitter correctly handles both individual and batch write node selections, maintaining proper job configuration and output generation in both scenarios.
 
 ## Running Tests
+To install necessary dependencies to run the tests, run:
+```sh
+hatch run squish:deps
+```
+Then, to run the tests:
 ```sh
 hatch run squish:test
 ```
@@ -67,7 +77,7 @@ A successful test will be indicated by pytest's green message saying that the te
 
 An unsuccessful test will show:
 - FAIL or FATAL messages in the Squish output
-- Error messages like "Job ID from Squish execution does not match the latest job ID"
+- Error messages like "Failed to download job output"
 - Assertion failures for squish commands, job submission, download, or job verification steps
 
 ### Image Verification Failures

--- a/test/squish/suite_nuke_submitter/basic_workflow_gui/test.py
+++ b/test/squish/suite_nuke_submitter/basic_workflow_gui/test.py
@@ -2,8 +2,6 @@
 # mypy: disable-error-code="attr-defined"
 import names
 import squish_helpers
-import os
-import test
 import squish
 
 
@@ -23,27 +21,10 @@ def main():
         squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
         squish.WindowState.Maximize,
     )
-
-    # Open the nuke script file that is being tested
-    squish.activateItem(squish.waitForObjectItem(names.o_QMenuBar, "File"))
-    squish.activateItem(squish.waitForObjectItem(names.file_Foundry_UI_Menu, "Open Comp..."))
-
-    file_path_edit = squish.waitForObject(names.script_to_open_FilePathEdit)
-    file_path_edit.selectAll()
-    nuke_asset_path = os.environ.get("NUKE_ASSET_ROOT")
-    if not nuke_asset_path:
-        test.fatal("NUKE_ASSET_ROOT environment variable not set")
-        return
-
-    NUKE_TEST_SCRIPT_PATH = "nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/scripts/nukeSubmitter_v02_nuke_default_one_write_node.nk"
-    script_path = os.path.join(nuke_asset_path, NUKE_TEST_SCRIPT_PATH)
-
-    squish.setFocus(file_path_edit)
-    squish.type(file_path_edit, script_path)
-
-    # Opens the nuke script file
-    squish.clickButton(squish.waitForObject(names.script_to_open_Open_QPushButton))
-
+    squish_helpers.open_nuke_script(
+        "nuke_submitter_v02_nuke_default_test_samples",
+        "nukeSubmitter_v02_nuke_default_one_write_node.nk",
+    )
     squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
     squish_helpers.open_nuke_submitter_gui()
     squish_helpers.configure_storage_profile()

--- a/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
+++ b/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
@@ -10,7 +10,7 @@ GUI test for submitting a Nuke job with custom settings to AWS Deadline Cloud.
 This test verifies that users can successfully modify and submit jobs with custom settings:
 This test configures custom job settings like the job name, job description, priority, max retries
 per task, max failed tasks, and continue on error. This test submits a job with these custom settings
-and ensures that the test ensures that all custom settings are properly applied to the submitted job
+and ensures that all custom settings are properly applied to the submitted job
 and that the job submission process works correctly with modified parameters.
 """
 

--- a/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
+++ b/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # mypy: disable-error-code="attr-defined"
 import names
 import squish_helpers

--- a/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
+++ b/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# mypy: disable-error-code="attr-defined"
+import names
+import squish_helpers
+import squish
+
+"""
+GUI test for submitting a Nuke job with custom settings to AWS Deadline Cloud.
+
+This test verifies that users can successfully modify and submit jobs with custom settings:
+This test configures custom job settings like the job name, job description, priority, max retries
+per task, max failed tasks, and continue on error. This test submits a job with these custom settings
+and ensures that the test ensures that all custom settings are properly applied to the submitted job
+and that the job submission process works correctly with modified parameters.
+"""
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+    squish_helpers.open_nuke_script(
+        "nuke_submitter_v02_nuke_default_test_samples",
+        "nukeSubmitter_v02_nuke_default_one_write_node.nk",
+    )
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.set_job_name("Custom Setting Submission")
+    squish_helpers.set_job_description("This test verifies submission with modified settings")
+
+    squish_helpers.set_priority(75)
+    squish_helpers.set_max_retries(3)
+    squish_helpers.set_max_failed_tasks(10)
+
+    squish_helpers.configure_aws_profile()
+    squish_helpers.set_continue_on_error()
+    squish_helpers.submit_job()
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/invalid_conda_gui/test.py
+++ b/test/squish/suite_nuke_submitter/invalid_conda_gui/test.py
@@ -1,0 +1,36 @@
+import names
+import squish_helpers
+import squish
+
+"""
+GUI test for validating Conda package validation in AWS Deadline Cloud submitter.
+
+This test verifies the submitter's error handling for invalid Conda configurations by 
+attempting to use non-existent packages and channels.
+"""
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+    squish_helpers.open_nuke_script(
+        "nuke_submitter_v02_nuke_default_test_samples",
+        "nukeSubmitter_v02_nuke_default_one_write_node.nk",
+    )
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+    squish_helpers.open_nuke_submitter_gui()
+    conda_package_edit = squish.waitForObject(
+        names.queue_Environment_Conda_Conda_Packages_QLineEdit
+    )
+    conda_package_edit.selectAll()
+    squish.type(conda_package_edit, "invalid-package=1.0")
+    conda_channel_edit = squish.waitForObject(
+        names.queue_Environment_Conda_Conda_Channels_QLineEdit
+    )
+    conda_channel_edit.selectAll()
+    squish.type(conda_channel_edit, "invalid-channel")
+    squish_helpers.check_missing_conda_packages()
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/invalid_conda_gui/test.py
+++ b/test/squish/suite_nuke_submitter/invalid_conda_gui/test.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import names
 import squish_helpers
 import squish

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from shared.scripts import api_helpers, verification_helpers, cleanup_helpers
 import pathlib
+import pytest
 
 
 def run_squish_command(testcase_name, local=True):
@@ -101,6 +102,32 @@ def test_valid_environment_variables():
         print(f"✓ {var_name} is valid: {value}")
 
 
+@pytest.fixture
+def cleanup_render_outputs():
+    """Fixture that manages cleanup of rendered image outputs with manual trigger points"""
+    cleanup_queue = []
+
+    def register_cleanup(output_dir: str, base_name: str):
+        """Register a cleanup task"""
+        cleanup_queue.append((output_dir, base_name))
+
+    def execute_cleanup():
+        """Execute all registered cleanups"""
+        while cleanup_queue:
+            output_dir, base_name = cleanup_queue.pop(0)
+            try:
+                success, message = cleanup_helpers.cleanup_output_images(output_dir, base_name)
+                if not success:
+                    raise RuntimeError(f"Cleanup failed: {message}")
+            except Exception as e:
+                raise RuntimeError(f"Cleanup error: {str(e)}")
+
+    yield register_cleanup, execute_cleanup
+
+    # Final cleanup of any remaining items
+    execute_cleanup()
+
+
 def test_invalid_conda_env():
     check_platform()
     success = run_squish_command("invalid_conda_gui")
@@ -114,8 +141,21 @@ def check_platform():
     ), "Deadline Nuke Squish Tests are only supported on macOS currently."
 
 
-def test_basic_workflow():
+def test_basic_workflow(cleanup_render_outputs):
     check_platform()
+
+    NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
+    TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
+    )
+    EXPECTED_DIR = f"{TEST_SAMPLES_DIR}/images/expected"
+    OUTPUT_DIR = f"{TEST_SAMPLES_DIR}/images/output"
+    FRAME_RANGE = (101, 120)
+    RGB_TOLERANCE = 0.1
+
+    register_cleanup, _ = cleanup_render_outputs
+    register_cleanup(OUTPUT_DIR, "nukeTest_output_v01")
+
     success, job_id = run_squish_command("basic_workflow_gui")
     # Exit early if the Squish test failed
     if not success:
@@ -144,27 +184,30 @@ def test_basic_workflow():
 
     # Verify the rendered image sequence matches expected output
     verification_helpers.verify_image_sequence_rgb_matches(
-        expected_dir=os.environ.get("NUKE_ASSET_ROOT", "")
-        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/expected",
-        output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
-        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
-        base_name="nukeTest_output_OCIO_v01",
-        start_frame=101,
-        end_frame=120,
-        rgb_diff_tolerance=0.1,
+        expected_dir=EXPECTED_DIR,
+        output_dir=OUTPUT_DIR,
+        base_name="nukeTest_output_v01",
+        start_frame=FRAME_RANGE[0],
+        end_frame=FRAME_RANGE[1],
+        rgb_diff_tolerance=RGB_TOLERANCE,
     )
 
-    cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
-        output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
-        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
-        base_name="nukeTest_output_OCIO_v01",
-    )
 
-    assert cleanup_success, f"Failed to clean up output images: {cleanup_message}"
-
-
-def test_custom_settings_workflow():
+def test_custom_settings_workflow(cleanup_render_outputs):
     check_platform()
+
+    NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
+    TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
+    )
+    EXPECTED_DIR = f"{TEST_SAMPLES_DIR}/images/expected"
+    OUTPUT_DIR = f"{TEST_SAMPLES_DIR}/images/output"
+    FRAME_RANGE = (101, 120)
+    RGB_TOLERANCE = 0.1
+
+    register_cleanup, _ = cleanup_render_outputs
+    register_cleanup(OUTPUT_DIR, "nukeTest_output_v01")
+
     success, job_id = run_squish_command("custom_settings_gui")
     # Exit early if the Squish test failed
     if not success:
@@ -185,40 +228,30 @@ def test_custom_settings_workflow():
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
 
-    latest_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
-    assert latest_job["name"] == "Custom Setting Submission"
-    assert latest_job["description"] == "This test verifies submission with modified settings"
-    assert latest_job["priority"] == 75
-    assert latest_job["maxFailedTasksCount"] == 10
-    assert latest_job["maxRetriesPerTask"] == 3
-    assert latest_job["parameters"]["ContinueOnError"]["string"] == "true"
+    custom_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+    assert custom_job["name"] == "Custom Setting Submission"
+    assert custom_job["description"] == "This test verifies submission with modified settings"
+    assert custom_job["priority"] == 75
+    assert custom_job["maxFailedTasksCount"] == 10
+    assert custom_job["maxRetriesPerTask"] == 3
+    assert custom_job["parameters"]["ContinueOnError"]["string"] == "true"
 
     # Download the job's output files
     api_helpers.download_output(farm_id, queue_id, job_id[0])
 
     # Verify the rendered image sequence matches expected output
     verification_helpers.verify_image_sequence_rgb_matches(
-        expected_dir=os.environ.get("NUKE_ASSET_ROOT", "")
-        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/expected",
-        output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
-        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
-        base_name="nukeTest_output_OCIO_v01",
-        start_frame=101,
-        end_frame=120,
-        rgb_diff_tolerance=0.1,
+        expected_dir=EXPECTED_DIR,
+        output_dir=OUTPUT_DIR,
+        base_name="nukeTest_output_v01",
+        start_frame=FRAME_RANGE[0],
+        end_frame=FRAME_RANGE[1],
+        rgb_diff_tolerance=RGB_TOLERANCE,
     )
-
-    cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
-        output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
-        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
-        base_name="nukeTest_output_OCIO_v01",
-    )
-
-    assert cleanup_success, f"Failed to clean up output images: {cleanup_message}"
 
 
 # Write Node Selection Test
-def test_write_node_selection():
+def test_write_node_selection(cleanup_render_outputs):
     check_platform()
 
     NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
@@ -230,6 +263,7 @@ def test_write_node_selection():
     FRAME_RANGE = (101, 120)
     RGB_TOLERANCE = 0.1
 
+    register_cleanup, execute_cleanup = cleanup_render_outputs
     success, job_ids = run_squish_command("write_node_gui")
 
     # Verify test execution was successful
@@ -256,6 +290,8 @@ def test_write_node_selection():
     download_success = api_helpers.download_output(farm_id, queue_id, single_write_node_id)
     assert download_success, "Failed to download single write node job output"
 
+    register_cleanup(OUTPUT_DIR, "nukeTest_output_v01")
+
     # Verify single write node output
     verification_helpers.verify_image_sequence_rgb_matches(
         expected_dir=EXPECTED_DIR,
@@ -266,11 +302,7 @@ def test_write_node_selection():
         rgb_diff_tolerance=RGB_TOLERANCE,
     )
 
-    # Clean up single write node output
-    cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
-        output_dir=OUTPUT_DIR, base_name="nukeTest_output_v01"
-    )
-    assert cleanup_success, f"Failed to clean up single write node output: {cleanup_message}"
+    execute_cleanup()
 
     # Process multiple write nodes job (most recent job)
     multiple_write_nodes_id = job_ids[1]
@@ -285,6 +317,7 @@ def test_write_node_selection():
 
     # Verify multiple write nodes outputs (two output files)
     for base_name in ["nukeTest_color_correct2", "nukeTest_output_v01"]:
+        register_cleanup(OUTPUT_DIR, base_name)
         verification_helpers.verify_image_sequence_rgb_matches(
             expected_dir=EXPECTED_DIR,
             output_dir=OUTPUT_DIR,
@@ -293,9 +326,3 @@ def test_write_node_selection():
             end_frame=FRAME_RANGE[1],
             rgb_diff_tolerance=RGB_TOLERANCE,
         )
-
-        # Clean up each output
-        cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
-            output_dir=OUTPUT_DIR, base_name=base_name
-        )
-        assert cleanup_success, f"Failed to clean up {base_name} output: {cleanup_message}"

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 from shared.scripts import api_helpers, verification_helpers, cleanup_helpers
+import pathlib
 
 
 def run_squish_command(testcase_name, local=True):
@@ -18,11 +19,8 @@ def run_squish_command(testcase_name, local=True):
             - success (bool): True if command executed successfully (return code 0)
             - job_id (str or None): Extracted job ID from output if found, None otherwise
     """
-    deadline_nuke_path = os.environ.get("DEADLINE_NUKE_PATH")
-    if not deadline_nuke_path:
-        print("DEADLINE_NUKE_PATH environment variable not set")
-        return False, None
 
+    deadline_nuke_path = os.environ.get("DEADLINE_NUKE_PATH")
     squish_runner = "/Applications/Squish\\ for\\ Qt\\ 8.1.0/bin/squishrunner"
     testsuite_path = f"{deadline_nuke_path}/test/squish/suite_nuke_submitter"
     local_flag = "--local" if local else ""
@@ -51,17 +49,17 @@ def run_squish_command(testcase_name, local=True):
 
         if result.returncode != 0:
             print(f"Squish command failed with return code {result.returncode}")
-            return False, None
+            return False, []
 
         # Check for Squish test failures in the output
         has_squish_failure = False
         failure_message = ""
         lines = result.stdout.split("\n")
-
+        job_ids = []
         for line in lines:
             # Look for job ID
             if "Found job ID:" in line:
-                job_id = line.split("Found job ID:")[1].strip()
+                job_ids.append(line.split("Found job ID:")[1].strip())
 
             # Check for FAIL or FATAL in the output
             if "\tFAIL\t" in line or "FAIL " in line:
@@ -73,24 +71,59 @@ def run_squish_command(testcase_name, local=True):
 
         if has_squish_failure:
             print(f"Squish test failed: {failure_message}")
-            return False, None
+            return False, []
 
         # Parse output to find job ID from test.log messages
-        return True, job_id
+        return True, job_ids
     except Exception as e:
         print(f"Error running squish command: {e}")
         return False
 
 
-def test_basic_workflow():
+def test_valid_environment_variables():
+    # Test that required environment variables are set and valid.
+    env_vars = {
+        "AWS_PROFILE": {"check_path": False},
+        "DEADLINE_NUKE_PATH": {"check_path": True},
+        "NUKE_ASSET_ROOT": {"check_path": True},
+    }
+
+    for var_name, config in env_vars.items():
+        # Check if variable is set
+        value = os.environ.get(var_name)
+        assert value, f"{var_name} environment variable is not set"
+
+        # Check if path exists
+        if config["check_path"]:
+            path = pathlib.Path(value)
+            assert path.exists(), f"{var_name} does not exist: {value}"
+
+        print(f"✓ {var_name} is valid: {value}")
+
+
+def test_invalid_conda_env():
+    check_platform()
+    success = run_squish_command("invalid_conda_gui")
+    if success is False:
+        assert success, "Squish command failed"
+
+
+def check_platform():
     assert (
         sys.platform == "darwin"
     ), "Deadline Nuke Squish Tests are only supported on macOS currently."
 
+
+def test_basic_workflow():
+    check_platform()
     success, job_id = run_squish_command("basic_workflow_gui")
     # Exit early if the Squish test failed
-    if success is False:
+    if not success:
         assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    print("Basic Workflow Job ID: " + job_id[0])
 
     # Get the farm ID from configuration
     farm_id = api_helpers.get_farm_id_by_name()
@@ -100,26 +133,13 @@ def test_basic_workflow():
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
     assert queue_id is not None, "Queue ID not found"
 
-    # Get the most recent job ID from the queue
-    latest_job_id = api_helpers.get_latest_job_id(farm_id, queue_id)
-
-    # Verify the job ID from Squish matches the latest job in the queue
-    if job_id == latest_job_id:
-        print("Job ID from Squish execution matches the latest job ID.")
-    else:
-        print("Error: Job ID from Squish execution does not match the latest job ID.")
-        return
-
-    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, latest_job_id)
-    latest_job = api_helpers.get_latest_job(farm_id, queue_id, latest_job_id)
-
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
 
-    print("\n=== Latest Job Information ===")
-    print(f"Job Info: {latest_job}")
+    api_helpers.get_job(farm_id, queue_id, job_id[0])
 
     # Download the job's output files and assert success
-    download_success = api_helpers.download_output(farm_id, queue_id, latest_job_id)
+    download_success = api_helpers.download_output(farm_id, queue_id, job_id[0])
     assert download_success, "Failed to download job output files"
 
     # Verify the rendered image sequence matches expected output
@@ -128,6 +148,7 @@ def test_basic_workflow():
         + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/expected",
         output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
         + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
+        base_name="nukeTest_output_OCIO_v01",
         start_frame=101,
         end_frame=120,
         rgb_diff_tolerance=0.1,
@@ -136,6 +157,145 @@ def test_basic_workflow():
     cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
         output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
         + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
+        base_name="nukeTest_output_OCIO_v01",
     )
 
     assert cleanup_success, f"Failed to clean up output images: {cleanup_message}"
+
+
+def test_custom_settings_workflow():
+    check_platform()
+    success, job_id = run_squish_command("custom_settings_gui")
+    # Exit early if the Squish test failed
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    print("Custom Settings Workflow Job ID: " + job_id[0])
+
+    # Get the farm ID from configuration
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    # Get the queue ID from configuration
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
+    assert job_in_queue
+
+    latest_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+    assert latest_job["name"] == "Custom Setting Submission"
+    assert latest_job["description"] == "This test verifies submission with modified settings"
+    assert latest_job["priority"] == 75
+    assert latest_job["maxFailedTasksCount"] == 10
+    assert latest_job["maxRetriesPerTask"] == 3
+    assert latest_job["parameters"]["ContinueOnError"]["string"] == "true"
+
+    # Download the job's output files
+    api_helpers.download_output(farm_id, queue_id, job_id[0])
+
+    # Verify the rendered image sequence matches expected output
+    verification_helpers.verify_image_sequence_rgb_matches(
+        expected_dir=os.environ.get("NUKE_ASSET_ROOT", "")
+        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/expected",
+        output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
+        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
+        base_name="nukeTest_output_OCIO_v01",
+        start_frame=101,
+        end_frame=120,
+        rgb_diff_tolerance=0.1,
+    )
+
+    cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
+        output_dir=os.environ.get("NUKE_ASSET_ROOT", "")
+        + "/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output",
+        base_name="nukeTest_output_OCIO_v01",
+    )
+
+    assert cleanup_success, f"Failed to clean up output images: {cleanup_message}"
+
+
+# Write Node Selection Test
+def test_write_node_selection():
+    check_platform()
+
+    NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
+    TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_modified_test_samples"
+    )
+    EXPECTED_DIR = f"{TEST_SAMPLES_DIR}/images/expected"
+    OUTPUT_DIR = f"{TEST_SAMPLES_DIR}/images/output"
+    FRAME_RANGE = (101, 120)
+    RGB_TOLERANCE = 0.1
+
+    success, job_ids = run_squish_command("write_node_gui")
+
+    # Verify test execution was successful
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_ids) != 2:
+        assert len(job_ids) == 2, f"Expected exactly one job ID, but got {len(job_ids)}"
+
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    # Process single write node job (second most recent job)
+    single_write_node_id = job_ids[0]
+    single_write_job = api_helpers.get_job(farm_id, queue_id, single_write_node_id)
+
+    print("\n=== Job Information ===")
+    print(single_write_job)
+
+    assert single_write_job is not None, "Failed to get single write node job"
+    assert single_write_job["parameters"]["WriteNode"]["string"] == "Write1"
+
+    download_success = api_helpers.download_output(farm_id, queue_id, single_write_node_id)
+    assert download_success, "Failed to download single write node job output"
+
+    # Verify single write node output
+    verification_helpers.verify_image_sequence_rgb_matches(
+        expected_dir=EXPECTED_DIR,
+        output_dir=OUTPUT_DIR,
+        base_name="nukeTest_output_v01",
+        start_frame=FRAME_RANGE[0],
+        end_frame=FRAME_RANGE[1],
+        rgb_diff_tolerance=RGB_TOLERANCE,
+    )
+
+    # Clean up single write node output
+    cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
+        output_dir=OUTPUT_DIR, base_name="nukeTest_output_v01"
+    )
+    assert cleanup_success, f"Failed to clean up single write node output: {cleanup_message}"
+
+    # Process multiple write nodes job (most recent job)
+    multiple_write_nodes_id = job_ids[1]
+    multiple_nodes_job = api_helpers.get_job(farm_id, queue_id, multiple_write_nodes_id)
+
+    print("\n=== Job Information ===")
+    print(multiple_nodes_job)
+    assert multiple_nodes_job is not None, "Failed to get multiple node selection job"
+    assert multiple_nodes_job["parameters"]["WriteNode"]["string"] == "All Write Nodes"
+    download_success = api_helpers.download_output(farm_id, queue_id, multiple_write_nodes_id)
+    assert download_success, "Failed to download multiple write nodes job output"
+
+    # Verify multiple write nodes outputs (two output files)
+    for base_name in ["nukeTest_color_correct2", "nukeTest_output_v01"]:
+        verification_helpers.verify_image_sequence_rgb_matches(
+            expected_dir=EXPECTED_DIR,
+            output_dir=OUTPUT_DIR,
+            base_name=base_name,
+            start_frame=FRAME_RANGE[0],
+            end_frame=FRAME_RANGE[1],
+            rgb_diff_tolerance=RGB_TOLERANCE,
+        )
+
+        # Clean up each output
+        cleanup_success, cleanup_message = cleanup_helpers.cleanup_output_images(
+            output_dir=OUTPUT_DIR, base_name=base_name
+        )
+        assert cleanup_success, f"Failed to clean up {base_name} output: {cleanup_message}"

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -145,7 +145,10 @@ def check_platform():
 def test_basic_workflow(cleanup_render_outputs):
     check_platform()
     register_cleanup, _ = cleanup_render_outputs
-    register_cleanup(TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR), "nukeTest_output_v01")
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
+        "nukeTest_output_v01",
+    )
 
     success, job_id = run_squish_command("basic_workflow_gui")
     # Exit early if the Squish test failed
@@ -187,7 +190,10 @@ def test_basic_workflow(cleanup_render_outputs):
 def test_custom_settings_workflow(cleanup_render_outputs):
     check_platform()
     register_cleanup, _ = cleanup_render_outputs
-    register_cleanup(TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR), "nukeTest_output_v01")
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
+        "nukeTest_output_v01",
+    )
 
     success, job_id = run_squish_command("custom_settings_gui")
     # Exit early if the Squish test failed
@@ -262,7 +268,10 @@ def test_write_node_selection(cleanup_render_outputs):
     download_success = api_helpers.download_output(farm_id, queue_id, single_write_node_id)
     assert download_success, "Failed to download single write node job output"
 
-    register_cleanup(TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR), "nukeTest_output_v01")
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
+        "nukeTest_output_v01",
+    )
 
     # Verify single write node output
     verification_helpers.verify_image_sequence_rgb_matches(
@@ -289,9 +298,13 @@ def test_write_node_selection(cleanup_render_outputs):
 
     # Verify multiple write nodes outputs (two output files)
     for base_name in ["nukeTest_color_correct2", "nukeTest_output_v01"]:
-        register_cleanup(TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR), base_name)
+        register_cleanup(
+            TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR), base_name
+        )
         verification_helpers.verify_image_sequence_rgb_matches(
-            expected_dir=TestConstants.get_expected_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
+            expected_dir=TestConstants.get_expected_img_dir(
+                TestConstants.MODIFIED_TEST_SAMPLES_DIR
+            ),
             output_dir=TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
             base_name=base_name,
             start_frame=TestConstants.FRAME_RANGE[0],

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -248,7 +248,7 @@ def test_write_node_selection(cleanup_render_outputs):
     if not success:
         assert success, "Squish command failed"
     if len(job_ids) != 2:
-        assert len(job_ids) == 2, f"Expected exactly one job ID, but got {len(job_ids)}"
+        assert len(job_ids) == 2, f"Expected exactly two job IDs, but got {len(job_ids)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
     assert farm_id is not None, "Farm ID not found"

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 from shared.scripts import api_helpers, verification_helpers, cleanup_helpers
+from shared.scripts.constants import TestConstants
 import pathlib
 import pytest
 
@@ -143,18 +144,8 @@ def check_platform():
 
 def test_basic_workflow(cleanup_render_outputs):
     check_platform()
-
-    NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
-    TEST_SAMPLES_DIR = (
-        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
-    )
-    EXPECTED_DIR = f"{TEST_SAMPLES_DIR}/images/expected"
-    OUTPUT_DIR = f"{TEST_SAMPLES_DIR}/images/output"
-    FRAME_RANGE = (101, 120)
-    RGB_TOLERANCE = 0.1
-
     register_cleanup, _ = cleanup_render_outputs
-    register_cleanup(OUTPUT_DIR, "nukeTest_output_v01")
+    register_cleanup(TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR), "nukeTest_output_v01")
 
     success, job_id = run_squish_command("basic_workflow_gui")
     # Exit early if the Squish test failed
@@ -184,29 +175,19 @@ def test_basic_workflow(cleanup_render_outputs):
 
     # Verify the rendered image sequence matches expected output
     verification_helpers.verify_image_sequence_rgb_matches(
-        expected_dir=EXPECTED_DIR,
-        output_dir=OUTPUT_DIR,
+        expected_dir=TestConstants.get_expected_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
+        output_dir=TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
         base_name="nukeTest_output_v01",
-        start_frame=FRAME_RANGE[0],
-        end_frame=FRAME_RANGE[1],
-        rgb_diff_tolerance=RGB_TOLERANCE,
+        start_frame=TestConstants.FRAME_RANGE[0],
+        end_frame=TestConstants.FRAME_RANGE[1],
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
     )
 
 
 def test_custom_settings_workflow(cleanup_render_outputs):
     check_platform()
-
-    NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
-    TEST_SAMPLES_DIR = (
-        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
-    )
-    EXPECTED_DIR = f"{TEST_SAMPLES_DIR}/images/expected"
-    OUTPUT_DIR = f"{TEST_SAMPLES_DIR}/images/output"
-    FRAME_RANGE = (101, 120)
-    RGB_TOLERANCE = 0.1
-
     register_cleanup, _ = cleanup_render_outputs
-    register_cleanup(OUTPUT_DIR, "nukeTest_output_v01")
+    register_cleanup(TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR), "nukeTest_output_v01")
 
     success, job_id = run_squish_command("custom_settings_gui")
     # Exit early if the Squish test failed
@@ -241,27 +222,18 @@ def test_custom_settings_workflow(cleanup_render_outputs):
 
     # Verify the rendered image sequence matches expected output
     verification_helpers.verify_image_sequence_rgb_matches(
-        expected_dir=EXPECTED_DIR,
-        output_dir=OUTPUT_DIR,
+        expected_dir=TestConstants.get_expected_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
+        output_dir=TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
         base_name="nukeTest_output_v01",
-        start_frame=FRAME_RANGE[0],
-        end_frame=FRAME_RANGE[1],
-        rgb_diff_tolerance=RGB_TOLERANCE,
+        start_frame=TestConstants.FRAME_RANGE[0],
+        end_frame=TestConstants.FRAME_RANGE[1],
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
     )
 
 
 # Write Node Selection Test
 def test_write_node_selection(cleanup_render_outputs):
     check_platform()
-
-    NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
-    TEST_SAMPLES_DIR = (
-        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_modified_test_samples"
-    )
-    EXPECTED_DIR = f"{TEST_SAMPLES_DIR}/images/expected"
-    OUTPUT_DIR = f"{TEST_SAMPLES_DIR}/images/output"
-    FRAME_RANGE = (101, 120)
-    RGB_TOLERANCE = 0.1
 
     register_cleanup, execute_cleanup = cleanup_render_outputs
     success, job_ids = run_squish_command("write_node_gui")
@@ -290,16 +262,16 @@ def test_write_node_selection(cleanup_render_outputs):
     download_success = api_helpers.download_output(farm_id, queue_id, single_write_node_id)
     assert download_success, "Failed to download single write node job output"
 
-    register_cleanup(OUTPUT_DIR, "nukeTest_output_v01")
+    register_cleanup(TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR), "nukeTest_output_v01")
 
     # Verify single write node output
     verification_helpers.verify_image_sequence_rgb_matches(
-        expected_dir=EXPECTED_DIR,
-        output_dir=OUTPUT_DIR,
+        expected_dir=TestConstants.get_expected_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
+        output_dir=TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
         base_name="nukeTest_output_v01",
-        start_frame=FRAME_RANGE[0],
-        end_frame=FRAME_RANGE[1],
-        rgb_diff_tolerance=RGB_TOLERANCE,
+        start_frame=TestConstants.FRAME_RANGE[0],
+        end_frame=TestConstants.FRAME_RANGE[1],
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
     )
 
     execute_cleanup()
@@ -317,12 +289,12 @@ def test_write_node_selection(cleanup_render_outputs):
 
     # Verify multiple write nodes outputs (two output files)
     for base_name in ["nukeTest_color_correct2", "nukeTest_output_v01"]:
-        register_cleanup(OUTPUT_DIR, base_name)
+        register_cleanup(TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR), base_name)
         verification_helpers.verify_image_sequence_rgb_matches(
-            expected_dir=EXPECTED_DIR,
-            output_dir=OUTPUT_DIR,
+            expected_dir=TestConstants.get_expected_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
+            output_dir=TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
             base_name=base_name,
-            start_frame=FRAME_RANGE[0],
-            end_frame=FRAME_RANGE[1],
-            rgb_diff_tolerance=RGB_TOLERANCE,
+            start_frame=TestConstants.FRAME_RANGE[0],
+            end_frame=TestConstants.FRAME_RANGE[1],
+            rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
         )

--- a/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
@@ -38,7 +38,7 @@ def get_queue_id_by_name(farm_id):
 
 
 def get_job(farm_id, queue_id, job_id, check_storage_profile=False):
-    # Returns the job details if found, None otherwise. This also servers to verify that the default farm/queue and the optional storage is selected.
+    # Returns the job details if found, None otherwise. This also serves to verify that the default farm/queue and the optional storage is selected.
     try:
         deadline = get_boto3_client("deadline")
         job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
@@ -84,14 +84,12 @@ def verify_job_in_queue(farm_id, queue_id, job_id):
             return False
 
         # Check if the job_id exists in the list of jobs
-        job_ids = [job["jobId"] for job in jobs["jobs"]]
-
-        if job_id in job_ids:
+        if any(job["jobId"] == job_id for job in jobs["jobs"]):
             print(f"Job {job_id} found in queue {queue_id}")
             return True
-        else:
-            print(f"Job {job_id} not found in queue {queue_id}")
-            return False
+        
+        print(f"Job {job_id} not found in queue {queue_id}")
+        return False
 
     except Exception as e:
         print(f"Error verifying job in queue: {str(e)}")

--- a/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
@@ -37,42 +37,21 @@ def get_queue_id_by_name(farm_id):
     return queue_id
 
 
-def get_latest_job_id(farm_id, queue_id):
-    """Get latest job from queue"""
-    jobs = list_jobs(farmId=farm_id, queueId=queue_id)
-    if not jobs["jobs"]:
-        return None
-
-    # Sort jobs by createdAt in descending order (newest first)
-    sorted_jobs = sorted(jobs["jobs"], key=lambda x: x["createdAt"], reverse=True)
-    latest_job_id = sorted_jobs[0]["jobId"]
-
-    print("\n=== Latest Job ID Information ===")
-    print(latest_job_id)
-    return latest_job_id
-
-
-def get_latest_job(farm_id, queue_id, job_id):
-    # Returns the job details if found, None otherwise
+def get_job(farm_id, queue_id, job_id, check_storage_profile=False):
+    # Returns the job details if found, None otherwise. This also servers to verify that the default farm/queue and the optional storage is selected.
     try:
         deadline = get_boto3_client("deadline")
         job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
 
         storage_profile_id = job.get("storageProfileId")
 
-        storage_profile = deadline.get_storage_profile(
-            farmId=farm_id, storageProfileId=storage_profile_id
-        )
-
-        # Assert it's the macOS profile
-        print(storage_profile["osFamily"])
-        assert storage_profile["osFamily"] == "MACOS", "Storage profile is not macOS"
-        print(f"Verified storage profile is macOS: {storage_profile['displayName']}")
-
-        print("Verified that default farm/queue/storage is selected")
-
-        print("\n=== Latest Job Information ===")
-        print(job)
+        if check_storage_profile:
+            storage_profile = deadline.get_storage_profile(
+                farmId=farm_id, storageProfileId=storage_profile_id
+            )
+            print(storage_profile["osFamily"])
+            assert storage_profile["osFamily"] == "MACOS", "Storage profile is not macOS"
+            print(f"Verified storage profile is macOS: {storage_profile['displayName']}")
         return job
     except ClientError as e:
         error_code = e.response["Error"]["Code"]
@@ -84,10 +63,38 @@ def get_latest_job(farm_id, queue_id, job_id):
 
 
 def verify_job_in_queue(farm_id, queue_id, job_id):
-    latest_job_id = get_latest_job_id(farm_id=farm_id, queue_id=queue_id)
-    if latest_job_id == job_id:
-        return True
-    else:
+    """
+    Verify if a job with the specified job_id exists in the queue.
+
+    Args:
+        farm_id (str): The ID of the farm
+        queue_id (str): The ID of the queue
+        job_id (str): The ID of the job to check
+
+    Returns:
+        bool: True if the job exists in the queue, False otherwise
+    """
+    try:
+        # Get all jobs in the queue
+        jobs = list_jobs(farmId=farm_id, queueId=queue_id)
+
+        # Check if the jobs list is empty
+        if not jobs or "jobs" not in jobs or not jobs["jobs"]:
+            print(f"No jobs found in queue {queue_id}")
+            return False
+
+        # Check if the job_id exists in the list of jobs
+        job_ids = [job["jobId"] for job in jobs["jobs"]]
+
+        if job_id in job_ids:
+            print(f"Job {job_id} found in queue {queue_id}")
+            return True
+        else:
+            print(f"Job {job_id} not found in queue {queue_id}")
+            return False
+
+    except Exception as e:
+        print(f"Error verifying job in queue: {str(e)}")
         return False
 
 
@@ -109,7 +116,7 @@ def wait_for_job_completion(farm_id, queue_id, job_id, timeout_seconds=600, poll
             return False, "TIMEOUT"
 
         # Get current job status
-        job = get_latest_job(farm_id, queue_id, job_id)
+        job = get_job(farm_id, queue_id, job_id)
         if not job:
             print(f"Could not get job status for {job_id}")
             return False, "ERROR"

--- a/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
@@ -87,7 +87,7 @@ def verify_job_in_queue(farm_id, queue_id, job_id):
         if any(job["jobId"] == job_id for job in jobs["jobs"]):
             print(f"Job {job_id} found in queue {queue_id}")
             return True
-        
+
         print(f"Job {job_id} not found in queue {queue_id}")
         return False
 

--- a/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
@@ -79,7 +79,7 @@ def verify_job_in_queue(farm_id, queue_id, job_id):
         jobs = list_jobs(farmId=farm_id, queueId=queue_id)
 
         # Check if the jobs list is empty
-        if not jobs or "jobs" not in jobs or not jobs["jobs"]:
+        if not jobs["jobs"]:
             print(f"No jobs found in queue {queue_id}")
             return False
 

--- a/test/squish/suite_nuke_submitter/shared/scripts/cleanup_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/cleanup_helpers.py
@@ -3,10 +3,7 @@ import glob
 from pathlib import Path
 
 
-def cleanup_output_images(
-    output_dir: str,
-    base_name: str = "nukeTest_output_OCIO_v01",
-) -> tuple[bool, str]:
+def cleanup_output_images(output_dir: str, base_name: str) -> tuple[bool, str]:
     """
     Delete all output images in the specified directory that match the base name.
 

--- a/test/squish/suite_nuke_submitter/shared/scripts/constants.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/constants.py
@@ -1,0 +1,27 @@
+import os
+
+NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
+
+class TestConstants:
+    # Test sample directories
+    DEFAULT_TEST_SAMPLES_DIR = f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
+    MODIFIED_TEST_SAMPLES_DIR = f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_modified_test_samples"
+
+    @staticmethod
+    def get_expected_img_dir(test_samples_dir):
+        return f"{test_samples_dir}/images/expected"
+    
+    @staticmethod
+    def get_output_img_dir(test_samples_dir):
+        return f"{test_samples_dir}/images/output"
+    
+    @staticmethod
+    def get_expected_mov_dir(test_samples_dir):
+        return f"{test_samples_dir}/movies/expected"
+    
+    @staticmethod
+    def get_output_mov_dir(test_samples_dir):
+        return f"{test_samples_dir}/movies/output"
+
+    FRAME_RANGE = (101, 120)
+    RGB_TOLERANCE = 0.1

--- a/test/squish/suite_nuke_submitter/shared/scripts/constants.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/constants.py
@@ -2,23 +2,28 @@ import os
 
 NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")
 
+
 class TestConstants:
     # Test sample directories
-    DEFAULT_TEST_SAMPLES_DIR = f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
-    MODIFIED_TEST_SAMPLES_DIR = f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_modified_test_samples"
+    DEFAULT_TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples"
+    )
+    MODIFIED_TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_modified_test_samples"
+    )
 
     @staticmethod
     def get_expected_img_dir(test_samples_dir):
         return f"{test_samples_dir}/images/expected"
-    
+
     @staticmethod
     def get_output_img_dir(test_samples_dir):
         return f"{test_samples_dir}/images/output"
-    
+
     @staticmethod
     def get_expected_mov_dir(test_samples_dir):
         return f"{test_samples_dir}/movies/expected"
-    
+
     @staticmethod
     def get_output_mov_dir(test_samples_dir):
         return f"{test_samples_dir}/movies/output"

--- a/test/squish/suite_nuke_submitter/shared/scripts/constants.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/constants.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 
 NUKE_ASSET_ROOT = os.environ.get("NUKE_ASSET_ROOT", "")

--- a/test/squish/suite_nuke_submitter/shared/scripts/names.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/names.py
@@ -343,3 +343,85 @@ queue_Environment_Conda_Conda_Packages_QLineEdit = {
     "unnamed": 1,
     "visible": 1,
 }
+queue_Environment_Conda_Conda_Channels_QLabel = {
+    "container": queue_Environment_Conda_JobTemplateGroupLayout,
+    "text": "Conda Channels",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+queue_Environment_Conda_Conda_Channels_QLineEdit = {
+    "container": queue_Environment_Conda_JobTemplateGroupLayout,
+    "leftWidget": queue_Environment_Conda_Conda_Channels_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_Properties_qt_spinbox_lineedit_QLineEdit = {
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "name": "qt_spinbox_lineedit",
+    "type": "QLineEdit",
+    "visible": 1,
+}
+job_Properties_qt_spinbox_lineedit_QLineEdit_2 = {
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "name": "qt_spinbox_lineedit",
+    "occurrence": 2,
+    "type": "QLineEdit",
+    "visible": 1,
+}
+job_Properties_qt_spinbox_lineedit_QLineEdit_3 = {
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "name": "qt_spinbox_lineedit",
+    "occurrence": 3,
+    "type": "QLineEdit",
+    "visible": 1,
+}
+job_Properties_Priority_QLabel = {
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "text": "Priority",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_Cloud_settings_DeadlineCloudSettingsWidget = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "title": "Deadline Cloud settings",
+    "type": "DeadlineCloudSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_Cloud_settings_OpenJDParametersWidget = {
+    "aboveWidget": deadline_Cloud_settings_DeadlineCloudSettingsWidget,
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "type": "OpenJDParametersWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+submit_to_AWS_Deadline_Cloud_QTabWidget = {
+    "type": "QTabWidget",
+    "unnamed": 1,
+    "visible": 1,
+    "window": submit_to_AWS_Deadline_Cloud_SubmitJobToDeadlineDialog,
+}
+continue_on_error_QCheckBox = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "text": "Continue on error",
+    "type": "QCheckBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+write_nodes_QLabel = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "text": "Write nodes",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+write_nodes_QComboBox = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "leftWidget": write_nodes_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}

--- a/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
@@ -4,6 +4,7 @@ import squish
 import test
 import names
 import config
+import os
 
 
 def launch_nuke():
@@ -11,18 +12,29 @@ def launch_nuke():
     test.log("Launched Nuke with Deadline Submitter")
 
 
-def set_job_name(name: str):
-    name_edit = squish.waitForObject(names.name_QLineEdit)
-    name_edit.selectAll()
-    squish.type(name_edit, name)
-    test.log(f"Job name set to {name}")
+def open_nuke_script(test_sample_name: str, script_name: str):
+    squish.activateItem(squish.waitForObjectItem(names.o_QMenuBar, "File"))
+    squish.activateItem(squish.waitForObjectItem(names.file_Foundry_UI_Menu, "Open Comp..."))
 
+    file_path_edit = squish.waitForObject(names.script_to_open_FilePathEdit)
+    file_path_edit.selectAll()
+    nuke_asset_path = os.environ.get("NUKE_ASSET_ROOT")
+    if not nuke_asset_path:
+        test.fatal("NUKE_ASSET_ROOT environment variable not set")
+        return
 
-def set_job_description(description: str):
-    description_edit = squish.waitForObject(names.job_Properties_Description_QLineEdit)
-    description_edit.selectAll()
-    squish.type(description_edit, description)
-    test.log(f"Job description set to {description}")
+    script_path = os.path.join(
+        nuke_asset_path, "nuke_test_samples", test_sample_name, "scripts", script_name
+    )
+    test.log(f"Using script path: {script_path}")
+
+    squish.setFocus(file_path_edit)
+    squish.type(file_path_edit, script_path)
+    squish.type(file_path_edit, "<Backspace>")
+    squish.type(file_path_edit, "k")
+
+    # Opens the nuke script file
+    squish.clickButton(squish.waitForObject(names.script_to_open_Open_QPushButton))
 
 
 def submit_job():
@@ -55,6 +67,54 @@ def open_nuke_submitter_gui():
         squish.waitForObjectItem(names.aWS_Deadline_Foundry_UI_Menu, "Submit to Deadline Cloud")
     )
     test.log("Opened the Nuke Submitter Console")
+
+
+def set_job_name(name: str):
+    name_edit = squish.waitForObject(names.name_QLineEdit)
+    name_edit.selectAll()
+    squish.type(name_edit, name)
+    test.log(f"Job name set to {name}")
+
+
+def set_job_description(description: str):
+    description_edit = squish.waitForObject(names.job_Properties_Description_QLineEdit)
+    description_edit.selectAll()
+    squish.type(description_edit, description)
+    test.log(f"Job description set to {description}")
+
+
+def set_max_retries(retries: int):
+    max_retries_edit = squish.waitForObject(names.job_Properties_qt_spinbox_lineedit_QLineEdit_3)
+    max_retries_edit.selectAll()
+    squish.type(max_retries_edit, str(retries))
+    test.log(f"Replaced max retries with {retries}")
+
+
+def set_max_failed_tasks(failed_tasks: int):
+    max_failed_tasks_edit = squish.waitForObject(
+        names.job_Properties_qt_spinbox_lineedit_QLineEdit_2
+    )
+    max_failed_tasks_edit.selectAll()
+    squish.type(max_failed_tasks_edit, str(failed_tasks))
+    test.log(f"Replaced max failed tasks with {failed_tasks}")
+
+
+def set_priority(priority: int):
+    priority_edit = squish.waitForObject(names.job_Properties_qt_spinbox_lineedit_QLineEdit)
+    priority_edit.selectAll()
+    squish.type(priority_edit, str(priority))
+    test.log(f"Replaced priority with {priority}")
+
+
+def set_continue_on_error():
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
+    )
+    if squish.waitForObjectExists(names.continue_on_error_QCheckBox).checked:
+        test.log("Continue on error is already enabled")
+    else:
+        squish.clickButton(squish.waitForObject(names.continue_on_error_QCheckBox))
+        test.log("Enabled continue on error")
 
 
 def configure_aws_profile():
@@ -168,6 +228,19 @@ def check_submission_success():
                 return True, job_id
     else:
         return False, None
+
+
+def check_missing_conda_packages():
+    conda_package_text = str(
+        squish.waitForObject(names.queue_Environment_Conda_Conda_Packages_QLineEdit).text
+    )
+    if conda_package_text != "nuke=16.* nuke-openjd=0.18.*":
+        test.fail("Conda packages are not configured correctly")
+    conda_channel_text = str(
+        squish.waitForObject(names.queue_Environment_Conda_Conda_Channels_QLineEdit).text
+    )
+    if conda_channel_text != "deadline-cloud":
+        test.fail("Conda channels are not configured correctly")
 
 
 def close_nuke():

--- a/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
@@ -18,6 +18,7 @@ def verify_image_sequence_rgb_matches(
     Args:
         expected_dir: Directory containing expected images
         output_dir: Directory containing output images
+        base_name: Base name of the image files to verify
         start_frame: First frame number
         end_frame: Last frame number
         rgb_diff_tolerance: Maximum allowed RGB difference

--- a/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
@@ -6,6 +6,7 @@ from PIL import Image
 def verify_image_sequence_rgb_matches(
     expected_dir: str,
     output_dir: str,
+    base_name: str,
     start_frame: int = 101,
     end_frame: int = 120,
     rgb_diff_tolerance: float = 0.1,
@@ -28,7 +29,7 @@ def verify_image_sequence_rgb_matches(
     # Process each frame
     for frame in range(start_frame, end_frame + 1):
         frame_str = f"{frame:04d}"  # e.g. 0101
-        filename = f"nukeTest_output_OCIO_v01.{frame_str}.png"
+        filename = f"{base_name}.{frame_str}.png"
 
         # Open images
         reference_img = Image.open(f"{expected_dir}/{filename}")

--- a/test/squish/suite_nuke_submitter/write_node_gui/test.py
+++ b/test/squish/suite_nuke_submitter/write_node_gui/test.py
@@ -1,0 +1,86 @@
+import names
+import squish_helpers
+import squish
+
+"""
+GUI test for verifying write node selection functionality in AWS Deadline Cloud submitter.
+
+This test executes two submission scenarios using the Deadline Cloud submitter GUI. First, it launches 
+Nuke with a multi-write-node script and submits a job targeting a single write node ("Write1"), 
+configuring necessary storage and AWS profiles. Then, it performs a second submission using the same 
+script but selecting all write nodes for processing. The test validates that the submitter can 
+correctly handle both individual and batch write node selections, ensuring proper job submission and 
+processing for different write node configurations.
+"""
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+    squish_helpers.open_nuke_script(
+        "nuke_submitter_v02_nuke_modified_test_samples", "nukeSubmitter_v02_nuke_modified.nk"
+    )
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.configure_storage_profile()
+
+    # Select Single Write Node
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
+    )
+    squish.mouseClick(
+        squish.waitForObject(names.write_nodes_QComboBox),
+        16,
+        11,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(names.write_nodes_QComboBox, "Write1"),
+        13,
+        10,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Shared job settings"
+    )
+
+    squish_helpers.set_job_name("Single Write Node Submission Test")
+    squish_helpers.set_job_description("Selected single write node for submission")
+    squish_helpers.configure_aws_profile()
+    squish_helpers.submit_job()
+
+    # Select Multiple Write Nodes
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.configure_storage_profile()
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
+    )
+    squish.mouseClick(
+        squish.waitForObject(names.write_nodes_QComboBox),
+        16,
+        11,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(names.write_nodes_QComboBox, "All write nodes"),
+        69,
+        12,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Shared job settings"
+    )
+
+    squish_helpers.set_job_name("Multiple Write Node Submission Test")
+    squish_helpers.set_job_description("All write nodes option selected for submission")
+    squish_helpers.configure_aws_profile()
+    squish_helpers.submit_job()
+
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/write_node_gui/test.py
+++ b/test/squish/suite_nuke_submitter/write_node_gui/test.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import names
 import squish_helpers
 import squish


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Nuke Submitter does not currently have E2E testing, only unit testing. Manual testing of the Nuke Submitter is time-consuming and error-prone for developers, requiring them to repeatedly perform complex sequences of UI interactions, verify job submissions, and validate image outputs. There isn't comprehensive end-to-end testing for our Nuke integration, which may cause customers to face potential disruptions in their rendering workflows when new updates are released.
### What was the solution? (How)
The framework currently implements the Basic Job Submission test case, ensuring reliable end-to-end testing of the core submission workflow. This PR will introduce a Custom Settings Job Submission test case, Write Node selection tests, and multiple error handling tests. The E2E tests currently only supports Mac. Support for other operating systems will come soon.
### What is the impact of this change?
Adds more E2E tests to Squish folder.
### How was this change tested?
The change was tested by running `hatch run squish:test`, which triggers the E2E integration tests in the `run_squish_test.py`file.
#### Please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Since these changes are focused on the test automation framework and don't modify the core job bundle functionality, running the Job Bundle Output Tests is not required. The changes are isolated to the test framework implementation.
```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Yes, the changes are through clear function and parameter documentation, logging, error messages, and more.
### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
