### PR TITLE
fix: Correct the build installer command for Nuke in development readme

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,7 +21,7 @@ hatch build
 ### Build the installer
 
 ```bash
-hatch run build-installer --local-dev-build --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
+hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-path <LOCATION> --output-dir <DIR>]
 ```
 
 Run `hatch run build-installer -h` to see the full list of arguments.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The build-installer command documentation in DEVELOPMENT.md contained three incorrect parameter names:
1. Used `--local-dev-build` instead of the correct `--local-dev` flag
2. Omitted the required `installer:` prefix for the command
3. Used `--install-builder-location` instead of `--install-builder-path`

These documentation errors are causing confusion and command failures because the CLI implementation in `build_installer_cli.py` uses the correct parameter names I specified above.
Code from `build_installer_cli.py`:
```sh
@click.option(
    "--install-builder-path",
    type=Path,
    callback=_mutually_exclude(["install_builder_s3_bucket"]),
    help="The path to the InstallBuilder builder executable",
)
@click.option(
    "--local-dev",
    is_flag=True,
    callback=_combine_callbacks(
        _not_allowed_if_env_var_set("CODEBUILD_BUILD_ID"), _mutually_exclude(["dev"])
    ),
    help="If specified, build in local dev mode",
)
```
### What was the solution? (How)
Updated the build-installer command documentation in DEVELOPMENT.md to show the correct command format.
### What is the impact of this change?
It improves documentation accuracy and prrevents command failures due to incorrect parameter names.
### How was this change tested?
This change was tested on Mac, Windows, and Linux. The previous command in the readme did not work and was unable to build the installer. This new installer was tested by making sure that the command succeeded and that the installer file generated from this build command worked.

### Was this change documented?
The change was documented on the DEVELOPMENT.md readme file.
### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
