### PR TITLE
fix: All Views rendering bug to properly render multiple views instea…

### DIFF
--- a/src/deadline/nuke_adaptor/NukeClient/nuke_handler.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_handler.py
@@ -191,9 +191,11 @@ class NukeHandler:
         views = data.get("views", [])
         NukeHandler._validate_non_empty_list_of_str(views, "views")
 
-        # The "All Views" value means to get all of them, and we do that per write node,
-        # therefore we don't set self.render_kwargs["views"] in this case.
+        # The "All Views" value means to get all of them from the script
         if views == ["All Views"]:
+            script_views = nuke.views()
+            if script_views:
+                self.render_kwargs["views"] = script_views
             return
 
         # Validate views exist in the nuke script

--- a/test/unit/deadline_adaptor_for_nuke/NukeClient/test_nuke_handler.py
+++ b/test/unit/deadline_adaptor_for_nuke/NukeClient/test_nuke_handler.py
@@ -413,6 +413,30 @@ class TestNukeHandler:
         # THEN
         assert nukehandler.render_kwargs["views"] == views
 
+    def test_set_views_all_views(self, views: List[str], nukehandler: NukeHandler):
+        # GIVEN
+        data = {"views": ["All Views"]}
+
+        # WHEN
+        nukehandler.set_views(data)
+
+        # THEN
+        # Should set render_kwargs["views"] to all views from the script
+        assert nukehandler.render_kwargs["views"] == views
+
+    def test_set_views_all_views_empty_script(self, nukehandler: NukeHandler):
+        # GIVEN
+        data = {"views": ["All Views"]}
+        # Mock nuke.views() to return empty list (script with no views)
+        nuke.views.return_value = []
+
+        # WHEN
+        nukehandler.set_views(data)
+
+        # THEN
+        # Should not set render_kwargs["views"] when script has no views
+        assert "views" not in nukehandler.render_kwargs
+
     missing_nodes_params = [
         (
             SortedList(["these", "do", "not", "exist"]),


### PR DESCRIPTION
…d of repeating first view

### What was the problem/requirement? (What/Why)

There is currently a bug in the submitter where if a customer picks "All Views" we actually don't include any of the views in the list on the adaptor logic. 

### What was the solution? (How)

Include all script views when "All Views" button is selected

### What is the impact of this change?

Correctly render all views in deadline cloud render farms.

### How was this change tested?
Added unit tests to verify logic works as intended, will also kick off a round of conda adaptor release for this change.
Built wheel files manually with the fixed adaptor, submitted a job that has the known issue, and verified that all views showed up in the output.

OS used: Mac
Nuke version: 16.0
SMF Linux
Conda Packages: nuke=16.* nuke-openjd=0.18.*

### Was this change documented?

No need for documentation change, this is a bugfix

### Is this a breaking change?
No
