### PR TITLE
fix: resolve NUKE_PATH duplication when individual installer called f…

### DIFF
--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -47,7 +47,7 @@
                 <setInstallerVariable name="nuke_installdir" value="${installdir}" />
             </actionList>
             <elseActionList>
-                <setInstallerVariable name="nuke_installdir" value="${installdir}/Submitters/Nuke" />
+                <setInstallerVariable name="nuke_installdir" value="${installdir}" />
             </elseActionList>
         </if>
 	</readyToInstallActionList>


### PR DESCRIPTION
…rom combined installer

### What was the problem/requirement? (What/Why)

When pairing with our combined installer logic we would have a nested incorrect path

### What was the solution? (How)

Simplified the path by using whatever gets passed by combined installer

### What is the impact of this change?

Correct Nuke path for Mac

### How was this change tested?

rebuild installer to verify path is correct


### Was this change documented?

Documentation was changed accordingly to display nuke support for mac

### Is this a breaking change?
No
