### PR TITLE
fix: fix behavior of automatic input / output path detection

### DIFF
--- a/job_bundle_output_tests/cwd-path/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/cwd-path/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/cwd-path.nk
 - name: ProxyMode
   value: 'false'
+- name: ContinueOnError
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/frame/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/frame/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: Write1
 - name: ProxyMode
   value: 'false'
+- name: ContinueOnError
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/group-read/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/group-read/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/group-read.nk
 - name: ProxyMode
   value: 'false'
+- name: ContinueOnError
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/multi-load-save/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/multi-load-save.nk
 - name: ProxyMode
   value: 'false'
+- name: ContinueOnError
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/noise-saver/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/noise-saver.nk
 - name: ProxyMode
   value: 'false'
+- name: ContinueOnError
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/ocio/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: /normalized/job/bundle/dir/config.ocio
 - name: ProxyMode
   value: 'false'
+- name: ContinueOnError
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os
 import re
-from collections.abc import Generator
-from os.path import commonpath, dirname, join, normpath, samefile
+import os
+from os.path import commonpath, dirname, join, normpath, samefile, isfile
+from dataclasses import dataclass
 from sys import platform
 import nuke
 
@@ -13,10 +13,18 @@ from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.nuke_util import ocio as nuke_ocio
 
-FRAME_REGEX = re.compile(r"(#+)|%(\d*)d", re.IGNORECASE)
+FRAME_VIEW_EXPRESSION_REGEX = re.compile(r"(%(\d*)d)|(%[vV])", re.IGNORECASE)
 FILE_KNOB_CLASS = "File_Knob"
 NUKE_WRITE_NODE_CLASSES: set[str] = {"Write", "DeepWrite", "WriteGeo"}
-JOB_ID_REGEX = re.compile(r"^job-[0-9a-z]{32}$")
+
+
+@dataclass
+class IOPath:
+    path: str
+    is_file: bool
+
+    def __hash__(self):
+        return self.path.__hash__()
 
 
 def get_nuke_script_file() -> str:
@@ -40,7 +48,7 @@ def get_scene_asset_references() -> AssetReferences:
     nuke.tprint("Walking node graph to auto-detect input/output asset references...")
     asset_references = AssetReferences()
     script_file = get_nuke_script_file()
-    if not os.path.isfile(script_file):
+    if not isfile(script_file):
         raise DeadlineOperationError(
             "The Nuke Script is not saved to disk. Please save it before opening the submitter dialog."
         )
@@ -57,7 +65,7 @@ def get_scene_asset_references() -> AssetReferences:
             is_read_node = read_knob.value()
 
         if is_read_node or node.Class() not in NUKE_WRITE_NODE_CLASSES:
-            for filename in get_node_filenames(node):
+            for iopath in get_input_paths_for_filenode(node):
                 # if the filename is in the install dir, ignore it.
                 if node is nuke.root():
                     # Windows / Linux
@@ -67,25 +75,31 @@ def get_scene_asset_references() -> AssetReferences:
                         # INSTALL_PATH: /Applications/Nuke15.0v2/Nuke15.0v2.app
                         install_path = dirname(dirname(dirname(nuke.EXE_PATH)))
                     try:
-                        common_file_path = commonpath((filename, install_path))
+                        common_file_path = commonpath((iopath.path, install_path))
                     except ValueError:
                         # Occurs if different drives, or mix of absolute + relative paths
                         pass
                     else:
                         if samefile(install_path, common_file_path):
                             continue
-                if not os.path.isdir(filename):
-                    asset_references.input_filenames.add(filename)
+
+                if iopath.is_file:
+                    asset_references.input_filenames.add(iopath.path)
+                else:
+                    asset_references.input_directories.add(iopath.path)
         else:
-            for filename in get_node_filenames(node):
-                asset_references.output_directories.add(dirname(filename))
+            for iopath in get_output_paths_for_filenode(node):
+                if iopath.is_file:
+                    asset_references.output_directories.add(dirname(iopath.path))
+                else:
+                    asset_references.output_directories.add(iopath.path)
 
     if nuke_ocio.is_OCIO_enabled():
         # Determine and add the config file and associated search directories
         ocio_config_path = nuke_ocio.get_ocio_config_path()
         # Add the references
         if ocio_config_path is not None:
-            if os.path.isfile(ocio_config_path):
+            if isfile(ocio_config_path):
                 asset_references.input_filenames.add(ocio_config_path)
 
                 ocio_config_search_paths = nuke_ocio.get_config_absolute_search_paths(
@@ -121,42 +135,103 @@ def find_all_write_nodes() -> set:
     return write_nodes
 
 
-def get_node_filenames(node) -> set[str]:
-    """Searches through all of a node's file knobs for potential filenames.
+def get_input_paths_for_filenode(node) -> set[IOPath]:
+    """Get all the file we will use as input for this node"""
 
-    Handles '%04d' or '####' style padding
-    """
-    filenames: set[str] = set()
-    for path in get_node_file_knob_paths(node):
-        found_frame_pattern = FRAME_REGEX.search(path)
-        if not found_frame_pattern:
-            filenames.add(path)
+    out = set()
+    for knob in node.allKnobs():
+        if knob.Class() != FILE_KNOB_CLASS or not knob.value():
             continue
 
-        # frame token pattern exists in filename
-        if found_frame_pattern.group(1):  # (#+)
-            padding_length = len(found_frame_pattern.group(1))  # type: int
-        else:  # %(\d*)d
-            # If no integer is provided, use 1 for the padding
-            padding_length = 1
-            if found_frame_pattern.group(2):
-                padding_length = int(found_frame_pattern.group(2))
+        context = nuke.OutputContext()
+        views = nuke.views()
+        project_path = get_project_path()
 
         for frame in node.frameRange():
-            evaluated_frame_string = str(frame).zfill(padding_length)
-            evaluated_filename = FRAME_REGEX.sub(evaluated_frame_string, path)  # type: str
-            filenames.add(evaluated_filename)
+            for view in views:
+                context.setFrame(frame)
+                context.setView(context.viewFromName(view))
+                out.add(
+                    IOPath(
+                        path=normpath(join(project_path, knob.getEvaluatedValue(context))),
+                        is_file=True,
+                    )
+                )
 
-    return filenames
+    return out
 
 
-def get_node_file_knob_paths(node) -> Generator[str, None, None]:
-    """Gets all file paths associated with a node"""
-    project_path = get_project_path()
+def get_output_paths_for_filenode(node) -> set[IOPath]:
+    """Get the directores or files we will pass to job attachments to capture all files consumed as input / produced as output for this node"""
+
+    out = set()
     for knob in node.allKnobs():
-        if knob.Class() == FILE_KNOB_CLASS and knob.value():
-            # If the knob value starts with a tcl expression, we evaluate it
-            if knob.value().startswith("["):
-                yield normpath(join(project_path, knob.getEvaluatedValue()))
+        if knob.Class() != FILE_KNOB_CLASS or not knob.value():
+            continue
+
+        # gets the file path, still containing %04d, %v or TCL expressions.
+        # note #### syntax for frames will be converted to %04d
+        # note backslashes for windows paths are converted to forward slashes
+        filepath = knob.value()
+        # evaluate any tcl expressions in the path
+        filepath = evaluate_tcl_subexpressions(filepath)
+
+        expression_match = FRAME_VIEW_EXPRESSION_REGEX.search(filepath)
+        path_is_file = True
+        if expression_match:
+            # in the case of an expression for frames / views, we will used the parent directory
+            # of the filenode containing the first expression
+
+            pos = expression_match.start()
+            # walk back to the nearest /
+            while pos >= 0 and filepath[pos] != "/":
+                pos -= 1
+
+            if pos == -1:
+                filepath = "./"
             else:
-                yield normpath(join(project_path, knob.value()))
+                filepath = filepath[: pos + 1]
+
+            path_is_file = False
+
+        project_path = get_project_path()
+        full_path = normpath(join(project_path, filepath))
+        out.add(IOPath(path=full_path, is_file=path_is_file))
+
+    return out
+
+
+def evaluate_tcl_subexpressions(string: str) -> str:
+    """Walk through a string, finding any tcl expressions (which are wrapped by []),
+    and replace them with their evaluation"""
+
+    # using list, then combining with join for efficiency
+    evaluated_string = []
+    bracket_nest_count = 0
+    current_tcl_expression = []
+
+    for c in string:
+        if c == "[":
+            # need to keep the [] for subexpressions
+            if bracket_nest_count > 0:
+                current_tcl_expression.append(c)
+
+            bracket_nest_count += 1
+
+        elif c == "]":
+            bracket_nest_count -= 1
+            if bracket_nest_count == 0:
+                # end tcl expression
+                evaluated_string.append(nuke.tcl("".join(current_tcl_expression)))
+                current_tcl_expression = []  # reset for any subsequent expressions
+            else:
+                # need to keep the [] for subexpressions
+                current_tcl_expression.append(c)
+
+        elif bracket_nest_count > 0:
+            # we are in an expression
+            current_tcl_expression.append(c)
+        else:
+            evaluated_string.append(c)
+
+    return "".join(evaluated_string)

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -15,8 +15,8 @@ from deadline.nuke_util import ocio as nuke_ocio
 
 # Nuke allows the use of printf style expressions in path names to be evaluated to the current frame number
 # and view being rendered. For example %04d would be the current frame number zero padded to be at least 4 digits.
-# %v or %V will be evaluated to the first character, or full name of the current view. 
-# 
+# %v or %V will be evaluated to the first character, or full name of the current view.
+#
 # Note Nuke also allows the use of '####' to describe a frame number as well, but we do not need to match
 # this since the knob.value() translates it to an equivalent printf style expression.
 # E.g. frame_####.exr becomes frame_%04d.exr.
@@ -187,7 +187,9 @@ def get_output_paths_for_filenode(node) -> set[IOPath]:
         if expression_match:
             # in the case of an expression for frames / views, we will used the parent directory
             # of the filenode containing the first expression
-            nuke.tprint(f"found printf style expression {expression_match.group(1)} starting at index {expression_match.start()} in path {filepath}")
+            nuke.tprint(
+                f"found printf style expression {expression_match.group(1)} starting at index {expression_match.start()} in path {filepath}"
+            )
 
             pos = expression_match.start()
             # walk back to the nearest /
@@ -195,7 +197,9 @@ def get_output_paths_for_filenode(node) -> set[IOPath]:
                 pos -= 1
 
             if pos == -1:
-                nuke.tprint("Did not find a written directory above the filenode where the expression appears. Using ./ as the output path.")
+                nuke.tprint(
+                    "Did not find a written directory above the filenode where the expression appears. Using ./ as the output path."
+                )
                 filepath = "./"
             else:
                 filepath = filepath[: pos + 1]
@@ -232,8 +236,10 @@ def evaluate_tcl_subexpressions(string: str) -> str:
                 # end tcl expression
                 expression = "".join(current_tcl_expression)
                 expression_evaluation = nuke.tcl(expression)
-                
-                nuke.tprint(f"Parsed expression [{expression}] in string {string}, which evaluated to {expression_evaluation}")
+
+                nuke.tprint(
+                    f"Parsed expression [{expression}] in string {string}, which evaluated to {expression_evaluation}"
+                )
 
                 evaluated_string.append(expression_evaluation)
                 current_tcl_expression = []  # reset for any subsequent expressions

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -13,7 +13,14 @@ from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.nuke_util import ocio as nuke_ocio
 
-FRAME_VIEW_EXPRESSION_REGEX = re.compile(r"(%(\d*)d)|(%[vV])", re.IGNORECASE)
+# Nuke allows the use of printf style expressions in path names to be evaluated to the current frame number
+# and view being rendered. For example %04d would be the current frame number zero padded to be at least 4 digits.
+# %v or %V will be evaluated to the first character, or full name of the current view. 
+# 
+# Note Nuke also allows the use of '####' to describe a frame number as well, but we do not need to match
+# this since the knob.value() translates it to an equivalent printf style expression.
+# E.g. frame_####.exr becomes frame_%04d.exr.
+FRAME_VIEW_EXPRESSION_REGEX = re.compile(r"(%(\d*)d)|(%v)", re.IGNORECASE)
 FILE_KNOB_CLASS = "File_Knob"
 NUKE_WRITE_NODE_CLASSES: set[str] = {"Write", "DeepWrite", "WriteGeo"}
 
@@ -83,10 +90,9 @@ def get_scene_asset_references() -> AssetReferences:
                         if samefile(install_path, common_file_path):
                             continue
 
-                if iopath.is_file:
-                    asset_references.input_filenames.add(iopath.path)
-                else:
-                    asset_references.input_directories.add(iopath.path)
+                # get_input_paths always returns filepaths, not directories.
+                asset_references.input_filenames.add(iopath.path)
+
         else:
             for iopath in get_output_paths_for_filenode(node):
                 if iopath.is_file:
@@ -181,6 +187,7 @@ def get_output_paths_for_filenode(node) -> set[IOPath]:
         if expression_match:
             # in the case of an expression for frames / views, we will used the parent directory
             # of the filenode containing the first expression
+            nuke.tprint(f"found printf style expression {expression_match.group(1)} starting at index {expression_match.start()} in path {filepath}")
 
             pos = expression_match.start()
             # walk back to the nearest /
@@ -188,6 +195,7 @@ def get_output_paths_for_filenode(node) -> set[IOPath]:
                 pos -= 1
 
             if pos == -1:
+                nuke.tprint("Did not find a written directory above the filenode where the expression appears. Using ./ as the output path.")
                 filepath = "./"
             else:
                 filepath = filepath[: pos + 1]
@@ -222,7 +230,12 @@ def evaluate_tcl_subexpressions(string: str) -> str:
             bracket_nest_count -= 1
             if bracket_nest_count == 0:
                 # end tcl expression
-                evaluated_string.append(nuke.tcl("".join(current_tcl_expression)))
+                expression = "".join(current_tcl_expression)
+                expression_evaluation = nuke.tcl(expression)
+                
+                nuke.tprint(f"Parsed expression [{expression}] in string {string}, which evaluated to {expression_evaluation}")
+
+                evaluated_string.append(expression_evaluation)
                 current_tcl_expression = []  # reset for any subsequent expressions
             else:
                 # need to keep the [] for subexpressions

--- a/test/unit/deadline_submitter_for_nuke/test_assets.py
+++ b/test/unit/deadline_submitter_for_nuke/test_assets.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock, Mock, patch
 
 import nuke
@@ -11,8 +10,9 @@ import pytest
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.nuke_submitter.assets import (
     find_all_write_nodes,
-    get_node_file_knob_paths,
-    get_node_filenames,
+    get_input_paths_for_filenode,
+    get_output_paths_for_filenode,
+    IOPath,
     get_scene_asset_references,
 )
 
@@ -30,11 +30,14 @@ def _activated_reading_write_node_knobs(knob_name: str):
     return knobs[knob_name]
 
 
-@patch("os.path.isfile", return_value=True)
+@patch("deadline.nuke_submitter.assets.isfile", return_value=True)
 @patch("deadline.nuke_submitter.assets.get_nuke_script_file", return_value="/this/scriptfile.nk")
 @patch(
-    "deadline.nuke_submitter.assets.get_node_filenames",
-    return_value=["/one/asset.png", "/two/asset.png"],
+    "deadline.nuke_submitter.assets.get_input_paths_for_filenode",
+    return_value=[
+        IOPath(path="/one/asset.png", is_file=True),
+        IOPath(path="/two/asset.png", is_file=True),
+    ],
 )
 @patch("deadline.nuke_util.ocio.is_custom_config_enabled", return_value=False)
 @patch("deadline.nuke_util.ocio.is_stock_config_enabled", return_value=False)
@@ -58,7 +61,7 @@ def test_get_scene_asset_references(
     mock_path_isfile: Mock,
 ):
     # GIVEN
-    expected_assets = mock_get_node_filenames.return_value
+    expected_assets = [result.path for result in mock_get_node_filenames.return_value]
     expected_script_file = mock_get_nuke_script_file.return_value
     nuke.allNodes.return_value = []
 
@@ -175,97 +178,156 @@ def test_find_all_write_nodes():
 @pytest.mark.parametrize(
     "asset_path,formatted_paths",
     [
-        ("/path/to/file_with_no_frames.png", {"/path/to/file_with_no_frames.png"}),
         (
-            "/path/to/file.####.hash",
+            "path/to/file_with_no_frames.png",
+            {IOPath(path="/project_path/path/to/file_with_no_frames.png", is_file=True)},
+        ),
+        (
+            "path/to/file.####.hash",
             {
-                "/path/to/file.0000.hash",
-                "/path/to/file.0001.hash",
-                "/path/to/file.0002.hash",
-                "/path/to/file.0100.hash",
+                IOPath(path="/project_path/path/to/file.0001.hash", is_file=True),
+                IOPath(path="/project_path/path/to/file.0002.hash", is_file=True),
+                IOPath(path="/project_path/path/to/file.0003.hash", is_file=True),
             },
         ),
         (
-            "/path/to/file.#.hash",
+            "/path/to/frame.####/frame.png",
             {
-                "/path/to/file.0.hash",
-                "/path/to/file.1.hash",
-                "/path/to/file.2.hash",
-                "/path/to/file.100.hash",
+                IOPath(path="/path/to/frame.0001/frame.png", is_file=True),
+                IOPath(path="/path/to/frame.0002/frame.png", is_file=True),
+                IOPath(path="/path/to/frame.0003/frame.png", is_file=True),
             },
         ),
         (
-            r"/path/to/file.%04d.formatting",
+            "[some_tcl_expression of [stuff]]/path/to/frame.####/frame.png",
             {
-                "/path/to/file.0000.formatting",
-                "/path/to/file.0001.formatting",
-                "/path/to/file.0002.formatting",
-                "/path/to/file.0100.formatting",
-            },
-        ),
-        (
-            r"/path/to/file.%d.formatting",
-            {
-                "/path/to/file.0.formatting",
-                "/path/to/file.1.formatting",
-                "/path/to/file.2.formatting",
-                "/path/to/file.100.formatting",
+                IOPath(path="/tcl_returned_path/path/to/frame.0001/frame.png", is_file=True),
+                IOPath(path="/tcl_returned_path/path/to/frame.0002/frame.png", is_file=True),
+                IOPath(path="/tcl_returned_path/path/to/frame.0003/frame.png", is_file=True),
             },
         ),
     ],
 )
-@patch("deadline.nuke_submitter.assets.get_node_file_knob_paths")
-def test_get_node_filenames(mock_get_node_file_knob_paths: Mock, asset_path, formatted_paths):
+@patch("deadline.nuke_submitter.assets.nuke")
+@patch("deadline.nuke_submitter.assets.get_project_path")
+def test_get_input_paths_for_filenode(
+    mock_get_project_path: Mock, mock_nuke: Mock, asset_path, formatted_paths
+):
     # GIVEN
-    node_filepaths = [asset_path]
-    mock_get_node_file_knob_paths.side_effect = lambda node: (path for path in node_filepaths)
+    mock_get_project_path.return_value = "/project_path"
+
+    output_context = MagicMock()
+
+    def update_frame(frame):
+        output_context.frame = frame
+
+    output_context.setFrame.side_effect = update_frame
+
+    mock_nuke.OutputContext.return_value = output_context
+    mock_nuke.views.return_value = "main"
+
     node = MagicMock()
-    node.frameRange.return_value = [0, 1, 2, 100]
+    node.frameRange.return_value = [1, 2, 3]
+    mock_path_knob = MagicMock()
+    mock_path_knob.Class.return_value = "File_Knob"
+
+    def evaluate_path(context):
+        tcl_subbed = asset_path.replace("[some_tcl_expression of [stuff]]", "/tcl_returned_path")
+        return tcl_subbed.replace("####", str(context.frame).zfill(4))
+
+    mock_path_knob.getEvaluatedValue.side_effect = evaluate_path
+    node.allKnobs.return_value = [mock_path_knob]
 
     # WHEN
-    results = get_node_filenames(node)
+    results = get_input_paths_for_filenode(node)
+
+    results = {
+        # fix windows pathing
+        IOPath(path=result.path.replace("\\", "/"), is_file=result.is_file)
+        for result in results
+    }
 
     # THEN
     assert results == formatted_paths
 
 
+@pytest.mark.parametrize(
+    "asset_path,formatted_paths",
+    [
+        (
+            "path/to/file_with_no_frames.png",
+            {IOPath(path="/project_path/path/to/file_with_no_frames.png", is_file=True)},
+        ),
+        (
+            "path/to/file.####.hash",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+        (
+            "path/to/frame.##/frame.png",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+        (
+            "./path/to/frame.##/frame.png",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+        (
+            "path/views/%v/to/frame.##/frame.png",
+            {IOPath(path="/project_path/path/views", is_file=False)},
+        ),
+        (
+            "path/views/%V/to/frame.##/frame.png",
+            {IOPath(path="/project_path/path/views", is_file=False)},
+        ),
+        (
+            "path/to/frame_%05d/views/%v/frame.png",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+        (
+            "[some_tcl_expression of [stuff]]/path/to/frame.##/frame.png",
+            {IOPath(path="/tcl_returned_path/path/to", is_file=False)},
+        ),
+        (
+            "path/to/frame.##/frame.png",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+        (
+            r"path/to/file.%04d.formatting",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+        (
+            r"path/to/file.%d.formatting",
+            {IOPath(path="/project_path/path/to", is_file=False)},
+        ),
+    ],
+)
+@patch("deadline.nuke_submitter.assets.nuke")
 @patch("deadline.nuke_submitter.assets.get_project_path")
-def test_get_node_file_knob_paths(mock_project_path: Mock):
+def test_get_output_paths_for_filenode(
+    mock_get_project_path: Mock, mock_nuke: Mock, asset_path, formatted_paths
+):
     # GIVEN
-    mock_project_path.return_value = os.path.join("project", "path")
-    mock_other_knob = MagicMock()
-    mock_other_knob.Class.return_value = "NotAFileKnob"
+    mock_get_project_path.return_value = "/project_path"
 
-    mock_tcl_file_knob = MagicMock()
-    mock_tcl_file_knob.Class.return_value = "File_Knob"
-    mock_tcl_file_knob.value.return_value = "[this is a tcl expression]"
-    mock_tcl_file_knob.getEvaluatedValue.return_value = os.path.join("evaluated", "tcl", "path")
+    mock_tcl = MagicMock()
+    mock_tcl.return_value = "/tcl_returned_path"
+    mock_nuke.tcl.return_value = mock_tcl()
 
-    mock_file_knob = MagicMock()
-    mock_file_knob.Class.return_value = "File_Knob"
-    mock_file_knob.value.return_value = os.path.join("this", "is", "a", "path")
-    mock_node = MagicMock()
-    mock_node.allKnobs.return_value = []
+    def sub_hashes(path):
+        # mimicking that node.value() will replace hashes with equivalent %0nd syntax for frame subs
+        return path.replace("####", "%04d").replace("##", "%02d")
+
+    node = MagicMock()
+    mock_path_knob = MagicMock()
+    mock_path_knob.Class.return_value = "File_Knob"
+    mock_path_knob.value.return_value = sub_hashes(asset_path)
+    node.allKnobs.return_value = [mock_path_knob]
 
     # WHEN
-    results = get_node_file_knob_paths(mock_node)
-    # THEN
-    with pytest.raises(StopIteration):
-        next(results)
+    results = get_output_paths_for_filenode(node)
 
-    # GIVEN
-    mock_node.allKnobs.return_value = [
-        mock_other_knob,
-        mock_tcl_file_knob,
-        mock_file_knob,
-    ]
-    mock_node.reset_mock()
-
-    # WHEN
-    results = get_node_file_knob_paths(mock_node)
+    results = {
+        IOPath(path=result.path.replace("\\", "/"), is_file=result.is_file) for result in results
+    }  # fix windows pathing
 
     # THEN
-    assert next(results) == os.path.join(
-        mock_project_path(), mock_tcl_file_knob.getEvaluatedValue()
-    )
-    assert next(results) == os.path.join(mock_project_path(), mock_file_knob.value())
+    assert results == formatted_paths


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We have a couple bugs with how we are generating input / output paths for job attachments.

The first bug is just that we weren't considering the %v or %V expressions correctly, so projects that had multiple views weren't going to work properly. 

The other bug is that paths containing TCL expressions were not being evaluated correctly. In the case of something like `[tcl expression]/output/frame_####.png` this ends up working out OK, as we just give the parent directory of the file to job attachments. But if the path was `[tcl expression]/output/frame_####/frame.png`, then you end up with with the output directories being something like `evaluted_path/output/frame_0450` rather than having a directory for frame_0000, frame_0001, etc.

### What was the solution? (How)

For input files, pass in context with each view and frame combination to getEvaluatedValue() to get all paths. For output files, just use the parent dir of the first filenode in the path containing an expression

### What is the impact of this change?

fix bugs related to input / output filepaths for job attachments

### How was this change tested?

added new unit tests, added new test cases, tested job bundle output tests.

tested with a couple nuke scenes containing multiple views. tested rendering locally, submitting to deadline, and confirmed downloaded output matched local results.

#### Please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

did not modify any files under `installer`

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here


Timestamp: 2025-08-18T15:50:57.611129-07:00
Running job bundle output test: C:\Users\npmac\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\cwd-path

cwd-path
Test succeeded

Timestamp: 2025-08-18T15:50:58.365645-07:00
Running job bundle output test: C:\Users\npmac\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\frame

frame
Test succeeded

Timestamp: 2025-08-18T15:50:58.857421-07:00
Running job bundle output test: C:\Users\npmac\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\group-read

group-read
Test succeeded

Timestamp: 2025-08-18T15:50:59.333041-07:00
Running job bundle output test: C:\Users\npmac\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\multi-load-save

multi-load-save
Test succeeded

Timestamp: 2025-08-18T15:50:59.894408-07:00
Running job bundle output test: C:\Users\npmac\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\noise-saver

noise-saver
Test succeeded

Timestamp: 2025-08-18T15:51:00.462525-07:00
Running job bundle output test: C:\Users\npmac\deadline-clients\deadline-cloud-for-nuke\job_bundle_output_tests\ocio

ocio
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2025-08-18T15:51:03.382003-07:00

```

### Was this change documented?
no

### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
