### PR TITLE
feat: Add OCIO, job attachment tests, and default frame range integration tests

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -43,7 +43,7 @@ test = "pytest --no-cov {args:test/*/e2e}"
 env-vars = { PYTHONPATH = "{env:PYTHONPATH:}:test/squish/suite_nuke_submitter" }
 
 [envs.squish.scripts]
-deps = "pip install numpy pytest pytest-xdist"
+deps = "pip install numpy pytest pytest-xdist opencv-python"
 test = "pytest --override-ini addopts= {args:test/squish/suite_nuke_submitter/run_squish_test.py} -v -n 0"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ module = [
   "names",
   "config",
   "PIL.*",
+  "cv2",
   "botocore.*",
   "squish_helpers"
 ]

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -52,28 +52,35 @@ The following Deadline Cloud resources are needed in order to run `tst_verify_se
 - Fleet instance market type of On-Demand instance
 
 ## Available Tests
-### Basic Workflow Test
-The `basic_workflow` test provides comprehensive end-to-end validation of the basic Nuke submitter workflow. This test consists of two main parts: First, the basic_workflow_gui Squish test automates the UI interaction by launching Nuke, opening a pre-configured script file with a write node, configuring AWS profile and resources, submitting a job to Deadline Cloud, and closing Nuke. Second, the test performs backend validation by verifying the job was successfully submitted to the correct queue, monitoring job completion, downloading the rendered output files, comparing them against reference images to ensure visual accuracy, and handling the cleanup of resource.
 
-### Custom Settings Submission Test
-The `custom_settings` test validates the customization capabilities of the Nuke submitter interface for Deadline Cloud jobs. This test automates the UI interaction by launching Nuke, opening a pre-configured script file, and accessing the submitter interface to configure various job parameters. It sets custom values for job metadata (name and description), performance settings (priority level 75, maximum 3 retries per task, maximum 10 failed tasks), and error handling options (continue on error). After configuring these parameters, the test submits the job and verifies that all custom settings are correctly applied in the submitted job configuration. This ensures that the submitter interface reliably handles non-default parameter configurations and maintains setting integrity throughout the submission process.
+### Common Test Flow
+All tests follow a standard pattern:
+- Launch Nuke and open a pre-configured script
+- Configure AWS profile and resources
+- Submit job to Deadline Cloud
+- Verify job submission and configuration
+- Download and validate rendered outputs
+- Clean up resources
 
-### Write Node Selection Tests
-The `write_node_selection` test provides comprehensive validation of the write node selection functionality in the Nuke submitter interface. This test executes two distinct submission scenarios: first submitting a job that targets a single write node ("Write1"), and then submitting another job that processes all write nodes in the script. For each scenario, the test automates the UI interaction by launching Nuke, configuring the AWS profile, selecting the appropriate write node option, and submitting the job. After submission, the test performs backend validation by verifying the jobs were created with correct write node parameters, downloading the rendered outputs, comparing them against reference images with RGB difference tolerance checks, and cleaning up the output files. This ensures that the submitter correctly handles both individual and batch write node selections, maintaining proper job configuration and output generation in both scenarios.
+### Test Categories
 
-### Job Attachments Tests
-The job attachments tests provide validation of both automatic and manual file attachment capabilities in the Nuke submitter interface. These tests consist of two main scenarios:
+#### Basic Workflow
+Validates the basic end-to-end submission workflow using default settings. Verifies job submission, rendering, and output generation with a simple write node configuration.
 
-The `auto_detected_attachments` test verifies that the submitter correctly identifies and includes all necessary files referenced within the Nuke script. This test automates the UI interaction by launching Nuke with a pre-configured script, submitting the job with default settings, and then performs backend validation to ensure all script-referenced files are properly detected and included in the job submission.
+#### Custom Settings
+Tests job submission with modified parameters including priority, retry limits, and error handling options. Ensures all custom settings are correctly applied and preserved in the submitted job.
 
-The `manual_attachments` test validates the ability to manually add supplementary files and output directories to a job submission. This test automates the UI interaction by launching Nuke with a configured script, navigating to the job attachments tab, and manually adding specific test files (EXR, NK, and PNG) along with a custom output directory. The test then performs validation by verifying the job configuration, confirming the presence of all manually attached files in the job manifest, validating the output directory configuration, and ensuring proper cleanup of resources. This comprehensive validation ensures that users can reliably supplement automatically detected files with additional required assets, supporting workflows that require files beyond those directly referenced in the Nuke script.
+#### Write Node Selection
+Validates job submission using both single and multiple write node selections. Verifies that outputs are correctly generated for each selected write node configuration.
 
-### OCIO Color Management Test
-The `ocio` test validates the integration of OpenColorIO (OCIO) color management within the Nuke submitter workflow for Deadline Cloud jobs. This test automates the UI interaction by launching Nuke with an ACES-configured script containing multiple write nodes and submitting separate jobs for different output types. After submission, the test performs backend validation by verifying OCIO configuration settings in the submitted jobs, downloading rendered outputs for both image sequences and movie files, performing RGB difference comparisons against reference images to ensure color accuracy, and validating movie file output integrity. This comprehensive validation ensures that the submission process correctly preserves color spaces, transformations, and ACES configurations throughout the entire workflow, from job submission to final render output.
+#### Job Attachments
+Tests automatic detection of script-referenced files and manual addition of supplementary files. Verifies that both auto-detected and manually added files are properly included in the job bundle.
 
-### Frame Range Tests
-The `default_frame_range` test validates that the Nuke submitter correctly uses frame ranges specified in the Nuke script when submitting jobs to Deadline Cloud. This test automates the UI interaction by launching Nuke with a pre-configured script containing a specific frame range, submitting the job without modifying the frame range settings, and then performs backend validation by verifying the frame range parameters in the submitted job configuration. After submission, the test downloads the rendered outputs and performs RGB difference comparisons against reference images to ensure all frames are correctly rendered within the specified range. This validation ensures that the submitter reliably preserves and uses the frame ranges defined in Nuke scripts.
+#### OCIO Color Management
+Tests job submission with ACES color configurations across multiple write nodes. Validates color accuracy of rendered outputs for both image sequences and movie files.
 
+#### Frame Range
+Validates that frame ranges specified in Nuke scripts are correctly used during job submission. Ensures all frames are properly rendered within the specified range.
 
 
 ## Running Tests

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -61,6 +61,21 @@ The `custom_settings` test validates the customization capabilities of the Nuke 
 ### Write Node Selection Tests
 The `write_node_selection` test provides comprehensive validation of the write node selection functionality in the Nuke submitter interface. This test executes two distinct submission scenarios: first submitting a job that targets a single write node ("Write1"), and then submitting another job that processes all write nodes in the script. For each scenario, the test automates the UI interaction by launching Nuke, configuring the AWS profile, selecting the appropriate write node option, and submitting the job. After submission, the test performs backend validation by verifying the jobs were created with correct write node parameters, downloading the rendered outputs, comparing them against reference images with RGB difference tolerance checks, and cleaning up the output files. This ensures that the submitter correctly handles both individual and batch write node selections, maintaining proper job configuration and output generation in both scenarios.
 
+### Job Attachments Tests
+The job attachments tests provide validation of both automatic and manual file attachment capabilities in the Nuke submitter interface. These tests consist of two main scenarios:
+
+The `auto_detected_attachments` test verifies that the submitter correctly identifies and includes all necessary files referenced within the Nuke script. This test automates the UI interaction by launching Nuke with a pre-configured script, submitting the job with default settings, and then performs backend validation to ensure all script-referenced files are properly detected and included in the job submission.
+
+The `manual_attachments` test validates the ability to manually add supplementary files and output directories to a job submission. This test automates the UI interaction by launching Nuke with a configured script, navigating to the job attachments tab, and manually adding specific test files (EXR, NK, and PNG) along with a custom output directory. The test then performs validation by verifying the job configuration, confirming the presence of all manually attached files in the job manifest, validating the output directory configuration, and ensuring proper cleanup of resources. This comprehensive validation ensures that users can reliably supplement automatically detected files with additional required assets, supporting workflows that require files beyond those directly referenced in the Nuke script.
+
+### OCIO Color Management Test
+The `ocio` test validates the integration of OpenColorIO (OCIO) color management within the Nuke submitter workflow for Deadline Cloud jobs. This test automates the UI interaction by launching Nuke with an ACES-configured script containing multiple write nodes and submitting separate jobs for different output types. After submission, the test performs backend validation by verifying OCIO configuration settings in the submitted jobs, downloading rendered outputs for both image sequences and movie files, performing RGB difference comparisons against reference images to ensure color accuracy, and validating movie file output integrity. This comprehensive validation ensures that the submission process correctly preserves color spaces, transformations, and ACES configurations throughout the entire workflow, from job submission to final render output.
+
+### Frame Range Tests
+The `default_frame_range` test validates that the Nuke submitter correctly uses frame ranges specified in the Nuke script when submitting jobs to Deadline Cloud. This test automates the UI interaction by launching Nuke with a pre-configured script containing a specific frame range, submitting the job without modifying the frame range settings, and then performs backend validation by verifying the frame range parameters in the submitted job configuration. After submission, the test downloads the rendered outputs and performs RGB difference comparisons against reference images to ensure all frames are correctly rendered within the specified range. This validation ensures that the submitter reliably preserves and uses the frame ranges defined in Nuke scripts.
+
+
+
 ## Running Tests
 To install necessary dependencies to run the tests, run:
 ```sh

--- a/test/squish/suite_nuke_submitter/default_frame_range_gui/test.py
+++ b/test/squish/suite_nuke_submitter/default_frame_range_gui/test.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import names
+import squish_helpers
+import squish
+
+"""
+GUI test for submitting a Nuke job using the default frame range from AWS Deadline Cloud.
+
+This test verifies that users can successfully submit jobs using the frame range specified in their Nuke script:
+The test opens a Nuke script that has a predefined frame range set within it, submits the job without modifying 
+the frame range settings, and ensures that the job submission process correctly uses these default frame range 
+values from the Nuke script. This verifies that when users don't explicitly set frame ranges in the submitter, 
+the system properly inherits and uses the frame range values already configured in their Nuke scripts.
+"""
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+    squish_helpers.open_nuke_script("intro_to_compositing_test_samples", "Shot002.v01.001.nk")
+    squish.snooze(3)
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.set_job_name("Default Frame Range Job")
+    squish_helpers.set_job_description(
+        "This test verifies that the default frame range specified in the Nuke Script is used"
+    )
+    squish_helpers.configure_aws_profile()
+    squish_helpers.submit_job()
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/manual_attachments_gui/test.py
+++ b/test/squish/suite_nuke_submitter/manual_attachments_gui/test.py
@@ -1,0 +1,60 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# mypy: disable-error-code="attr-defined"
+import names
+import squish_helpers
+import test
+import squish
+import os
+
+"""
+GUI test for submitting a Nuke job with manually added file attachments to AWS Deadline Cloud.
+
+This test verifies that users can successfully add and submit jobs with manual file attachments:
+The test demonstrates the ability to manually attach additional input files and output directories 
+that may not be automatically detected from the Nuke script. It adds specific test files 
+(EXR, NK, and PNG) as input attachments and configures a custom output directory. This ensures 
+that the manual attachment functionality works correctly for both input files and output locations.
+"""
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+    squish_helpers.open_nuke_script(
+        "nuke_submitter_v02_nuke_aces_custom_samples", "nukeSubmitter_OCIO_v02_aces_custom.nk"
+    )
+    squish.snooze(3)
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.set_job_name("Manual Job Attachments Test")
+    squish_helpers.set_job_description(
+        "Verify that additional files can be manually added as attachments"
+    )
+    squish_helpers.configure_aws_profile()
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job attachments"
+    )
+
+    nuke_asset_path = os.environ.get("NUKE_ASSET_ROOT")
+    if not nuke_asset_path:
+        test.fatal("NUKE_ASSET_ROOT environment variable not set")
+        return
+
+    aces_custom_sample_path = "nuke_test_samples/nuke_submitter_v02_nuke_aces_custom_samples"
+
+    manual_attachments = ["manual_asset.exr", "manual_script.nk", "nukeTest_manual_frame.png"]
+    for attachment in manual_attachments:
+        manual_attachment_path = os.path.join(
+            nuke_asset_path, aces_custom_sample_path, "manual", attachment
+        )
+        squish_helpers.add_input_files(manual_attachment_path)
+
+    squish_helpers.add_output_directory(
+        os.path.join(nuke_asset_path, aces_custom_sample_path, "manual")
+    )
+
+    squish_helpers.submit_job()
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/ocio_gui/test.py
+++ b/test/squish/suite_nuke_submitter/ocio_gui/test.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import names
+import squish
+import squish_helpers
+
+"""
+GUI test for submitting Nuke jobs with OCIO color management configurations to AWS Deadline Cloud.
+
+This test verifies that users can successfully submit jobs that utilize OCIO color management:
+The test demonstrates the ability to submit multiple render jobs from a single Nuke script that 
+uses OCIO (OpenColorIO) color management. It tests this by submitting separate jobs for different 
+write nodes within the same ACES-configured Nuke script, ensuring that the color management settings 
+and transformations are properly preserved and handled during job submission. This verification is 
+crucial for maintaining color accuracy and consistency in professional workflows that rely on OCIO 
+for color space transformations and management.
+"""
+
+
+def submit_ocio_job(write_node: str):
+    """Helper function to submit a job with specified write node."""
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.set_job_name("OCIO Config Job Submission")
+    squish_helpers.set_job_description(
+        "This test includes a render that includes the use of OCIO color management."
+    )
+
+    # Configure job-specific settings
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
+    )
+    squish.mouseClick(
+        squish.waitForObject(names.write_nodes_QComboBox),
+        16,
+        11,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(names.write_nodes_QComboBox, write_node),
+        13,
+        10,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+
+    # Configure shared settings
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Shared job settings"
+    )
+    squish_helpers.configure_aws_profile()
+    squish_helpers.submit_job()
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+
+    squish_helpers.open_nuke_script(
+        "nuke_submitter_v02_nuke_aces_stock_test_samples",
+        "nukeSubmitter_OCIO_v02_aces_stock.nk",
+    )
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+
+    submit_ocio_job("Write1")
+    submit_ocio_job("Write2")
+
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -455,7 +455,7 @@ def test_default_frame_range(cleanup_render_outputs):
     ), f"Frame range mismatch: Expected '1-56' from Nuke script, but got '{default_frame_range_job['parameters']['Frames']['string']}'"
 
     download_success = api_helpers.download_output(farm_id, queue_id, job_id[0])
-    assert download_success, "Failed to download OCIO job output"
+    assert download_success, "Failed to download default frame range output"
 
     verification_helpers.count_files(
         TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR)

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -507,7 +507,35 @@ def test_auto_detected_attachments(cleanup_render_outputs):
 
     input_paths = api_helpers.get_job_input_paths(farm_id, queue_id, job_id[0])
 
-    verification_helpers.verify_required_files(input_paths)
+    root_path = next(iter(input_paths))
+    manifest_group = input_paths[root_path]
+    all_paths = set(manifest_group.get_all_paths())
+
+    missing_files = []
+
+    # Check all required files including sequences
+    for i in range(1, 57):
+        fire_path = f"intro_to_compositing_test_samples/images/input/fire/fire.{i:03d}.exr"
+        ember_path = f"intro_to_compositing_test_samples/images/input/Embers/embers.{i:03d}.exr"
+
+        if fire_path not in all_paths:
+            missing_files.append(fire_path)
+        if ember_path not in all_paths:
+            missing_files.append(ember_path)
+
+    # Check individual files
+    individual_files = [
+        "intro_to_compositing_test_samples/images/input/sh009_RAW_v001_1200.exr",
+        "intro_to_compositing_test_samples/images/input/sh009_STN_monster_BTY_v001_1200.exr",
+        "intro_to_compositing_test_samples/images/input/videoplayback.mov",
+        "intro_to_compositing_test_samples/scripts/Shot002.v01.001.nk",
+    ]
+
+    missing_files.extend([f for f in individual_files if f not in all_paths])
+
+    assert len(missing_files) == 0, f"Missing {len(missing_files)} required files:\n" + "\n".join(
+        f"  - {f}" for f in missing_files
+    )
 
 
 def test_manual_attachments(cleanup_render_outputs):

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -6,6 +6,8 @@ from shared.scripts import api_helpers, verification_helpers, cleanup_helpers
 from shared.scripts.constants import TestConstants
 import pathlib
 import pytest
+import json
+from typing import Optional
 
 
 def run_squish_command(testcase_name, local=True):
@@ -108,18 +110,28 @@ def cleanup_render_outputs():
     """Fixture that manages cleanup of rendered image outputs with manual trigger points"""
     cleanup_queue = []
 
-    def register_cleanup(output_dir: str, base_name: str):
+    def register_cleanup(
+        output_dir: str, base_name: str, render_settings_path: Optional[str] = None
+    ):
         """Register a cleanup task"""
-        cleanup_queue.append((output_dir, base_name))
+        cleanup_queue.append((output_dir, base_name, render_settings_path))
 
     def execute_cleanup():
         """Execute all registered cleanups"""
         while cleanup_queue:
-            output_dir, base_name = cleanup_queue.pop(0)
+            output_dir, base_name, render_settings_path = cleanup_queue.pop(0)
             try:
                 success, message = cleanup_helpers.cleanup_output_images(output_dir, base_name)
                 if not success:
                     raise RuntimeError(f"Cleanup failed: {message}")
+
+                if render_settings_path:
+                    success, message = cleanup_helpers.cleanup_render_settings_json(
+                        render_settings_path
+                    )
+                    if not success:
+                        raise RuntimeError(f"Render settings cleanup failed: {message}")
+
             except Exception as e:
                 raise RuntimeError(f"Cleanup error: {str(e)}")
 
@@ -145,9 +157,14 @@ def check_platform():
 def test_basic_workflow(cleanup_render_outputs):
     check_platform()
     register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.DEFAULT_TEST_SAMPLES_DIR,
+        "scripts/nukeSubmitter_v02_nuke_default_one_write_node.deadline_render_settings.json",
+    )
     register_cleanup(
         TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
         "nukeTest_output_v01",
+        render_settings_path,
     )
 
     success, job_id = run_squish_command("basic_workflow_gui")
@@ -190,9 +207,14 @@ def test_basic_workflow(cleanup_render_outputs):
 def test_custom_settings_workflow(cleanup_render_outputs):
     check_platform()
     register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.DEFAULT_TEST_SAMPLES_DIR,
+        "scripts/nukeSubmitter_v02_nuke_default_one_write_node.deadline_render_settings.json",
+    )
     register_cleanup(
         TestConstants.get_output_img_dir(TestConstants.DEFAULT_TEST_SAMPLES_DIR),
         "nukeTest_output_v01",
+        render_settings_path,
     )
 
     success, job_id = run_squish_command("custom_settings_gui")
@@ -242,6 +264,10 @@ def test_write_node_selection(cleanup_render_outputs):
     check_platform()
 
     register_cleanup, execute_cleanup = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.MODIFIED_TEST_SAMPLES_DIR,
+        "scripts/nukeSubmitter_v02_nuke_modified.deadline_render_settings.json",
+    )
     success, job_ids = run_squish_command("write_node_gui")
 
     # Verify test execution was successful
@@ -271,6 +297,7 @@ def test_write_node_selection(cleanup_render_outputs):
     register_cleanup(
         TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
         "nukeTest_output_v01",
+        render_settings_path,
     )
 
     # Verify single write node output
@@ -299,7 +326,9 @@ def test_write_node_selection(cleanup_render_outputs):
     # Verify multiple write nodes outputs (two output files)
     for base_name in ["nukeTest_color_correct2", "nukeTest_output_v01"]:
         register_cleanup(
-            TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR), base_name
+            TestConstants.get_output_img_dir(TestConstants.MODIFIED_TEST_SAMPLES_DIR),
+            base_name,
+            render_settings_path,
         )
         verification_helpers.verify_image_sequence_rgb_matches(
             expected_dir=TestConstants.get_expected_img_dir(
@@ -311,3 +340,225 @@ def test_write_node_selection(cleanup_render_outputs):
             end_frame=TestConstants.FRAME_RANGE[1],
             rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
         )
+
+
+def test_ocio_job(cleanup_render_outputs):
+    check_platform()
+
+    register_cleanup, execute_cleanup = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.ACES_STOCK_TEST_SAMPLES_DIR,
+        "scripts/nukeSubmitter_OCIO_v02_aces_stock.deadline_render_settings.json",
+    )
+    success, job_ids = run_squish_command("ocio_gui")
+
+    # Verify test execution was successful
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_ids) != 2:
+        assert len(job_ids) == 2, f"Expected exactly one job ID, but got {len(job_ids)}"
+
+    # Get the farm ID from configuration
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    # Get the queue ID from configuration
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_ids[0])
+    assert job_in_queue
+
+    ocio_job = api_helpers.get_job(farm_id, queue_id, job_ids[0])
+    print(json.dumps(ocio_job, indent=2, default=str))
+
+    ocio_config_path = pathlib.Path(
+        "/Applications/Nuke16.0v1/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
+    )
+    api_helpers.verify_ocio_config(ocio_config_path, ocio_job)
+
+    download_success = api_helpers.download_output(farm_id, queue_id, job_ids[0])
+    assert download_success, "Failed to download OCIO job output"
+
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.ACES_STOCK_TEST_SAMPLES_DIR),
+        "nukeTest_output_OCIO_v01",
+        render_settings_path,
+    )
+
+    verification_helpers.verify_image_sequence_rgb_matches(
+        expected_dir=TestConstants.get_expected_img_dir(TestConstants.ACES_STOCK_TEST_SAMPLES_DIR),
+        output_dir=TestConstants.get_output_img_dir(TestConstants.ACES_STOCK_TEST_SAMPLES_DIR),
+        base_name="nukeTest_output_OCIO_v01",
+        start_frame=TestConstants.FRAME_RANGE[0],
+        end_frame=TestConstants.FRAME_RANGE[1],
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
+    )
+
+    execute_cleanup()
+
+    # Verify movie output
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_ids[1])
+    assert job_in_queue
+
+    ocio_job = api_helpers.get_job(farm_id, queue_id, job_ids[1])
+    print(json.dumps(ocio_job, indent=2, default=str))
+    api_helpers.verify_ocio_config(ocio_config_path, ocio_job)
+
+    download_success = api_helpers.download_output(farm_id, queue_id, job_ids[1])
+    assert download_success, "Failed to download OCIO job output"
+
+    register_cleanup(
+        TestConstants.get_output_mov_dir(TestConstants.ACES_STOCK_TEST_SAMPLES_DIR),
+        "nukeTest_OCIO_aces_stock",
+        render_settings_path,
+    )
+
+    expected_movie_path = f"{TestConstants.get_expected_mov_dir(TestConstants.ACES_STOCK_TEST_SAMPLES_DIR)}/nukeTest_OCIO_aces_stock.mov"
+    output_movie_path = f"{TestConstants.get_output_mov_dir(TestConstants.ACES_STOCK_TEST_SAMPLES_DIR)}/nukeTest_OCIO_aces_stock.mov"
+    verification_helpers.verify_video_sequence_matches(expected_movie_path, output_movie_path)
+
+
+def test_default_frame_range(cleanup_render_outputs):
+    check_platform()
+    register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR,
+        "scripts/Shot002.v01.001.deadline_render_settings.json",
+    )
+
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR),
+        "Shot002_v01_001",
+        render_settings_path,
+    )
+    success, job_id = run_squish_command("default_frame_range_gui")
+
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
+    assert job_in_queue
+
+    default_frame_range_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+
+    assert (
+        default_frame_range_job["parameters"]["Frames"]["string"] == "1-56"
+    ), f"Frame range mismatch: Expected '1-56' from Nuke script, but got '{default_frame_range_job['parameters']['Frames']['string']}'"
+
+    download_success = api_helpers.download_output(farm_id, queue_id, job_id[0])
+    assert download_success, "Failed to download OCIO job output"
+
+    verification_helpers.count_files(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR)
+    )
+
+    verification_helpers.verify_image_sequence_rgb_matches(
+        expected_dir=TestConstants.get_expected_img_dir(
+            TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR
+        ),
+        output_dir=TestConstants.get_output_img_dir(
+            TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR
+        ),
+        base_name="Shot002_v01_001",
+        start_frame=1,
+        end_frame=56,
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
+    )
+
+
+def test_auto_detected_attachments(cleanup_render_outputs):
+    check_platform()
+
+    success, job_id = run_squish_command("default_frame_range_gui")
+    register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR,
+        "scripts/Shot002.v01.001.deadline_render_settings.json",
+    )
+
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR),
+        "Shot002_v01_001",
+        render_settings_path,
+    )
+
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    default_frame_range_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+    print(json.dumps(default_frame_range_job, indent=2, default=str))
+
+    input_paths = api_helpers.get_job_input_paths(farm_id, queue_id, job_id[0])
+
+    verification_helpers.verify_required_files(input_paths)
+
+
+def test_manual_attachments(cleanup_render_outputs):
+    check_platform()
+    success, job_id = run_squish_command("manual_attachments_gui")
+
+    register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.ACES_CUSTOM_TEST_SAMPLES_DIR,
+        "scripts/nukeSubmitter_OCIO_v02_aces_custom.deadline_render_settings.json",
+    )
+
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.ACES_CUSTOM_TEST_SAMPLES_DIR),
+        "nukeTest_output_OCIO_v01",
+        render_settings_path,
+    )
+
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    manual_attachment_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+
+    input_paths = api_helpers.get_job_input_paths(farm_id, queue_id, job_id[0])
+
+    root_path = next(iter(input_paths))
+    manifest_group = input_paths[root_path]
+    all_paths = set(manifest_group.get_all_paths())
+
+    base_path = os.path.join(
+        TestConstants.ACES_CUSTOM_TEST_SAMPLES_DIR,
+        "manual",
+    )[1:]
+
+    api_helpers.verify_output_directory(base_path, manual_attachment_job)
+
+    manual_files = ["manual_asset.exr", "manual_script.nk", "nukeTest_manual_frame.png"]
+    missing_files = [
+        os.path.join(base_path, f)
+        for f in manual_files
+        if os.path.join(base_path, f) not in all_paths
+    ]
+
+    assert not missing_files, f"Missing {len(missing_files)} required files:\n" + "\n".join(
+        f"  - {f}" for f in missing_files
+    )

--- a/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
@@ -3,9 +3,15 @@
 from shared.scripts import config
 from deadline.client.api import get_boto3_client, list_farms, list_queues, list_jobs
 from botocore.exceptions import ClientError
-from deadline.job_attachments.download import OutputDownloader
-from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.download import OutputDownloader, get_job_input_paths_by_asset_root
+from deadline.job_attachments.models import (
+    JobAttachmentS3Settings,
+    Attachments,
+    ManifestProperties,
+)
+from pathlib import Path
 import time
+from typing import Dict, Any, cast
 
 
 def get_farm_id_by_name():
@@ -96,6 +102,32 @@ def verify_job_in_queue(farm_id, queue_id, job_id):
         return False
 
 
+def verify_ocio_config(ocio_path: Path, job_info):
+    if job_info["parameters"]["OCIOConfigPath"] is None:
+        raise AssertionError("No OCIO config path found")
+
+    assert job_info["parameters"]["OCIOConfigPath"]["path"] == str(ocio_path), (
+        f"OCIO config path mismatch:\n"
+        f"Expected: {str(ocio_path)}\n"
+        f"Actual: {job_info['parameters']['OCIOConfigPath']['path']}"
+    )
+
+
+def verify_output_directory(output_dir_path: Path, job_info):
+    manifest = job_info["attachments"]["manifests"][0]
+    if not manifest.get("outputRelativeDirectories"):
+        raise AssertionError("No output directories found in manifest")
+
+    output_dir_str = str(output_dir_path)
+    assert any(
+        output_dir_str in directory for directory in manifest["outputRelativeDirectories"]
+    ), (
+        f"Output directory not found in job manifest:\n"
+        f"Expected: {output_dir_str}\n"
+        f"Available directories: {', '.join(manifest['outputRelativeDirectories'])}"
+    )
+
+
 def wait_for_job_completion(farm_id, queue_id, job_id, timeout_seconds=600, poll_interval=10):
     """
     Wait for a job to complete (succeed or fail) with timeout and a poll interval (seconds).
@@ -168,3 +200,35 @@ def download_output(farm_id, queue_id, job_id):
         error_msg = f"Error downloading outputs: {str(e)}"
         print(error_msg)
         return False
+
+
+def get_job_input_paths(farm_id, queue_id, job_id):
+    try:
+        deadline = get_boto3_client("deadline")
+        queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+
+        s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+
+        job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+
+        attachments = Attachments(**job["attachments"])
+
+        for i in range(len(attachments.manifests)):
+            manifest_dict = cast(Dict[str, Any], attachments.manifests[i])
+            manifest = ManifestProperties(**manifest_dict)
+            if manifest.inputManifestPath is not None:
+                manifest.inputManifestPath = s3_settings.add_root_and_manifest_folder_prefix(
+                    manifest.inputManifestPath
+                )
+            attachments.manifests[i] = manifest
+
+        input_paths = get_job_input_paths_by_asset_root(
+            s3_settings=s3_settings,
+            attachments=attachments,
+        )
+
+        return input_paths
+
+    except Exception as e:
+        print(f"Error getting input paths: {str(e)}")
+        return None

--- a/test/squish/suite_nuke_submitter/shared/scripts/cleanup_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/cleanup_helpers.py
@@ -35,3 +35,31 @@ def cleanup_output_images(output_dir: str, base_name: str) -> tuple[bool, str]:
 
     except Exception as e:
         return False, f"Error cleaning up output images: {str(e)}"
+
+
+def cleanup_render_settings_json(render_settings_path: str) -> tuple[bool, str]:
+    """
+    Delete the render settings JSON file at the specified path.
+
+    Args:
+        render_settings_path: Path to the render settings JSON file to delete
+
+    Returns:
+        tuple[bool, str]: (success, message)
+        - success: True if file was deleted successfully or didn't exist
+        - message: Description of what was deleted or any errors
+    """
+    try:
+        file_path = Path(render_settings_path)
+
+        if not file_path.exists():
+            return (
+                True,
+                f"Render settings file {render_settings_path} does not exist, nothing to clean",
+            )
+
+        file_path.unlink()
+        return True, f"Successfully deleted render settings file: {render_settings_path}"
+
+    except Exception as e:
+        return False, f"Error cleaning up render settings file: {str(e)}"

--- a/test/squish/suite_nuke_submitter/shared/scripts/constants.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/constants.py
@@ -12,6 +12,15 @@ class TestConstants:
     MODIFIED_TEST_SAMPLES_DIR = (
         f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_modified_test_samples"
     )
+    ACES_STOCK_TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_aces_stock_test_samples"
+    )
+    ACES_CUSTOM_TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/nuke_submitter_v02_nuke_aces_custom_samples"
+    )
+    INTRO_COMPOSITION_TEST_SAMPLES_DIR = (
+        f"{NUKE_ASSET_ROOT}/nuke_test_samples/intro_to_compositing_test_samples"
+    )
 
     @staticmethod
     def get_expected_img_dir(test_samples_dir):

--- a/test/squish/suite_nuke_submitter/shared/scripts/names.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/names.py
@@ -425,3 +425,57 @@ write_nodes_QComboBox = {
     "unnamed": 1,
     "visible": 1,
 }
+attach_input_files_QGroupBox = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "title": "Attach input files",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+attach_input_files_Add_QPushButton = {
+    "container": attach_input_files_QGroupBox,
+    "text": "Add...",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+fileNameLabel_QLabel = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "name": "fileNameLabel",
+    "type": "QLabel",
+    "visible": 1,
+}
+fileNameEdit_QLineEdit = {
+    "buddy": fileNameLabel_QLabel,
+    "name": "fileNameEdit",
+    "type": "QLineEdit",
+    "visible": 1,
+}
+open_QPushButton = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "text": "Open",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+specify_output_directories_QGroupBox = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "title": "Specify output directories",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+specify_output_directories_Add_QPushButton = {
+    "container": specify_output_directories_QGroupBox,
+    "text": "Add...",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+choose_QPushButton = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "text": "Choose",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}

--- a/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
@@ -5,6 +5,7 @@ import test
 import names
 import config
 import os
+from pathlib import Path
 
 
 def launch_nuke():
@@ -67,6 +68,27 @@ def open_nuke_submitter_gui():
         squish.waitForObjectItem(names.aWS_Deadline_Foundry_UI_Menu, "Submit to Deadline Cloud")
     )
     test.log("Opened the Nuke Submitter Console")
+
+
+def add_input_files(input_file_path: Path):
+    squish.clickButton(squish.waitForObject(names.attach_input_files_Add_QPushButton))
+    input_file_edit = squish.waitForObject(names.fileNameEdit_QLineEdit)
+    input_file_edit.selectAll()
+    squish.setFocus(input_file_edit)
+    squish.type(input_file_edit, input_file_path)
+    squish.type(input_file_edit, "<Backspace>")
+    last_char = str(input_file_path)[-1]
+    squish.type(input_file_edit, last_char)
+    squish.clickButton(squish.waitForObject(names.open_QPushButton))
+
+
+def add_output_directory(output_dir: Path):
+    squish.clickButton(squish.waitForObject(names.specify_output_directories_Add_QPushButton))
+    output_dir_edit = squish.waitForObject(names.fileNameEdit_QLineEdit)
+    output_dir_edit.selectAll()
+    squish.setFocus(output_dir_edit)
+    squish.type(output_dir_edit, output_dir)
+    squish.clickButton(squish.waitForObject(names.choose_QPushButton))
 
 
 def set_job_name(name: str):

--- a/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
@@ -162,35 +162,3 @@ def verify_video_sequence_matches(
 
 def count_files(directory, extension=".png"):
     return len(list(Path(directory).glob(f"*{extension}")))
-
-
-def verify_required_files(input_paths):
-    root_path = next(iter(input_paths))
-    manifest_group = input_paths[root_path]
-    all_paths = set(manifest_group.get_all_paths())
-
-    missing_files = []
-
-    # Check all required files including sequences
-    for i in range(1, 57):
-        fire_path = f"intro_to_compositing_test_samples/images/input/fire/fire.{i:03d}.exr"
-        ember_path = f"intro_to_compositing_test_samples/images/input/Embers/embers.{i:03d}.exr"
-
-        if fire_path not in all_paths:
-            missing_files.append(fire_path)
-        if ember_path not in all_paths:
-            missing_files.append(ember_path)
-
-    # Check individual files
-    individual_files = [
-        "intro_to_compositing_test_samples/images/input/sh009_RAW_v001_1200.exr",
-        "intro_to_compositing_test_samples/images/input/sh009_STN_monster_BTY_v001_1200.exr",
-        "intro_to_compositing_test_samples/images/input/videoplayback.mov",
-        "intro_to_compositing_test_samples/scripts/Shot002.v01.001.nk",
-    ]
-
-    missing_files.extend([f for f in individual_files if f not in all_paths])
-
-    assert len(missing_files) == 0, f"Missing {len(missing_files)} required files:\n" + "\n".join(
-        f"  - {f}" for f in missing_files
-    )

--- a/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/verification_helpers.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import numpy as np
 from PIL import Image
+from pathlib import Path
+import cv2
 
 
 def verify_image_sequence_rgb_matches(
@@ -40,6 +42,9 @@ def verify_image_sequence_rgb_matches(
         ref_img_pixels = np.asarray(reference_img)
         out_img_pixels = np.asarray(output_img)
 
+        ref_img_pixels = ref_img_pixels[..., :3]
+        out_img_pixels = out_img_pixels[..., :3]
+
         # Verify dimensions match
         height1, width1, channel_count1 = ref_img_pixels.shape
         height2, width2, channel_count2 = out_img_pixels.shape
@@ -62,3 +67,130 @@ def verify_image_sequence_rgb_matches(
     assert (
         img_err <= rgb_diff_tolerance
     ), f"RGB difference {img_err} exceeds tolerance {rgb_diff_tolerance}"
+
+
+def verify_video_sequence_matches(
+    expected_video: str,
+    output_video: str,
+    frame_interval: int = 1,
+    rgb_diff_tolerance: float = 0.1,
+):
+    """
+    Compare two video sequences by extracting frames and comparing their RGB values.
+    Verifies that both videos have matching resolution, duration, and frame count,
+    while also checking that the content matches between corresponding frames.
+
+    Args:
+        expected_video: Path to the expected reference video
+        output_video: Path to the output video to compare
+        frame_interval: Sample every nth frame (default: 1, meaning check every frame)
+        rgb_diff_tolerance: Maximum allowed RGB difference (default: 0.1)
+    """
+    # Open both videos
+    ref_cap = cv2.VideoCapture(expected_video)
+    out_cap = cv2.VideoCapture(output_video)
+
+    if not ref_cap.isOpened() or not out_cap.isOpened():
+        raise ValueError("Failed to open one or both video files")
+
+    try:
+        # Compare video metadata
+        ref_frame_count = int(ref_cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        out_frame_count = int(out_cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        assert ref_frame_count == out_frame_count, (
+            f"Frame count mismatch: expected {ref_frame_count}, " f"got {out_frame_count}"
+        )
+
+        ref_width = int(ref_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        ref_height = int(ref_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        out_width = int(out_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        out_height = int(out_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        assert (ref_width, ref_height) == (out_width, out_height), (
+            f"Resolution mismatch: expected {ref_width}x{ref_height}, "
+            f"got {out_width}x{out_height}"
+        )
+
+        # Initialize RGB accumulators
+        total_ref_rgb = np.zeros(3)  # [R, G, B]
+        total_out_rgb = np.zeros(3)  # [R, G, B]
+        total_pixels = 0
+        frames_processed = 0
+
+        # Process frames at specified intervals
+        frame_idx = 0
+        while True:
+            ref_ret, ref_frame = ref_cap.read()
+            out_ret, out_frame = out_cap.read()
+
+            if not ref_ret or not out_ret:
+                break
+
+            if frame_idx % frame_interval == 0:
+                # Convert BGR to RGB (cv2 reads in BGR format)
+                ref_frame_rgb = cv2.cvtColor(ref_frame, cv2.COLOR_BGR2RGB)
+                out_frame_rgb = cv2.cvtColor(out_frame, cv2.COLOR_BGR2RGB)
+
+                # Accumulate RGB values
+                total_ref_rgb += ref_frame_rgb.sum(axis=(0, 1))
+                total_out_rgb += out_frame_rgb.sum(axis=(0, 1))
+                total_pixels += ref_height * ref_width
+                frames_processed += 1
+
+            frame_idx += 1
+
+        if frames_processed == 0:
+            raise ValueError("No frames were processed")
+
+        # Compute average RGB across all processed frames
+        avg_ref_rgb = total_ref_rgb / total_pixels
+        avg_out_rgb = total_out_rgb / total_pixels
+
+        # Compare RGB difference
+        diff = avg_ref_rgb - avg_out_rgb
+        video_err = np.sum(diff**2)
+
+        print(f"Average RGB difference across {frames_processed} frames: {video_err}")
+        assert (
+            video_err <= rgb_diff_tolerance
+        ), f"RGB difference {video_err} exceeds tolerance {rgb_diff_tolerance}"
+
+    finally:
+        # Clean up
+        ref_cap.release()
+        out_cap.release()
+
+
+def count_files(directory, extension=".png"):
+    return len(list(Path(directory).glob(f"*{extension}")))
+
+
+def verify_required_files(input_paths):
+    root_path = next(iter(input_paths))
+    manifest_group = input_paths[root_path]
+    all_paths = set(manifest_group.get_all_paths())
+
+    missing_files = []
+
+    # Check all required files including sequences
+    for i in range(1, 57):
+        fire_path = f"intro_to_compositing_test_samples/images/input/fire/fire.{i:03d}.exr"
+        ember_path = f"intro_to_compositing_test_samples/images/input/Embers/embers.{i:03d}.exr"
+
+        if fire_path not in all_paths:
+            missing_files.append(fire_path)
+        if ember_path not in all_paths:
+            missing_files.append(ember_path)
+
+    # Check individual files
+    individual_files = [
+        "intro_to_compositing_test_samples/images/input/sh009_RAW_v001_1200.exr",
+        "intro_to_compositing_test_samples/images/input/sh009_STN_monster_BTY_v001_1200.exr",
+        "intro_to_compositing_test_samples/images/input/videoplayback.mov",
+        "intro_to_compositing_test_samples/scripts/Shot002.v01.001.nk",
+    ]
+
+    missing_files.extend([f for f in individual_files if f not in all_paths])
+
+    assert len(missing_files) == 0, f"Missing {len(missing_files)} required files:\n" + "\n".join(
+        f"  - {f}" for f in missing_files
+    )

--- a/test/squish/suite_nuke_submitter/suite.conf
+++ b/test/squish/suite_nuke_submitter/suite.conf
@@ -2,6 +2,6 @@ AUT=Nuke16.0v1
 ENVVARS=envvars
 LANGUAGE=Python
 OBJECTMAPSTYLE=script
-TEST_CASES=basic_workflow_gui
+TEST_CASES=basic_workflow_gui custom_settings_gui default_frame_range_gui invalid_conda_gui manual_attachments_gui ocio_gui write_node_gui
 VERSION=3
 WRAPPERS=Qt


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Nuke Submitter does not currently have E2E testing, only unit testing. Manual testing of the Nuke Submitter is time-consuming and error-prone for developers, requiring them to repeatedly perform complex sequences of UI interactions, verify job submissions, and validate image outputs. There isn't comprehensive end-to-end testing for our Nuke integration, which may cause customers to face potential disruptions in their rendering workflows when new updates are released.

### What was the solution? (How)
The framework currently implements the Basic Job Submission test case, custom settings job submission test case, write node selection test cases, etc, ensuring reliable end-to-end testing of the core submission workflow. This PR will introduce OCIO color management, job attachments, and frame range test cases. The E2E tests currently only supports Mac. Support for other operating systems will come soon.

### What is the impact of this change?
Adds more E2E tests to Squish folder.

### How was this change tested?
The change was tested by running hatch run squish:test, which triggers the E2E integration tests in the `run_squish_test.py` file.

#### Please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Yes, this change was documented in the SQUISH_README markdown file. The test cases were given a description of how they function in this markdown file.
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
