### PR TITLE
fix: update override frame range function to correctly trigger frame override text box status

### DIFF
--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -300,4 +300,4 @@ class SceneSettingsWidget(QWidget):
         """
         Set the activated/deactivated status of the Frame override text box
         """
-        self.frame_override_txt.setEnabled(state == Qt.Checked)
+        self.frame_override_txt.setEnabled(bool(state))


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The override frame range text box in the Nuke submitter UI was not becoming editable when the override frame range checkbox was checked. This was a UI bug that prevented users from entering custom frame ranges even when they enabled the override option.

### What was the solution? (How)
Modified the activate_frame_override_changed method in SceneSettingsWidget to properly handle Qt checkbox states. The fix changed the text box enablement logic from comparing against Qt.Checked to using bool(state), which correctly handles Qt's integer state values (0 for unchecked, 2 for checked).

### What is the impact of this change?
Will make the override frame range checkbox on the Nuke Submitter UI functional.

### How was this change tested?
I built and tested the local installer in which I made the changes. I did manual testing by unchecking the override frame button and making sure that the text box is not editable anymore and then I checked the box and made sure I could edit the frame range text box. I also tested by submitting a job that I made through editing the frame range in the text box associated with the override frame range checkbox and made sure that the job template had the correct parameters.

#### Please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
