### PR TITLE
fix: Remove unbounded lru_cache

### DIFF
--- a/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
+++ b/src/deadline/nuke_adaptor/NukeClient/nuke_client.py
@@ -37,6 +37,10 @@ except ImportError:
     from deadline.nuke_util import ocio as nuke_ocio
 
 
+# Maximum size for LRU caches to prevent unbounded memory growth
+_LRU_CACHE_MAX_SIZE = 512
+
+
 class NukeClient(_ClientInterface):
     """
     Client for that runs in Nuke for the Nuke Adaptor
@@ -74,7 +78,7 @@ class NukeClient(_ClientInterface):
         nuke.scriptClose()
         nuke.scriptExit()
 
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=_LRU_CACHE_MAX_SIZE)
     def map_path(self, path: str) -> str:
         """
         Override of the base map_path implementation to return the mapped path without back slashes.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had one unbounded lru_cache in the package.

### What was the solution? (How)

Added a fixed size for it.

### What is the impact of this change?

Unbounded caches can lead to high memory utilization and crashes, it's better if we set it to some max size.

### How was this change tested?

Unit testing and building installer manually and submitting a rendering job.

### Was this change documented?

No need for documentation changes.

### Is this a breaking change?
No