### PR TITLE
chore: add native dependency psutil to deps bundle

### DIFF
--- a/scripts/depsBundle.py
+++ b/scripts/depsBundle.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
-NATIVE_DEPENDENCIES = ["xxhash"]
+NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 
 
 def _get_project_dict() -> dict[str, Any]:

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -91,6 +91,7 @@ def _validate_files(installation_path: Path) -> None:
     assert "deadline" in top_level_dir
     assert "qtpy" in top_level_dir
     assert "xxhash" in top_level_dir
+    assert "psutil" in top_level_dir
 
     # Check for menu.py which is part of the Nuke integration
     assert "menu.py" in top_level_dir


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We added a new dependency psutil to deadine-cloud https://github.com/aws-deadline/deadline-cloud/blob/e5176598cc859584217eaea00d5e6a14a40070d5/pyproject.toml#L47 for a new feature in experimental. This dependency has native components and needs to be added to deps bundle for every installer

### What was the solution? (How)
Added psutil to native dependencies for the feature to be supported.

### What is the impact of this change?
Bundling required dependencies for every submitter installer

### How was this change tested?
Built the installer
```
hatch run installer:build-installer --install-builder-path /Applications/InstallBuilder\ Enterprise\ 25.6.0 --output-dir . --lo
cal-dev --installer-source-path ./installer/DeadlineCloudForNuke.xml 

cwd: /Volumes/workplace/deadline-cloud-for-nuke
working directory: /var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmpxk9095g_
Collecting toml
  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Installing collected packages: toml
Successfully installed toml-0.10.2

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
Collecting deadline<0.51,>=0.49
  Using cached deadline-0.50.1-py3-none-any.whl.metadata (13 kB)
Collecting boto3>=1.36.8 (from deadline<0.51,>=0.49)
  Using cached boto3-1.39.4-py3-none-any.whl.metadata (6.6 kB)
Collecting click>=8.1.7 (from deadline<0.51,>=0.49)
  Using cached click-8.2.1-py3-none-any.whl.metadata (2.5 kB)
Collecting jsonschema<5.0,>=4.17 (from deadline<0.51,>=0.49)
  Using cached jsonschema-4.24.0-py3-none-any.whl.metadata (7.8 kB)
Collecting psutil>=7.0.0 (from deadline<0.51,>=0.49)
  Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl.metadata (22 kB)
Collecting pyyaml>=6.0 (from deadline<0.51,>=0.49)
  Using cached PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl.metadata (2.1 kB)
Collecting qtpy==2.4.* (from deadline<0.51,>=0.49)
  Using cached QtPy-2.4.3-py3-none-any.whl.metadata (12 kB)
Collecting typing-extensions>=4.8 (from deadline<0.51,>=0.49)
  Using cached typing_extensions-4.14.1-py3-none-any.whl.metadata (3.0 kB)
Collecting xxhash<3.6,>=3.4 (from deadline<0.51,>=0.49)
  Using cached xxhash-3.5.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (12 kB)
Collecting packaging (from qtpy==2.4.*->deadline<0.51,>=0.49)
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting botocore<1.40.0,>=1.39.4 (from boto3>=1.36.8->deadline<0.51,>=0.49)
  Using cached botocore-1.39.4-py3-none-any.whl.metadata (5.7 kB)
Collecting jmespath<2.0.0,>=0.7.1 (from boto3>=1.36.8->deadline<0.51,>=0.49)
  Using cached jmespath-1.0.1-py3-none-any.whl.metadata (7.6 kB)
Collecting s3transfer<0.14.0,>=0.13.0 (from boto3>=1.36.8->deadline<0.51,>=0.49)
  Using cached s3transfer-0.13.0-py3-none-any.whl.metadata (1.7 kB)
Collecting attrs>=22.2.0 (from jsonschema<5.0,>=4.17->deadline<0.51,>=0.49)
  Using cached attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema<5.0,>=4.17->deadline<0.51,>=0.49)
  Using cached jsonschema_specifications-2025.4.1-py3-none-any.whl.metadata (2.9 kB)
Collecting referencing>=0.28.4 (from jsonschema<5.0,>=4.17->deadline<0.51,>=0.49)
  Using cached referencing-0.36.2-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema<5.0,>=4.17->deadline<0.51,>=0.49)
  Using cached rpds_py-0.26.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (4.2 kB)
Collecting python-dateutil<3.0.0,>=2.1 (from botocore<1.40.0,>=1.39.4->boto3>=1.36.8->deadline<0.51,>=0.49)
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting urllib3!=2.2.0,<3,>=1.25.4 (from botocore<1.40.0,>=1.39.4->boto3>=1.36.8->deadline<0.51,>=0.49)
  Using cached urllib3-2.5.0-py3-none-any.whl.metadata (6.5 kB)
Collecting six>=1.5 (from python-dateutil<3.0.0,>=2.1->botocore<1.40.0,>=1.39.4->boto3>=1.36.8->deadline<0.51,>=0.49)
  Using cached six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Using cached deadline-0.50.1-py3-none-any.whl (278 kB)
Using cached QtPy-2.4.3-py3-none-any.whl (95 kB)
Using cached boto3-1.39.4-py3-none-any.whl (139 kB)
Using cached click-8.2.1-py3-none-any.whl (102 kB)
Using cached jsonschema-4.24.0-py3-none-any.whl (88 kB)
Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl (239 kB)
Using cached PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl (171 kB)
Using cached typing_extensions-4.14.1-py3-none-any.whl (43 kB)
Using cached xxhash-3.5.0-cp310-cp310-macosx_11_0_arm64.whl (30 kB)
Using cached attrs-25.3.0-py3-none-any.whl (63 kB)
Using cached botocore-1.39.4-py3-none-any.whl (13.8 MB)
Using cached jmespath-1.0.1-py3-none-any.whl (20 kB)
Using cached jsonschema_specifications-2025.4.1-py3-none-any.whl (18 kB)
Using cached referencing-0.36.2-py3-none-any.whl (26 kB)
Using cached rpds_py-0.26.0-cp310-cp310-macosx_11_0_arm64.whl (357 kB)
Using cached s3transfer-0.13.0-py3-none-any.whl (85 kB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached urllib3-2.5.0-py3-none-any.whl (129 kB)
Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: xxhash, urllib3, typing-extensions, six, rpds-py, pyyaml, psutil, packaging, jmespath, click, attrs, referencing, qtpy, python-dateutil, jsonschema-specifications, botocore, s3transfer, jsonschema, boto3, deadline
Successfully installed attrs-25.3.0 boto3-1.39.4 botocore-1.39.4 click-8.2.1 deadline-0.50.1 jmespath-1.0.1 jsonschema-4.24.0 jsonschema-specifications-2025.4.1 packaging-25.0 psutil-7.0.0 python-dateutil-2.9.0.post0 pyyaml-6.0.2 qtpy-2.4.3 referencing-0.36.2 rpds-py-0.26.0 s3transfer-0.13.0 six-1.17.0 typing-extensions-4.14.1 urllib3-2.5.0 xxhash-3.5.0

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp39-cp39-macosx_11_0_arm64.whl.metadata (12 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl.metadata (22 kB)
Using cached xxhash-3.5.0-cp39-cp39-macosx_11_0_arm64.whl (30 kB)
Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl (239 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (12 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl.metadata (22 kB)
Using cached xxhash-3.5.0-cp310-cp310-macosx_11_0_arm64.whl (30 kB)
Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl (239 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (12 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl.metadata (22 kB)
Using cached xxhash-3.5.0-cp311-cp311-macosx_11_0_arm64.whl (30 kB)
Using cached psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl (239 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
[PosixPath('/var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmp75b9tzq2/native'), PosixPath('/var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmp75b9tzq2/deadline_cloud_for_nuke_submitter-deps.zip'), PosixPath('/var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmp75b9tzq2/base_env')]
Running cmd: [PosixPath('/Applications/InstallBuilder Enterprise 25.6.0/bin/builder'), 'build', 'installer/DeadlineCloudForNuke.xml', 'osx', '--setvars', 'project.outputDirectory=/var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmpxk9095g_/out', 'project.version=00000000-2025-07-14']
------------------------------
Begin Install Builder Output
------------------------------
 Building AWS Deadline Cloud for Nuke Submitter osx
 0% ______________ 50% ______________ 100%
 #########################################

Built with an evaluation version of InstallBuilder

------------------------------
End Install Builder Output
------------------------------
```

#### Please run the integration tests and paste the results below
Unit tests:
```
Required test coverage of 72.0% reached. Total coverage: 74.41%
================================================================================ slowest 5 durations ================================================================================
0.12s call     test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py::TestNukeAdaptor_on_start::test_nuke_init_timeout
0.04s call     test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py::TestNukeAdaptor_on_start::test_nuke_init_fail
0.03s call     test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py::TestNukeAdaptor_on_run::test_on_run
0.03s call     test/unit/deadline_submitter_for_nuke/test_assets.py::test_get_scene_asset_references
0.02s call     test/unit/deadline_adaptor_for_nuke/NukeAdaptor/test_adaptor.py::TestNukeAdaptor_on_start::test_server_init_fail
================================================================================ 123 passed in 3.82s ================================================================================
(

```
#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

```
================================================================================ slowest 5 durations ================================================================================
13.78s setup    test/installer/test_installer.py::TestUserInstall::test_install
13.72s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
13.36s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
3.67s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
2.74s call     test/installer/test_installer.py::test_default_location
=========================================================================== 4 passed, 9 skipped in 18.66s ===========================================================================
(
```

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, unrelated to change

### Was this change documented?
Not required, I've followed the same process as ``xxhash``

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
