### PR TITLE
feat: Add frame range tests, rewrote QCombobox interactions

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -43,7 +43,7 @@ test = "pytest --no-cov {args:test/*/e2e}"
 env-vars = { PYTHONPATH = "{env:PYTHONPATH:}:test/squish/suite_nuke_submitter" }
 
 [envs.squish.scripts]
-deps = "pip install numpy pytest pytest-xdist opencv-python"
+deps = "pip install numpy pytest pytest-xdist opencv-python filelock"
 test = "pytest --override-ini addopts= {args:test/squish/suite_nuke_submitter/run_squish_test.py} -v -n 4"
 
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -44,7 +44,7 @@ env-vars = { PYTHONPATH = "{env:PYTHONPATH:}:test/squish/suite_nuke_submitter" }
 
 [envs.squish.scripts]
 deps = "pip install numpy pytest pytest-xdist opencv-python"
-test = "pytest --override-ini addopts= {args:test/squish/suite_nuke_submitter/run_squish_test.py} -v -n 0"
+test = "pytest --override-ini addopts= {args:test/squish/suite_nuke_submitter/run_squish_test.py} -v -n 4"
 
 
 [envs.release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ module = [
   "config",
   "PIL.*",
   "cv2",
+  "filelock",
   "botocore.*",
   "squish_helpers"
 ]

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -80,7 +80,7 @@ Tests automatic detection of script-referenced files and manual addition of supp
 Tests job submission with ACES color configurations across multiple write nodes. Validates color accuracy of rendered outputs for both image sequences and movie files.
 
 #### Frame Range
-Validates that frame ranges specified in Nuke scripts are correctly used during job submission. Ensures all frames are properly rendered within the specified range.
+Validates frame range handling across multiple scenarios: using default ranges from Nuke scripts, applying user-specified custom ranges, and respecting write node frame limits. 
 
 
 ## Running Tests

--- a/test/squish/suite_nuke_submitter/basic_workflow_gui/test.py
+++ b/test/squish/suite_nuke_submitter/basic_workflow_gui/test.py
@@ -27,7 +27,7 @@ def main():
     )
     squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
     squish_helpers.open_nuke_submitter_gui()
-    squish_helpers.configure_storage_profile()
+    squish_helpers.configure_storage_profile("macOS Storage Profile")
     squish_helpers.set_job_name("Basic Workflow Submission Test")
     squish_helpers.set_job_description("Basic Workflow Test Description")
     squish_helpers.configure_aws_profile()

--- a/test/squish/suite_nuke_submitter/custom_frame_range_gui/test.py
+++ b/test/squish/suite_nuke_submitter/custom_frame_range_gui/test.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# mypy: disable-error-code="attr-defined"
+import names
+import squish_helpers
+import squish
+import test
+
+"""
+GUI test for submitting a Nuke job with custom frame range settings to AWS Deadline Cloud.
+
+This test verifies that users can successfully override and submit jobs with custom frame ranges:
+This test enables the frame range override option and configures a specific frame range (1-10) 
+instead of using the default range from the Nuke script. This test submits a job with the custom 
+frame range and ensures that the override is properly applied to the submitted job.
+"""
+
+
+def main():
+    squish_helpers.launch_nuke()
+    squish.setWindowState(
+        squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
+        squish.WindowState.Maximize,
+    )
+    squish_helpers.open_nuke_script("intro_to_compositing_test_samples", "Shot002.v01.001.nk")
+    squish.snooze(3)
+    squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
+    squish_helpers.open_nuke_submitter_gui()
+    squish_helpers.set_job_name("Custom Frame Range Job")
+    squish_helpers.set_job_description(
+        "This test verifies that a custom frame range can be specified"
+    )
+    squish_helpers.configure_aws_profile()
+    squish.clickTab(
+        squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
+    )
+
+    combo_box = squish.waitForObject(names.write_nodes_QComboBox)
+    squish.mouseClick(combo_box)
+    combo_box.setCurrentText("Write1")
+
+    if not squish.waitForObject(names.override_frame_range_QCheckBox).isChecked():
+        squish.clickButton(squish.waitForObject(names.override_frame_range_QCheckBox))
+        test.log("Clicked the override frame range checkbox")
+
+    override_frame_range_edit = squish.waitForObject(names.override_frame_range_QLineEdit)
+    override_frame_range_edit.selectAll()
+    squish.type(override_frame_range_edit, "1-10")
+    test.log("Overrided frame range to 1-10")
+    squish_helpers.configure_storage_profile("<none selected>")
+    squish_helpers.configure_aws_profile()
+    squish_helpers.submit_job()
+    squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/custom_frame_range_gui/test.py
+++ b/test/squish/suite_nuke_submitter/custom_frame_range_gui/test.py
@@ -3,7 +3,6 @@
 import names
 import squish_helpers
 import squish
-import test
 
 """
 GUI test for submitting a Nuke job with custom frame range settings to AWS Deadline Cloud.
@@ -40,12 +39,12 @@ def main():
 
     if not squish.waitForObject(names.override_frame_range_QCheckBox).isChecked():
         squish.clickButton(squish.waitForObject(names.override_frame_range_QCheckBox))
-        test.log("Clicked the override frame range checkbox")
+        squish_helpers.test_log("Clicked the override frame range checkbox")
 
     override_frame_range_edit = squish.waitForObject(names.override_frame_range_QLineEdit)
     override_frame_range_edit.selectAll()
     squish.type(override_frame_range_edit, "1-10")
-    test.log("Overrided frame range to 1-10")
+    squish_helpers.test_log("Overrided frame range to 1-10")
     squish_helpers.configure_storage_profile("<none selected>")
     squish_helpers.configure_aws_profile()
     squish_helpers.submit_job()

--- a/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
+++ b/test/squish/suite_nuke_submitter/custom_settings_gui/test.py
@@ -25,15 +25,15 @@ def main():
         "nuke_submitter_v02_nuke_default_test_samples",
         "nukeSubmitter_v02_nuke_default_one_write_node.nk",
     )
+    squish.snooze(3)
     squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
     squish_helpers.open_nuke_submitter_gui()
     squish_helpers.set_job_name("Custom Setting Submission")
     squish_helpers.set_job_description("This test verifies submission with modified settings")
-
     squish_helpers.set_priority(75)
     squish_helpers.set_max_retries(3)
     squish_helpers.set_max_failed_tasks(10)
-
+    squish_helpers.configure_storage_profile("<none selected>")
     squish_helpers.configure_aws_profile()
     squish_helpers.set_continue_on_error()
     squish_helpers.submit_job()

--- a/test/squish/suite_nuke_submitter/manual_attachments_gui/test.py
+++ b/test/squish/suite_nuke_submitter/manual_attachments_gui/test.py
@@ -2,7 +2,6 @@
 # mypy: disable-error-code="attr-defined"
 import names
 import squish_helpers
-import test
 import squish
 import os
 
@@ -41,7 +40,7 @@ def main():
 
     nuke_asset_path = os.environ.get("NUKE_ASSET_ROOT")
     if not nuke_asset_path:
-        test.fatal("NUKE_ASSET_ROOT environment variable not set")
+        squish_helpers.test_log("NUKE_ASSET_ROOT environment variable not set.")
         return
 
     aces_custom_sample_path = "nuke_test_samples/nuke_submitter_v02_nuke_aces_custom_samples"

--- a/test/squish/suite_nuke_submitter/manual_attachments_gui/test.py
+++ b/test/squish/suite_nuke_submitter/manual_attachments_gui/test.py
@@ -33,6 +33,7 @@ def main():
     squish_helpers.set_job_description(
         "Verify that additional files can be manually added as attachments"
     )
+    squish_helpers.configure_storage_profile("<none selected>")
     squish_helpers.configure_aws_profile()
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job attachments"

--- a/test/squish/suite_nuke_submitter/ocio_gui/test.py
+++ b/test/squish/suite_nuke_submitter/ocio_gui/test.py
@@ -28,25 +28,15 @@ def submit_ocio_job(write_node: str):
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
     )
-    squish.mouseClick(
-        squish.waitForObject(names.write_nodes_QComboBox),
-        16,
-        11,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(names.write_nodes_QComboBox, write_node),
-        13,
-        10,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    combo_box = squish.waitForObject(names.write_nodes_QComboBox)
+    squish.mouseClick(combo_box)
+    combo_box.setCurrentText(write_node)
 
     # Configure shared settings
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Shared job settings"
     )
+    squish_helpers.configure_storage_profile("<none selected>")
     squish_helpers.configure_aws_profile()
     squish_helpers.submit_job()
 

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -457,9 +457,11 @@ def test_default_frame_range(cleanup_render_outputs):
     download_success = api_helpers.download_output(farm_id, queue_id, job_id[0])
     assert download_success, "Failed to download default frame range output"
 
-    verification_helpers.count_files(
+    num_files = verification_helpers.count_files(
         TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR)
     )
+
+    assert num_files == 56, f"Expected 56 output files but got {num_files}"
 
     verification_helpers.verify_image_sequence_rgb_matches(
         expected_dir=TestConstants.get_expected_img_dir(
@@ -471,6 +473,121 @@ def test_default_frame_range(cleanup_render_outputs):
         base_name="Shot002_v01_001",
         start_frame=1,
         end_frame=56,
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
+    )
+
+
+def test_custom_frame_range(cleanup_render_outputs):
+    check_platform()
+    register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR,
+        "scripts/Shot002.v01.001.deadline_render_settings.json",
+    )
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR),
+        "Shot002_v01_001",
+        render_settings_path,
+    )
+    success, job_id = run_squish_command("custom_frame_range_gui")
+
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
+    assert job_in_queue
+
+    custom_frame_range_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+
+    print(json.dumps(custom_frame_range_job, indent=2, default=str))
+
+    assert (
+        custom_frame_range_job["parameters"]["Frames"]["string"] == "1-10"
+    ), f"Frame range mismatch: Expected '1-10' from the specified custom frame range, but got '{custom_frame_range_job['parameters']['Frames']['string']}'"
+
+    download_success = api_helpers.download_output(farm_id, queue_id, job_id[0])
+    assert download_success, "Failed to download custom frame range output"
+
+    num_files = verification_helpers.count_files(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR)
+    )
+    assert num_files == 10, f"Expected 10 output files but got {num_files}"
+
+    verification_helpers.verify_image_sequence_rgb_matches(
+        expected_dir=TestConstants.get_expected_img_dir(
+            TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR
+        ),
+        output_dir=TestConstants.get_output_img_dir(
+            TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR
+        ),
+        base_name="Shot002_v01_001",
+        start_frame=1,
+        end_frame=10,
+        rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
+    )
+
+
+def test_write_node_frame_range_limits(cleanup_render_outputs):
+    check_platform()
+    register_cleanup, _ = cleanup_render_outputs
+    render_settings_path = os.path.join(
+        TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR,
+        "scripts/Shot002_modified_write_frame_limits.deadline_render_settings.json",
+    )
+    register_cleanup(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR),
+        "Shot002_v01_001",
+        render_settings_path,
+    )
+
+    success, job_id = run_squish_command("write_node_limit_gui")
+    if not success:
+        assert success, "Squish command failed"
+    if len(job_id) != 1:
+        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+
+    farm_id = api_helpers.get_farm_id_by_name()
+    assert farm_id is not None, "Farm ID not found"
+
+    queue_id = api_helpers.get_queue_id_by_name(farm_id)
+    assert queue_id is not None, "Queue ID not found"
+
+    job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
+    assert job_in_queue
+
+    write_node_frame_range_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+    print(json.dumps(write_node_frame_range_job, indent=2, default=str))
+
+    assert (
+        write_node_frame_range_job["parameters"]["Frames"]["string"] == "11-20"
+    ), f"Frame range mismatch: Expected '11-20' from the specified custom frame range, but got '{write_node_frame_range_job['parameters']['Frames']['string']}'"
+
+    download_success = api_helpers.download_output(farm_id, queue_id, job_id[0])
+    assert download_success, "Failed to download custom frame range output"
+
+    num_files = verification_helpers.count_files(
+        TestConstants.get_output_img_dir(TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR)
+    )
+    assert num_files == 10, f"Expected 10 output files but got {num_files}"
+
+    verification_helpers.verify_image_sequence_rgb_matches(
+        expected_dir=TestConstants.get_expected_img_dir(
+            TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR
+        ),
+        output_dir=TestConstants.get_output_img_dir(
+            TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR
+        ),
+        base_name="Shot002_v01_001",
+        start_frame=11,
+        end_frame=20,
         rgb_diff_tolerance=TestConstants.RGB_TOLERANCE,
     )
 
@@ -502,8 +619,8 @@ def test_auto_detected_attachments(cleanup_render_outputs):
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
     assert queue_id is not None, "Queue ID not found"
 
-    default_frame_range_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
-    print(json.dumps(default_frame_range_job, indent=2, default=str))
+    auto_detected_attachments_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
+    print(json.dumps(auto_detected_attachments_job, indent=2, default=str))
 
     input_paths = api_helpers.get_job_input_paths(farm_id, queue_id, job_id[0])
 

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -186,7 +186,6 @@ def test_basic_workflow(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("basic_workflow_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("basic_workflow_gui")
     # Exit early if the Squish test failed
     assert success, "Squish command failed"
     assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
@@ -237,7 +236,6 @@ def test_custom_settings_workflow(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("custom_settings_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("custom_settings_gui")
     # Exit early if the Squish test failed
     assert success, "Squish command failed"
     assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
@@ -290,7 +288,6 @@ def test_write_node_selection(cleanup_render_outputs):
     with lock:
         success, job_ids = run_squish_command("write_node_gui")
         time.sleep(5)
-    # success, job_ids = run_squish_command("write_node_gui")
 
     # Verify test execution was successful
     assert success, "Squish command failed"
@@ -374,7 +371,6 @@ def test_ocio_job(cleanup_render_outputs):
     with lock:
         success, job_ids = run_squish_command("ocio_gui")
         time.sleep(5)
-    # success, job_ids = run_squish_command("ocio_gui")
 
     # Verify test execution was successful
     assert success, "Squish command failed"
@@ -458,7 +454,6 @@ def test_default_frame_range(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("default_frame_range_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("default_frame_range_gui")
 
     assert success, "Squish command failed"
     assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
@@ -517,7 +512,6 @@ def test_custom_frame_range(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("custom_frame_range_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("custom_frame_range_gui")
 
     assert success, "Squish command failed"
     assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
@@ -577,7 +571,6 @@ def test_write_node_frame_range_limits(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("write_node_limit_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("write_node_limit_gui")
 
     assert success, "Squish command failed"
     assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
@@ -626,7 +619,7 @@ def test_auto_detected_attachments(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("default_frame_range_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("default_frame_range_gui")
+
     register_cleanup, _ = cleanup_render_outputs
     render_settings_path = os.path.join(
         TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR,
@@ -690,7 +683,6 @@ def test_manual_attachments(cleanup_render_outputs):
     with lock:
         success, job_id = run_squish_command("manual_attachments_gui")
         time.sleep(5)
-    # success, job_id = run_squish_command("manual_attachments_gui")
 
     register_cleanup, _ = cleanup_render_outputs
     render_settings_path = os.path.join(

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -7,6 +7,8 @@ from shared.scripts.constants import TestConstants
 import pathlib
 import pytest
 import json
+from filelock import FileLock
+import time
 from typing import Optional
 
 
@@ -55,23 +57,34 @@ def run_squish_command(testcase_name, local=True):
             print(f"Squish command failed with return code {result.returncode}")
             return False, []
 
-        # Check for Squish test failures in the output
+        # Check for Squish test failures in both stdout and stderr
         has_squish_failure = False
         failure_message = ""
-        lines = result.stdout.split("\n")
         job_ids = []
-        for line in lines:
+
+        # Process stdout for job IDs and failures
+        for line in result.stdout.split("\n"):
             # Look for job ID
             if "Found job ID:" in line:
                 job_ids.append(line.split("Found job ID:")[1].strip())
 
-            # Check for FAIL or FATAL in the output
+            # Check for FAIL or FATAL in stdout
             if "\tFAIL\t" in line or "FAIL " in line:
                 has_squish_failure = True
                 failure_message = line.strip()
             elif "\tFATAL\t" in line or "FATAL " in line:
                 has_squish_failure = True
                 failure_message = line.strip()
+
+        # Process stderr for failures
+        if not has_squish_failure:  # Only check stderr if no failure found in stdout
+            for line in result.stderr.split("\n"):
+                if "\tFAIL\t" in line or "FAIL " in line:
+                    has_squish_failure = True
+                    failure_message = line.strip()
+                elif "\tFATAL\t" in line or "FATAL " in line:
+                    has_squish_failure = True
+                    failure_message = line.strip()
 
         if has_squish_failure:
             print(f"Squish test failed: {failure_message}")
@@ -143,9 +156,12 @@ def cleanup_render_outputs():
 
 def test_invalid_conda_env():
     check_platform()
-    success = run_squish_command("invalid_conda_gui")
-    if success is False:
-        assert success, "Squish command failed"
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, _ = run_squish_command("invalid_conda_gui")
+        time.sleep(5)
+    # Test should fail when invalid Conda settings are detected
+    assert success is False, "Expected test to fail with invalid Conda settings"
 
 
 def check_platform():
@@ -166,23 +182,24 @@ def test_basic_workflow(cleanup_render_outputs):
         "nukeTest_output_v01",
         render_settings_path,
     )
-
-    success, job_id = run_squish_command("basic_workflow_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("basic_workflow_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("basic_workflow_gui")
     # Exit early if the Squish test failed
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     print("Basic Workflow Job ID: " + job_id[0])
 
     # Get the farm ID from configuration
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     # Get the queue ID from configuration
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
@@ -216,23 +233,24 @@ def test_custom_settings_workflow(cleanup_render_outputs):
         "nukeTest_output_v01",
         render_settings_path,
     )
-
-    success, job_id = run_squish_command("custom_settings_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("custom_settings_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("custom_settings_gui")
     # Exit early if the Squish test failed
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     print("Custom Settings Workflow Job ID: " + job_id[0])
 
     # Get the farm ID from configuration
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     # Get the queue ID from configuration
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
@@ -268,18 +286,20 @@ def test_write_node_selection(cleanup_render_outputs):
         TestConstants.MODIFIED_TEST_SAMPLES_DIR,
         "scripts/nukeSubmitter_v02_nuke_modified.deadline_render_settings.json",
     )
-    success, job_ids = run_squish_command("write_node_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_ids = run_squish_command("write_node_gui")
+        time.sleep(5)
+    # success, job_ids = run_squish_command("write_node_gui")
 
     # Verify test execution was successful
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_ids) != 2:
-        assert len(job_ids) == 2, f"Expected exactly two job IDs, but got {len(job_ids)}"
+    assert success, "Squish command failed"
+    assert len(job_ids) == 2, f"Expected exactly two job IDs, but got {len(job_ids)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     # Process single write node job (second most recent job)
     single_write_node_id = job_ids[0]
@@ -288,7 +308,7 @@ def test_write_node_selection(cleanup_render_outputs):
     print("\n=== Job Information ===")
     print(single_write_job)
 
-    assert single_write_job is not None, "Failed to get single write node job"
+    assert single_write_job, "Failed to get single write node job"
     assert single_write_job["parameters"]["WriteNode"]["string"] == "Write1"
 
     download_success = api_helpers.download_output(farm_id, queue_id, single_write_node_id)
@@ -318,7 +338,7 @@ def test_write_node_selection(cleanup_render_outputs):
 
     print("\n=== Job Information ===")
     print(multiple_nodes_job)
-    assert multiple_nodes_job is not None, "Failed to get multiple node selection job"
+    assert multiple_nodes_job, "Failed to get multiple node selection job"
     assert multiple_nodes_job["parameters"]["WriteNode"]["string"] == "All Write Nodes"
     download_success = api_helpers.download_output(farm_id, queue_id, multiple_write_nodes_id)
     assert download_success, "Failed to download multiple write nodes job output"
@@ -350,21 +370,23 @@ def test_ocio_job(cleanup_render_outputs):
         TestConstants.ACES_STOCK_TEST_SAMPLES_DIR,
         "scripts/nukeSubmitter_OCIO_v02_aces_stock.deadline_render_settings.json",
     )
-    success, job_ids = run_squish_command("ocio_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_ids = run_squish_command("ocio_gui")
+        time.sleep(5)
+    # success, job_ids = run_squish_command("ocio_gui")
 
     # Verify test execution was successful
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_ids) != 2:
-        assert len(job_ids) == 2, f"Expected exactly one job ID, but got {len(job_ids)}"
+    assert success, "Squish command failed"
+    assert len(job_ids) == 2, f"Expected exactly one job ID, but got {len(job_ids)}"
 
     # Get the farm ID from configuration
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     # Get the queue ID from configuration
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_ids[0])
     assert job_in_queue
@@ -432,18 +454,20 @@ def test_default_frame_range(cleanup_render_outputs):
         "Shot002_v01_001",
         render_settings_path,
     )
-    success, job_id = run_squish_command("default_frame_range_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("default_frame_range_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("default_frame_range_gui")
 
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
@@ -489,18 +513,20 @@ def test_custom_frame_range(cleanup_render_outputs):
         "Shot002_v01_001",
         render_settings_path,
     )
-    success, job_id = run_squish_command("custom_frame_range_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("custom_frame_range_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("custom_frame_range_gui")
 
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
@@ -547,18 +573,20 @@ def test_write_node_frame_range_limits(cleanup_render_outputs):
         "Shot002_v01_001",
         render_settings_path,
     )
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("write_node_limit_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("write_node_limit_gui")
 
-    success, job_id = run_squish_command("write_node_limit_gui")
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     job_in_queue = api_helpers.verify_job_in_queue(farm_id, queue_id, job_id[0])
     assert job_in_queue
@@ -594,8 +622,11 @@ def test_write_node_frame_range_limits(cleanup_render_outputs):
 
 def test_auto_detected_attachments(cleanup_render_outputs):
     check_platform()
-
-    success, job_id = run_squish_command("default_frame_range_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("default_frame_range_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("default_frame_range_gui")
     register_cleanup, _ = cleanup_render_outputs
     render_settings_path = os.path.join(
         TestConstants.INTRO_COMPOSITION_TEST_SAMPLES_DIR,
@@ -608,16 +639,14 @@ def test_auto_detected_attachments(cleanup_render_outputs):
         render_settings_path,
     )
 
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     auto_detected_attachments_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
     print(json.dumps(auto_detected_attachments_job, indent=2, default=str))
@@ -657,7 +686,11 @@ def test_auto_detected_attachments(cleanup_render_outputs):
 
 def test_manual_attachments(cleanup_render_outputs):
     check_platform()
-    success, job_id = run_squish_command("manual_attachments_gui")
+    lock = FileLock("squish_gui.lock")
+    with lock:
+        success, job_id = run_squish_command("manual_attachments_gui")
+        time.sleep(5)
+    # success, job_id = run_squish_command("manual_attachments_gui")
 
     register_cleanup, _ = cleanup_render_outputs
     render_settings_path = os.path.join(
@@ -671,16 +704,14 @@ def test_manual_attachments(cleanup_render_outputs):
         render_settings_path,
     )
 
-    if not success:
-        assert success, "Squish command failed"
-    if len(job_id) != 1:
-        assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
+    assert success, "Squish command failed"
+    assert len(job_id) == 1, f"Expected exactly one job ID, but got {len(job_id)}"
 
     farm_id = api_helpers.get_farm_id_by_name()
-    assert farm_id is not None, "Farm ID not found"
+    assert farm_id, "Farm ID not found"
 
     queue_id = api_helpers.get_queue_id_by_name(farm_id)
-    assert queue_id is not None, "Queue ID not found"
+    assert queue_id, "Queue ID not found"
 
     manual_attachment_job = api_helpers.get_job(farm_id, queue_id, job_id[0])
 

--- a/test/squish/suite_nuke_submitter/shared/scripts/names.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/names.py
@@ -479,3 +479,17 @@ choose_QPushButton = {
     "unnamed": 1,
     "visible": 1,
 }
+override_frame_range_QCheckBox = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "text": "Override frame range",
+    "type": "QCheckBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+override_frame_range_QLineEdit = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "leftWidget": override_frame_range_QCheckBox,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}

--- a/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
@@ -13,6 +13,10 @@ def launch_nuke():
     test.log("Launched Nuke with Deadline Submitter")
 
 
+def test_log(log_message: str):
+    test.log(log_message)
+
+
 def open_nuke_script(test_sample_name: str, script_name: str):
     squish.activateItem(squish.waitForObjectItem(names.o_QMenuBar, "File"))
     squish.activateItem(squish.waitForObjectItem(names.file_Foundry_UI_Menu, "Open Comp..."))

--- a/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
@@ -143,93 +143,39 @@ def configure_aws_profile():
     squish.clickButton(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_Settings_QPushButton)
     )
-    squish.sendEvent(
-        "QMoveEvent",
-        squish.waitForObject(
-            names.aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog
-        ),
-        541,
-        213,
-        810,
-        851,
-    )
 
     # Set the AWS profile to profile specified in the AWS_PROFILE environment variable
-    squish.mouseClick(
-        squish.waitForObject(names.global_settings_AWS_profile_QComboBox),
-        118,
-        19,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(names.global_settings_AWS_profile_QComboBox, config.profile_name),
-        117,
-        18,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    aws_profile_combo_box = squish.waitForObject(names.global_settings_AWS_profile_QComboBox)
+    squish.mouseClick(aws_profile_combo_box)
+    aws_profile_combo_box.setCurrentText(config.profile_name)
 
     # Set the farm to Nuke Submitter Squish Farm
-    squish.mouseClick(
-        squish.waitForObject(names.profile_settings_QComboBox),
-        54,
-        12,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(names.profile_settings_QComboBox, "Nuke Submitter Squish Farm"),
-        55,
-        10,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    farm_combo_box = squish.waitForObject(names.profile_settings_QComboBox)
+    squish.mouseClick(farm_combo_box)
+    farm_combo_box.setCurrentText("Nuke Submitter Squish Farm")
 
     # Set the farm to Nuke Submitter Squish Automation Queue
-    squish.mouseClick(
-        squish.waitForObject(names.farm_settings_QComboBox),
-        55,
-        7,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(
-            names.farm_settings_QComboBox, "Nuke Submitter Squish Automation Queue"
-        ),
-        57,
-        14,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    queue_combo_box = squish.waitForObject(names.farm_settings_QComboBox)
+    squish.mouseClick(queue_combo_box)
+    queue_combo_box.setCurrentText("Nuke Submitter Squish Automation Queue")
 
     squish.clickButton(
         squish.waitForObject(names.aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton)
     )
 
 
-def configure_storage_profile():
+def configure_storage_profile(profile_name: str):
     squish.clickButton(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_Settings_QPushButton)
     )
-    squish.mouseClick(
-        squish.waitForObject(names.farm_settings_QComboBox_2),
-        78,
-        6,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(names.farm_settings_QComboBox_2, "macOS Storage Profile"),
-        82,
-        8,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    squish.snooze(3)
+    combo_box = squish.waitForObject(names.farm_settings_QComboBox_2)
+    squish.mouseClick(combo_box)
+    combo_box.setCurrentText(profile_name)
     squish.clickButton(
         squish.waitForObject(names.aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton)
     )
+    test.log(f"Configured storage profile to {profile_name}")
 
 
 def check_submission_success():

--- a/test/squish/suite_nuke_submitter/suite.conf
+++ b/test/squish/suite_nuke_submitter/suite.conf
@@ -2,6 +2,6 @@ AUT=Nuke16.0v1
 ENVVARS=envvars
 LANGUAGE=Python
 OBJECTMAPSTYLE=script
-TEST_CASES=basic_workflow_gui custom_settings_gui default_frame_range_gui invalid_conda_gui manual_attachments_gui ocio_gui write_node_gui
+TEST_CASES=basic_workflow_gui custom_frame_range_gui custom_settings_gui default_frame_range_gui invalid_conda_gui manual_attachments_gui ocio_gui write_node_gui write_node_limit_gui
 VERSION=3
 WRAPPERS=Qt

--- a/test/squish/suite_nuke_submitter/write_node_gui/test.py
+++ b/test/squish/suite_nuke_submitter/write_node_gui/test.py
@@ -26,26 +26,15 @@ def main():
     )
     squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
     squish_helpers.open_nuke_submitter_gui()
-    squish_helpers.configure_storage_profile()
+    squish_helpers.configure_storage_profile("<none selected>")
 
     # Select Single Write Node
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
     )
-    squish.mouseClick(
-        squish.waitForObject(names.write_nodes_QComboBox),
-        16,
-        11,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(names.write_nodes_QComboBox, "Write1"),
-        13,
-        10,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    one_node_combo_box = squish.waitForObject(names.write_nodes_QComboBox)
+    squish.mouseClick(one_node_combo_box)
+    one_node_combo_box.setCurrentText("Write1")
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Shared job settings"
     )
@@ -57,24 +46,13 @@ def main():
 
     # Select Multiple Write Nodes
     squish_helpers.open_nuke_submitter_gui()
-    squish_helpers.configure_storage_profile()
+    squish_helpers.configure_storage_profile("<none selected>")
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Job-specific settings"
     )
-    squish.mouseClick(
-        squish.waitForObject(names.write_nodes_QComboBox),
-        16,
-        11,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
-    squish.mouseClick(
-        squish.waitForObjectItem(names.write_nodes_QComboBox, "All write nodes"),
-        69,
-        12,
-        squish.Qt.NoModifier,
-        squish.Qt.LeftButton,
-    )
+    all_nodes_combo_box = squish.waitForObject(names.write_nodes_QComboBox)
+    squish.mouseClick(all_nodes_combo_box)
+    all_nodes_combo_box.setCurrentText("All write nodes")
     squish.clickTab(
         squish.waitForObject(names.submit_to_AWS_Deadline_Cloud_QTabWidget), "Shared job settings"
     )
@@ -83,5 +61,4 @@ def main():
     squish_helpers.set_job_description("All write nodes option selected for submission")
     squish_helpers.configure_aws_profile()
     squish_helpers.submit_job()
-
     squish_helpers.close_nuke()

--- a/test/squish/suite_nuke_submitter/write_node_limit_gui/test.py
+++ b/test/squish/suite_nuke_submitter/write_node_limit_gui/test.py
@@ -1,17 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+# mypy: disable-error-code="attr-defined"
 import names
 import squish_helpers
 import squish
 
 """
-GUI test for submitting a Nuke job using the default frame range from AWS Deadline Cloud.
+GUI test for submitting a Nuke job with write nodes that have frame range limits to AWS Deadline Cloud.
 
-This test verifies that users can successfully submit jobs using the frame range specified in their Nuke script:
-The test opens a Nuke script that has a predefined frame range set within it, submits the job without modifying 
-the frame range settings, and ensures that the job submission process correctly uses these default frame range 
-values from the Nuke script. This verifies that when users don't explicitly set frame ranges in the submitter, 
-the system properly inherits and uses the frame range values already configured in their Nuke scripts.
+This test verifies that the submitter correctly handles write nodes with frame range restrictions:
+This test uses a Nuke script containing write nodes with specific frame range limits and submits 
+a job targeting one of these write nodes. This test ensures that the submitter properly detects 
+and respects the frame range limits defined in the write node, preventing rendering outside the 
+node's specified frame range regardless of the project's overall frame range.
 """
 
 
@@ -21,13 +21,15 @@ def main():
         squish.waitForObject(names.nukeMainWindow_Foundry_UI_DockMainWindow),
         squish.WindowState.Maximize,
     )
-    squish_helpers.open_nuke_script("intro_to_compositing_test_samples", "Shot002.v01.001.nk")
+    squish_helpers.open_nuke_script(
+        "intro_to_compositing_test_samples", "Shot002_modified_write_frame_limits.nk"
+    )
     squish.snooze(3)
     squish.type(squish.waitForObject(names.nukeMainWindow_DAG_DAG_Window), "<Ctrl+S>")
     squish_helpers.open_nuke_submitter_gui()
-    squish_helpers.set_job_name("Default Frame Range Job")
+    squish_helpers.set_job_name("Write Node Frame Range Limits Job")
     squish_helpers.set_job_description(
-        "This test verifies that the default frame range specified in the Nuke Script is used"
+        "Verify that the Write node frame range limits are respected"
     )
     squish_helpers.configure_storage_profile("<none selected>")
     squish_helpers.configure_aws_profile()
@@ -37,6 +39,5 @@ def main():
     combo_box = squish.waitForObject(names.write_nodes_QComboBox)
     squish.mouseClick(combo_box)
     combo_box.setCurrentText("Write1")
-
     squish_helpers.submit_job()
     squish_helpers.close_nuke()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Nuke Submitter does not currently have E2E testing, only unit testing. Manual testing of the Nuke Submitter is time-consuming and error-prone for developers, requiring them to repeatedly perform complex sequences of UI interactions, verify job submissions, and validate image outputs. There isn't comprehensive end-to-end testing for our Nuke integration, which may cause customers to face potential disruptions in their rendering workflows when new updates are released.
### What was the solution? (How)
The framework currently implements the basic job submission, custom settings job submission, write node selection, job attachments, and OCIO test cases, ensuring reliable end-to-end testing of the core submission workflow. This PR will introduce frame range test cases. The E2E tests currently only supports Mac. Support for other operating systems will come soon.
### What is the impact of this change?
Adds more E2E tests to Squish folder.
### How was this change tested?
The change was tested by running hatch run squish:test, which triggers the E2E integration tests in the run_squish_test.py file. Tests are optimized using pytest-xdist with -n 4 for parallel execution across 4 worker processes, while filelock ensures GUI operations remain sequential to prevent window overlap. This allows the non-GUI operations (like API calls and verification) to run in parallel while maintaining proper GUI synchronization, where a test's GUI portion must complete before the next one begins. This approach has significantly reduced test execution time from 40 minutes to approximately 10 minutes.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Yes, this change was documented in the SQUISH_README markdown file. The test cases were given a description of how they function in this markdown file.
### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
