### PR TITLE
feat: Add Linux E2E testing support

### DIFF
--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -3,10 +3,23 @@
 Nuke and Squish require a license. If you have a Squish and Nuke license, please follow the guide below to run the tests. The current tests have been validated on macOS 15.5, Windows, and Linux.
 
 ## Prerequisites
+### Install Python
+
+Install Python 3.x on your system. This is required for running the test framework and managing dependencies.
+
 ### Install Nuke
 
 Download and install Nuke 16.0v1. 
 
+### Install Required Libraries
+Clone the required repositories:
+```sh
+# Clone the deadline-cloud repository
+git clone git@github.com:aws-deadline/deadline-cloud.git
+
+# Clone the deadline-cloud-for-nuke repository
+git clone git@github.com:aws-deadline/deadline-cloud-for-nuke.git
+```
 ### Set up the Deadline Cloud Nuke Submitter
 
 Read the DEVELOPMENT.md for instructions on setting up the Nuke submitter.
@@ -17,7 +30,9 @@ Install Squish 8.1.0 for Qt 6.5. If you are using any other version, be sure to 
 
 ### Set Up Test Assets
 
-The test suite includes large media files (images, movies) that are managed using Git LFS (Large File Storage). To properly clone and set up the test assets, install [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage). Then to download these files, run `git lfs pull`.
+The test suite includes large media files (images, movies) that are managed using Git LFS (Large File Storage). To properly clone and set up the test assets:
+1. Install [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage). 
+2. Run `git lfs pull` to download test assets.
 
 ## Configure Squish Environment
 
@@ -29,7 +44,7 @@ Import the test suite to Squish by going to 'File' -> 'Open Test Suite' and ente
 ```/Users/<user>/deadline-clients/deadline-cloud-for-nuke/test/squish/suite_nuke_submitter```
 
 #### For Windows: 
-```C:\Users\<user>\deadline-client\deadline-cloud-for-nuke\test\squish\suite_nuke_submitter```
+```C:\Users\<user>\deadline-clients\deadline-cloud-for-nuke\test\squish\suite_nuke_submitter```
 
 #### For Linux:
 ```/home/<user>/deadline-clients/deadline-cloud-for-nuke/test/squish/suite_nuke_submitter```
@@ -167,7 +182,7 @@ The test compares RGB values across the frames and calculates an average differe
 In the case changes are made to the Nuke script, such as adding color correction nodes, applying visual effects, or modifying render settings, the output images will likely differ from the reference images. When these changes are intentional, you should update the reference images to reflect the new expected output.
 
 ## Adding Tests
-New tests should be added to ```test/squish/suite_nuke_submitter/```. The test suite provides helper functions for common operations. Place test assets in nuke-assets/ and use Git LFS for large media files.
+New Squish GUI tests should be added to ```test/squish/suite_nuke_submitter/```. To add E2E tests that call these squish gui tests, add them to the ```run_squish_test.py``` file. The test suite provides helper functions for common operations. Place test assets in nuke-assets/ and use Git LFS for large media files.
 
 ## A Final Word on Testing
 The Deadline Cloud for Nuke test suite combines Squish UI automation with AWS infrastructure testing. Before submitting changes:
@@ -175,5 +190,12 @@ The Deadline Cloud for Nuke test suite combines Squish UI automation with AWS in
 - Run the full test suite locally
 - Ensure proper resource cleanup
 - Update documentation if adding new tests
+
+Cross-platform testing (Windows, macOS, Linux) is suggested when modifying:
+- File paths or environment variables
+- UI Interaction changes such as adding new UI elements or modifying Squish locators
+- System-specific features such as file permissions or shell commands
+
+Other changes such as job logic, documentation updates, and AWS resource handling can be tested on a single OS.
 
 For API details, consult the Squish and Deadline Cloud documentation.

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -3,20 +3,17 @@
 Nuke and Squish require a license. If you have a Squish and Nuke license, please follow the guide below to run the tests. The current tests have been validated on macOS 15.5, Windows, and Linux.
 
 ## Prerequisites
-### Install Python
+### Install Python and Deadline CLI
 
-Install Python 3.x on your system. This is required for running the test framework and managing dependencies.
+Install Python 3.x and the Deadline CLI on your system. This is required for running the test framework, submitting jobs, and managing dependencies.
 
 ### Install Nuke
 
 Download and install Nuke 16.0v1. 
 
-### Install Required Libraries
-Clone the required repositories:
+### Install Required Library
+Clone the required repository:
 ```sh
-# Clone the deadline-cloud repository
-git clone git@github.com:aws-deadline/deadline-cloud.git
-
 # Clone the deadline-cloud-for-nuke repository
 git clone git@github.com:aws-deadline/deadline-cloud-for-nuke.git
 ```

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -172,10 +172,10 @@ An unsuccessful test will show:
 - Assertion failures for squish commands, job submission, download, or job verification steps
 
 ### Image Verification Failures
-When image verification fails, you can check the output images located at `$NUKE_ASSET_ROOT/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output` 
+When image verification fails, you can check the output images located at `$DEADLINE_NUKE_PATH/test/squish/suite_nuke_submitter/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/output`.
 
 These output images can be compared with the expected reference images at:
-`$NUKE_ASSET_ROOT/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/expected`.
+`$DEADLINE_NUKE_PATH/test/squish/suite_nuke_submitter/nuke_test_samples/nuke_submitter_v02_nuke_default_test_samples/images/expected`.
 
 The test compares RGB values across the frames and calculates an average difference. A difference exceeding the tolerance (default: 0.1) will cause the test to fail.
 

--- a/test/squish/SQUISH_README.md
+++ b/test/squish/SQUISH_README.md
@@ -1,11 +1,11 @@
 # Nuke Submitter E2E Testing with Squish
 
-Nuke and Squish require a license. If you have a Squish and Nuke license, please follow the guide below to run the tests.
+Nuke and Squish require a license. If you have a Squish and Nuke license, please follow the guide below to run the tests. The current tests have been validated on macOS 15.5, Windows, and Linux.
 
 ## Prerequisites
 ### Install Nuke
 
-Download and install Nuke 16.0v1. The current tests have been validated on macOS 15.5 and Windows. Support for Linux will be added after macOS and Windows support is established. 
+Download and install Nuke 16.0v1. 
 
 ### Set up the Deadline Cloud Nuke Submitter
 
@@ -13,7 +13,7 @@ Read the DEVELOPMENT.md for instructions on setting up the Nuke submitter.
 
 ### Install Squish Framework
 
-Install Squish 8.1.0 for Qt 6.5. If you are using any other version, be sure to select the correct version of Qt that is being used with Nuke on your machine.
+Install Squish 8.1.0 for Qt 6.5. If you are using any other version, be sure to select the correct version of Qt that is being used with Nuke on your machine. Once installed, launch Squish IDE on your machine and follow the remaining instructions below.
 
 ### Set Up Test Assets
 
@@ -23,12 +23,16 @@ The test suite includes large media files (images, movies) that are managed usin
 
 Register Nuke as an AUT (Application Under Test) by going to 'Edit' -> 'Server Settings' and registering under 'Mapped AUTs' (in Squish IDE). 
 
-Import the test suite to Squish by going to 'File' -> 'Open Test Suite' and entering the test suite directory. 
-#### For Windows: 
-```C:\Users\<user>\deadline-client\deadline-cloud-for-nuke\test\squish\suite_nuke_submitter```
+Import the test suite to Squish by going to 'File' -> 'Open Test Suite' and entering the test suite directory. Make sure that the AUT subpage of the test suite has Nuke set as the AUT. The paths to the test suite directory may look like this:
 
 #### For macOS:
 ```/Users/<user>/deadline-clients/deadline-cloud-for-nuke/test/squish/suite_nuke_submitter```
+
+#### For Windows: 
+```C:\Users\<user>\deadline-client\deadline-cloud-for-nuke\test\squish\suite_nuke_submitter```
+
+#### For Linux:
+```/home/<user>/deadline-clients/deadline-cloud-for-nuke/test/squish/suite_nuke_submitter```
 
 \
 Then, configure the Nuke Submitter path by going to the test suite settings in the Squish IDE and adding an AUT environment variable called NUKE_PATH. Set it to the path where your Nuke submitter is installed: 
@@ -39,7 +43,7 @@ Then, configure the Nuke Submitter path by going to the test suite settings in t
 C:\path\to\DeadlineCloudForNukeSubmitter
 ```
 In the suite.conf file, set AUT to ```Nuke16.0```.
-#### For macOS:
+#### For macOS and Linux:
 ```sh
 /path/to/DeadlineCloudForNukeSubmitter
 ```
@@ -53,6 +57,8 @@ The following environment variables are required for running the tests:
 ```sh
 AWS_PROFILE=<profile name>
 DEADLINE_NUKE_PATH=/path/to/deadline-cloud-for-nuke
+SQUISH_FOLDER_PATH='/path/to/Squish for Qt 8.1.0'
+NUKE_FOLDER_PATH=/path/to/Nuke16.0v1
 ```
 
 ### Replace environment variables in Nuke Scripts
@@ -64,7 +70,10 @@ The test suite includes Nuke scripts that use environment variables in their fil
 cd deadline-cloud-for-nuke/test/squish/suite_nuke_submitter/shared/scripts/
 
 # Replace $DEADLINE_NUKE_PATH with actual paths
+# For MacOS/Linux:
 python3 replace_env_paths.py
+# For Windows:
+python replace_env_paths.py
 
 # To revert back to environment variables (if needed)
 python3 replace_env_paths.py --revert
@@ -85,7 +94,8 @@ The following Deadline Cloud resources are needed in order to run `tst_verify_se
 - A farm named "Nuke Submitter Squish Farm"
 - A queue named "Nuke Submitter Squish Automation Queue"
 - Three storage profiles named "Linux Storage Profile", "Windows Storage Profile", and "macOS Storage Profile"
-- Fleet instance market type of On-Demand instance
+- Fleet instance market type of On-Demand instance 
+- Fleet max auto scaling capacity of 10
 
 ## Available Tests
 
@@ -124,18 +134,17 @@ To install necessary dependencies to run the tests, run:
 ```sh
 hatch run squish:deps
 ```
+
 Then, to run the tests:
 ```sh
+# For Linux, connect to the squishserver in the background:
+/home/<user>/squish-for-qt-8.1.0/bin/squishserver
+
 hatch run squish:test
 ```
 To run a specific test:
 ```sh
-# Navigate to the scripts directory
-cd deadline-cloud-for-nuke/test/squish/suite_nuke_submitter
-
-# Run the testcase
-pytest run_squish_test.py::<testcase name>
-
+hatch run squish:test test/squish/suite_nuke_submitter/run_squish_test.py::<testcase>
 ```
 
 ## Test Results Interpretation
@@ -156,3 +165,15 @@ These output images can be compared with the expected reference images at:
 The test compares RGB values across the frames and calculates an average difference. A difference exceeding the tolerance (default: 0.1) will cause the test to fail.
 
 In the case changes are made to the Nuke script, such as adding color correction nodes, applying visual effects, or modifying render settings, the output images will likely differ from the reference images. When these changes are intentional, you should update the reference images to reflect the new expected output.
+
+## Adding Tests
+New tests should be added to ```test/squish/suite_nuke_submitter/```. The test suite provides helper functions for common operations. Place test assets in nuke-assets/ and use Git LFS for large media files.
+
+## A Final Word on Testing
+The Deadline Cloud for Nuke test suite combines Squish UI automation with AWS infrastructure testing. Before submitting changes:
+
+- Run the full test suite locally
+- Ensure proper resource cleanup
+- Update documentation if adding new tests
+
+For API details, consult the Squish and Deadline Cloud documentation.

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -26,10 +26,13 @@ def run_squish_command(testcase_name, local=True):
             - job_id (str or None): Extracted job ID from output if found, None otherwise
     """
     deadline_nuke_path = os.environ.get("DEADLINE_NUKE_PATH", "")
+    squish_folder_path = os.environ.get("SQUISH_FOLDER_PATH", "")
     if sys.platform == "win32":
-        squish_runner = pathlib.Path("C:/Program Files/Squish for Qt 8.1.0/bin/squishrunner.exe")
+        squish_runner = pathlib.Path(f"{squish_folder_path}/bin/squishrunner.exe")
+    elif sys.platform == "linux":
+        squish_runner = pathlib.Path(f"{squish_folder_path}/bin/squishrunner")
     else:
-        squish_runner = pathlib.Path("/Applications/Squish\\ for\\ Qt\\ 8.1.0/bin/squishrunner")
+        squish_runner = pathlib.Path(f"'{squish_folder_path}'/bin/squishrunner")
     testsuite_path = os.path.join(deadline_nuke_path, "test", "squish", "suite_nuke_submitter")
     testsuite_path = os.path.normpath(testsuite_path)
     local_flag = "--local" if local else ""
@@ -113,6 +116,8 @@ def test_valid_environment_variables():
     env_vars = {
         "AWS_PROFILE": {"check_path": False},
         "DEADLINE_NUKE_PATH": {"check_path": True},
+        "NUKE_FOLDER_PATH": {"check_path": True},
+        "SQUISH_FOLDER_PATH": {"check_path": True},
     }
 
     for var_name, var_spec in env_vars.items():
@@ -194,7 +199,8 @@ def check_platform():
     assert sys.platform in [
         "darwin",
         "win32",
-    ], "Deadline Nuke Squish Tests are only supported on macOS and Windows currently."
+        "linux",
+    ], "Deadline Nuke Squish Tests are only supported on macOS, Windows, and Linux."
 
 
 def test_basic_workflow(cleanup_render_outputs):
@@ -433,13 +439,19 @@ def test_ocio_job(cleanup_render_outputs):
     ocio_job = api_helpers.get_job(farm_id, queue_id, job_ids[0])
     print(json.dumps(ocio_job, indent=2, default=str))
 
+    nuke_folder_path = os.environ.get("NUKE_FOLDER_PATH", "")
     if sys.platform == "win32":
+        nuke_folder_path = nuke_folder_path.replace("/", "\\")
         ocio_config_path = pathlib.Path(
-            r"C:\Program Files\Nuke16.0v1\plugins\OCIOConfigs\configs\aces_1.2\config.ocio"
+            rf"{nuke_folder_path}\plugins\OCIOConfigs\configs\aces_1.2\config.ocio"
+        )
+    elif sys.platform == "linux":
+        ocio_config_path = pathlib.Path(
+            f"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
         )
     else:
         ocio_config_path = pathlib.Path(
-            "/Applications/Nuke16.0v1/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
+            f"{nuke_folder_path}/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
         )
     api_helpers.verify_ocio_config(ocio_config_path, ocio_job)
 
@@ -751,11 +763,18 @@ def test_manual_attachments(cleanup_render_outputs):
         "nukeTest_output_OCIO_v01",
         render_settings_path,
     )
-
-    win_path = r"C:/Program Files/Nuke16.0v1/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
-
-    mac_path = "/Applications/Nuke16.0v1/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
-    new_ocio_path = win_path if sys.platform == "win32" else mac_path
+    nuke_folder_path = os.environ.get("NUKE_FOLDER_PATH", "")
+    if sys.platform == "win32":
+        nuke_folder_path = nuke_folder_path.replace("\\", "/")
+    win_path = rf"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
+    linux_path = f"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
+    mac_path = f"{nuke_folder_path}/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
+    if sys.platform == "win32":
+        new_ocio_path = win_path
+    elif sys.platform == "linux":
+        new_ocio_path = linux_path
+    else:
+        new_ocio_path = mac_path
 
     with open(nk_script_path, "r") as file:
         lines = file.readlines()

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -766,7 +766,7 @@ def test_manual_attachments(cleanup_render_outputs):
     nuke_folder_path = os.environ.get("NUKE_FOLDER_PATH", "")
     if sys.platform == "win32":
         nuke_folder_path = nuke_folder_path.replace("\\", "/")
-        new_ocio_path = rf"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
+        new_ocio_path = f"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
     elif sys.platform == "linux":
         new_ocio_path = f"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
     else:

--- a/test/squish/suite_nuke_submitter/run_squish_test.py
+++ b/test/squish/suite_nuke_submitter/run_squish_test.py
@@ -766,15 +766,11 @@ def test_manual_attachments(cleanup_render_outputs):
     nuke_folder_path = os.environ.get("NUKE_FOLDER_PATH", "")
     if sys.platform == "win32":
         nuke_folder_path = nuke_folder_path.replace("\\", "/")
-    win_path = rf"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
-    linux_path = f"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
-    mac_path = f"{nuke_folder_path}/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
-    if sys.platform == "win32":
-        new_ocio_path = win_path
+        new_ocio_path = rf"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
     elif sys.platform == "linux":
-        new_ocio_path = linux_path
+        new_ocio_path = f"{nuke_folder_path}/plugins/OCIOConfigs/configs/aces_1.2/config.ocio"
     else:
-        new_ocio_path = mac_path
+        new_ocio_path = f"{nuke_folder_path}/Nuke16.0v1.app/Contents/Resources/OCIOConfigs/configs/aces_1.2/config.ocio"
 
     with open(nk_script_path, "r") as file:
         lines = file.readlines()

--- a/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/squish_helpers.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 def launch_nuke():
-    if sys.platform == "win32":
+    if sys.platform in ["win32", "linux"]:
         squish.startApplication("Nuke16.0")
     if sys.platform == "darwin":
         squish.startApplication("Nuke16.0v1")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Nuke Submitter does not currently have E2E testing, only unit testing. Manual testing of the Nuke Submitter is time-consuming and error-prone for developers, requiring them to repeatedly perform complex sequences of UI interactions, verify job submissions, and validate image outputs. There isn't comprehensive end-to-end testing for our Nuke integration, which may cause customers to face potential disruptions in their rendering workflows when new updates are released.

### What was the solution? (How)
The framework currently implements the basic job submission, custom settings job submission, write node selection, job attachments, OCIO test cases, and frame range test cases, ensuring reliable end-to-end testing of the core submission workflow. E2E testing currently supports Mac and Windows. This PR will introduce Linux testing support.
### What is the impact of this change?
Brings in Linux E2E test support.
### How was this change tested?
The change was tested by running hatch run squish:test, which triggers the E2E integration tests in the run_squish_test.py file. I used a Linux workstation instance hosted on EC2 to test these changes. I also used NICE DCV (Desktop Cloud Visualization), which is a remote desktop and streaming protocol, to remotely access a graphical Linux machine. This GUI experience provided by NICE DCV allows me to test these integration tests. I downloaded Nuke and Squish on Linux to test these changes and made sure that path management in these test cases worked properly on these three operating systems. I also tested these changes on macOS and Windows and made sure that the tests pass there as well.
#### Please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Yes, this change was documented in the SQUISH_README markdown file. Instructions on how to run the tests on both Mac, Windows, and Linux were given.
### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
