### PR TITLE
feat: add submitter for copycat.

### DIFF
--- a/src/deadline/nuke_adaptor/copycat_adaptor.py
+++ b/src/deadline/nuke_adaptor/copycat_adaptor.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import time
+import pathlib
 from typing import Dict, List, Optional, TextIO, Tuple
 
 error_regex = re.compile(r".*(ERROR: |Error ?:|Eddy\[ERROR\])(.+)")
@@ -74,7 +75,7 @@ def _stream_reader(stream_name: str, stream: TextIO, logger: logging.Logger):
 
 def get_nuke_remap_string(path_mapping_rules: List[Dict[str, str]]) -> str:
     return ",".join(
-        path.replace("\\", "/")
+        pathlib.Path(path.replace("\\", "/")).as_posix()
         for rule in path_mapping_rules
         for path in (rule["source_path"], rule["destination_path"])
     )
@@ -103,7 +104,6 @@ def run_adaptor(
         "-F",  # when running copycat we specify to execute only a single "frame"
         "1",
         "--gpu",
-        nuke_script_path,
     ]
 
     if path_mapping_rules_path:
@@ -116,6 +116,8 @@ def run_adaptor(
             "--remap",
             nuke_path_mapping_string,
         ]
+
+    nuke_run_copycat_args.append(nuke_script_path)  # positional argument needs to be last
 
     if using_stubber_for_nuke:
         nuke_run_copycat_args.insert(0, "python")

--- a/src/deadline/nuke_submitter/__init__.py
+++ b/src/deadline/nuke_submitter/__init__.py
@@ -2,14 +2,16 @@
 
 from ._logging import get_logger
 from ._version import __version__
-from .deadline_submitter_for_nuke import show_nuke_render_submitter_noargs
+from .deadline_submitter_for_nuke import show_nuke_render_submitter
 from .job_bundle_output_test_runner import run_render_submitter_job_bundle_output_test
+from .data_classes import JobType
 
 logger = get_logger("deadline")
 
 __all__ = [
     "__version__",
     "logger",
-    "show_nuke_render_submitter_noargs",
+    "show_nuke_render_submitter",
     "run_render_submitter_job_bundle_output_test",
+    "JobType",
 ]

--- a/src/deadline/nuke_submitter/assets.py
+++ b/src/deadline/nuke_submitter/assets.py
@@ -22,6 +22,7 @@ from deadline.nuke_util import ocio as nuke_ocio
 FRAME_VIEW_EXPRESSION_REGEX = re.compile(r"(%(\d*)d)|(%v)|(#+)", re.IGNORECASE)
 FILE_KNOB_CLASS = "File_Knob"
 NUKE_WRITE_NODE_CLASSES: set[str] = {"Write", "DeepWrite", "WriteGeo"}
+COPYCAT_NODE_CLASS: str = "CopyCat"
 
 
 @dataclass
@@ -142,6 +143,10 @@ def get_scene_asset_references() -> AssetReferencesParsingOutcome:
     return outcome
 
 
+def find_all_copycat_nodes() -> set:
+    return {node for node in nuke.allNodes() if node.Class() == COPYCAT_NODE_CLASS}
+
+
 def find_all_write_nodes() -> set:
     write_nodes = set()
 
@@ -165,13 +170,27 @@ def get_input_paths_for_filenode(node) -> set[IOPath]:
     """Get all the file we will use as input for this node"""
 
     out = set()
+    project_path = get_project_path()
+    context = nuke.OutputContext()
+    views = nuke.views()
+
+    if node.Class() == COPYCAT_NODE_CLASS:
+        # CopyCat nodes can optionally reference a .cat file as initial weights.
+        # we need to add that file to attachments if it is used.
+        initial_weights_knob = node.knob("initialWeights")
+        if initial_weights_knob.value() == "Checkpoint":
+            out.add(
+                IOPath(
+                    path=normpath(
+                        join(project_path, node.knob("checkpointFile").getEvaluatedValue(context))
+                    ),
+                    is_file=True,
+                )
+            )
+        return out
     for knob in node.allKnobs():
         if knob.Class() != FILE_KNOB_CLASS or not knob.value():
             continue
-
-        context = nuke.OutputContext()
-        views = nuke.views()
-        project_path = get_project_path()
 
         for frame in node.frameRange():
             for view in views:

--- a/src/deadline/nuke_submitter/copycat_job_template.yaml
+++ b/src/deadline/nuke_submitter/copycat_job_template.yaml
@@ -24,7 +24,7 @@ parameterDefinitions:
 - name: DataDir
   type: PATH
   objectType: DIRECTORY
-  dataFlow: INOUT
+  dataFlow: OUT
   userInterface:
     control: CHOOSE_DIRECTORY
     label: Data Directory
@@ -53,11 +53,6 @@ steps:
         set -xeuo pipefail
 
         mkdir -p {{Param.DataDir}}
-
-        # Nukes path mapping does not work for the CopyCat data directory, so we have to
-        # directly modify the nuke script to inject the mapped path.
-        ESCAPED_DATA_DIR=$(echo "{{Param.DataDir}}" | sed 's/\//\\\//g')
-        sed -i "s/dataDirectory .*/dataDirectory ${ESCAPED_DATA_DIR}/" {{Param.NukeScriptFile}}
 
         python '{{Param.CopyCatAdaptor}}' \
         --nuke nuke \

--- a/src/deadline/nuke_submitter/data_classes.py
+++ b/src/deadline/nuke_submitter/data_classes.py
@@ -3,15 +3,38 @@
 from __future__ import annotations
 
 import dataclasses
+from dataclasses import dataclass, field, is_dataclass
 import json
-from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Union, Dict, Any
+from enum import Enum
 
 RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
+COPYCAT_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_copycat_settings.json"
+
+
+class JobType(Enum):
+    RENDER = "render"
+    COPYCAT_TRAINING = "copycat_training"
 
 
 @dataclass
-class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
+class RenderSettings:
+    override_frame_range: bool = field(default=False, metadata={"sticky": True})
+    frame_list: str = field(default="", metadata={"sticky": True})
+    write_node_selection: str = field(default="", metadata={"sticky": True})
+    view_selection: str = field(default="", metadata={"sticky": True})
+    is_proxy_mode: bool = field(default=False, metadata={"sticky": True})
+    continue_on_error: bool = field(default=False, metadata={"sticky": True})
+
+
+@dataclass
+class CopyCatTrainingSettings:
+    copycat_node: str = field(default="", metadata={"sticky": True})
+
+
+@dataclass
+class SubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     """
     Settings that the submitter UI will use
     """
@@ -21,12 +44,9 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     name: str = field(default="", metadata={"sticky": True})
     description: str = field(default="", metadata={"sticky": True})
 
-    override_frame_range: bool = field(default=False, metadata={"sticky": True})
-    frame_list: str = field(default="", metadata={"sticky": True})
-    write_node_selection: str = field(default="", metadata={"sticky": True})
-    view_selection: str = field(default="", metadata={"sticky": True})
-    is_proxy_mode: bool = field(default=False, metadata={"sticky": True})
-    continue_on_error: bool = field(default=False, metadata={"sticky": True})
+    jobtype_specific_settings: Union[CopyCatTrainingSettings, RenderSettings] = field(
+        default_factory=RenderSettings, metadata={"sticky": True}
+    )
 
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
@@ -42,25 +62,43 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 
+    def get_job_type(self):
+        return (
+            JobType.RENDER
+            if type(self.jobtype_specific_settings) is RenderSettings
+            else JobType.COPYCAT_TRAINING
+        )
+
+    def _load_sticky_settings_from_dict(self, sticky_settings: dict):
+        if isinstance(sticky_settings, dict):
+            sticky_fields = {
+                field.name: field
+                for field in dataclasses.fields(self)
+                if field.metadata.get("sticky")
+            }
+            jobtype_specific_sticky_fields = {
+                field.name: field
+                for field in dataclasses.fields(self.jobtype_specific_settings)
+                if field.metadata.get("sticky")
+            }
+            for name, value in sticky_settings.items():
+                # Only set fields that are defined in the dataclass
+                if name in sticky_fields:
+                    setattr(self, name, value)
+                if name in jobtype_specific_sticky_fields:
+                    setattr(self.jobtype_specific_settings, name, value)
+
     def load_sticky_settings(self, scene_filename: str):
         sticky_settings_filename = Path(scene_filename).with_suffix(
             RENDER_SUBMITTER_SETTINGS_FILE_EXT
+            if self.get_job_type() == JobType.RENDER
+            else COPYCAT_SUBMITTER_SETTINGS_FILE_EXT
         )
         if sticky_settings_filename.exists() and sticky_settings_filename.is_file():
             try:
                 with open(sticky_settings_filename, encoding="utf8") as fh:
                     sticky_settings = json.load(fh)
-
-                if isinstance(sticky_settings, dict):
-                    sticky_fields = {
-                        field.name: field
-                        for field in dataclasses.fields(self)
-                        if field.metadata.get("sticky")
-                    }
-                    for name, value in sticky_settings.items():
-                        # Only set fields that are defined in the dataclass
-                        if name in sticky_fields:
-                            setattr(self, name, value)
+                self._load_sticky_settings_from_dict(sticky_settings)
             except (OSError, json.JSONDecodeError):
                 # If something bad happened to the sticky settings file,
                 # just use the defaults instead of producing an error.
@@ -71,14 +109,34 @@ class RenderSubmitterUISettings:  # pylint: disable=too-many-instance-attributes
                     f"WARNING: Failed to load sticky settings file {sticky_settings_filename}, reverting to the default settings."
                 )
 
+    def _get_sticky_settings_dict(self) -> Dict[str, Any]:
+        # flattening makes this more complicated, but is necessary for backwards compatibility
+        def get_flat_dict_of_sticky_attributes(obj) -> Dict[str, Any]:
+            output = {}
+
+            for attr_field in dataclasses.fields(obj):
+                if not attr_field.metadata.get("sticky"):
+                    continue
+
+                attr = getattr(obj, attr_field.name)
+                if is_dataclass(attr):
+                    flattened = get_flat_dict_of_sticky_attributes(attr)
+                    for k, v in flattened.items():
+                        output[k] = v
+                else:
+                    output[attr_field.name] = attr
+
+            return output
+
+        return get_flat_dict_of_sticky_attributes(self)
+
     def save_sticky_settings(self, scene_filename: str):
         sticky_settings_filename = Path(scene_filename).with_suffix(
             RENDER_SUBMITTER_SETTINGS_FILE_EXT
+            if self.get_job_type() == JobType.RENDER
+            else COPYCAT_SUBMITTER_SETTINGS_FILE_EXT
         )
+
         with open(sticky_settings_filename, "w", encoding="utf8") as fh:
-            obj = {
-                field.name: getattr(self, field.name)
-                for field in dataclasses.fields(self)
-                if field.metadata.get("sticky")
-            }
+            obj = self._get_sticky_settings_dict()
             json.dump(obj, fh, indent=1)

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -44,31 +44,39 @@ from .assets import (
     get_nuke_script_file,
     get_scene_asset_references,
 )
-from .data_classes import RenderSubmitterUISettings
+from .data_classes import (
+    JobType,
+    RenderSettings,
+    CopyCatTrainingSettings,
+    SubmitterUISettings,
+)
 from .ui.components.asset_scan_warning_dialog import AssetScanWarningDialog
 from .ui.components.scene_settings_tab import SceneSettingsWidget
 
-g_submitter_dialog = None
+g_render_submitter_dialog = None
+g_copycat_submitter_dialog = None
 
 
-def show_nuke_render_submitter_noargs() -> SubmitJobToDeadlineDialog:
+def show_nuke_render_submitter(job_type: JobType) -> SubmitJobToDeadlineDialog:
     with gui_error_handler("Error opening AWS Deadline Cloud Submitter", None):
         # Get the main Nuke window so we can parent the submitter to it
         app = QApplication.instance()
         mainwin = [widget for widget in app.topLevelWidgets() if isinstance(widget, QMainWindow)][0]
     with gui_error_handler("Error opening AWS Deadline Cloud Submitter", mainwin):
-        return show_nuke_render_submitter(mainwin, f=Qt.Tool)
+        return _show_nuke_render_submitter(mainwin, job_type=job_type, f=Qt.Tool)
 
 
-def _get_write_node(settings: RenderSubmitterUISettings) -> tuple[Node, str]:
-    if settings.write_node_selection:
-        write_node = nuke.toNode(settings.write_node_selection)
+def _get_write_node(settings: SubmitterUISettings) -> tuple[Node, str]:
+    assert settings.get_job_type() == JobType.RENDER
+
+    if settings.jobtype_specific_settings.write_node_selection:  # type: ignore[union-attr]
+        write_node = nuke.toNode(settings.jobtype_specific_settings.write_node_selection)  # type: ignore[union-attr]
     else:
         write_node = nuke.root()
-    return write_node, settings.write_node_selection
+    return write_node, settings.jobtype_specific_settings.write_node_selection  # type: ignore[union-attr]
 
 
-def _set_timeouts(template: dict[str, Any], settings: RenderSubmitterUISettings) -> None:
+def _set_timeouts(template: dict[str, Any], settings: SubmitterUISettings) -> None:
     """
     Timeouts are an OpenJD field applicable to actions but for specification 2023-09, timeouts must
     be hard-coded in the job template. There are three types of actions: OnRun, onEnter, and onExit.
@@ -151,10 +159,18 @@ def _remove_ocio_path_from_job_template(job_template: dict[str, Any]) -> None:
             break
 
 
-def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
+def _get_job_template(settings: SubmitterUISettings) -> dict[str, Any]:
+    job_type = settings.get_job_type()
     # Load the default Nuke job template, and then fill in scene-specific
     # values it needs.
-    with open(Path(__file__).parent / "default_nuke_job_template.yaml") as f:
+
+    template_name = (
+        "default_nuke_job_template.yaml"
+        if job_type == JobType.RENDER
+        else "copycat_job_template.yaml"
+    )
+
+    with open(Path(__file__).parent / template_name) as f:
         job_template = yaml.safe_load(f)
 
     # Set the job's name and description
@@ -165,99 +181,148 @@ def _get_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
     # Set the timeouts for each action:
     _set_timeouts(job_template, settings)
 
-    # Add Gizmo directory to NUKE_PATH if we copied
-    # any gizmos to the job bundle.
-    if settings.include_gizmos_in_job_bundle:
-        _add_gizmo_dir_to_job_template(job_template)
-    else:
-        _remove_gizmo_dir_from_job_template(job_template)
+    if job_type == JobType.RENDER:
+        # Add Gizmo directory to NUKE_PATH if we copied
+        # any gizmos to the job bundle.
+        if settings.include_gizmos_in_job_bundle:
+            _add_gizmo_dir_to_job_template(job_template)
+        else:
+            _remove_gizmo_dir_from_job_template(job_template)
 
-    # Get a map of the parameter definitions for easier lookup
-    parameter_def_map = {param["name"]: param for param in job_template["parameterDefinitions"]}
+        # Get a map of the parameter definitions for easier lookup
+        parameter_def_map = {param["name"]: param for param in job_template["parameterDefinitions"]}
 
-    # Set the WriteNode parameter allowed values
-    parameter_def_map["WriteNode"]["allowedValues"].extend(
-        sorted(node.fullName() for node in find_all_write_nodes())
-    )
+        # Set the WriteNode parameter allowed values
+        parameter_def_map["WriteNode"]["allowedValues"].extend(
+            sorted(node.fullName() for node in find_all_write_nodes())
+        )
 
-    # Set the View parameter allowed values
-    parameter_def_map["View"]["allowedValues"] = ["All Views"] + sorted(nuke.views())
+        # Set the View parameter allowed values
+        parameter_def_map["View"]["allowedValues"] = ["All Views"] + sorted(nuke.views())
 
-    # if OCIO is disabled, remove OCIO path from the template
-    if nuke_ocio.is_OCIO_enabled():
-        _add_ocio_path_to_job_template(job_template)
-    else:
-        _remove_ocio_path_from_job_template(job_template)
+        # if OCIO is disabled, remove OCIO path from the template
+        if nuke_ocio.is_OCIO_enabled():
+            _add_ocio_path_to_job_template(job_template)
+        else:
+            _remove_ocio_path_from_job_template(job_template)
 
-    # If this developer option is enabled, merge the adaptor_override_environment
-    if settings.include_adaptor_wheels:
-        with open(Path(__file__).parent / "adaptor_override_environment.yaml") as f:
-            override_environment = yaml.safe_load(f)
+        # If this developer option is enabled, merge the adaptor_override_environment
+        if settings.include_adaptor_wheels:
+            with open(Path(__file__).parent / "adaptor_override_environment.yaml") as f:
+                override_environment = yaml.safe_load(f)
 
-        # Read DEVELOPMENT.md for instructions to create the wheels directory.
-        wheels_path = Path(__file__).parent.parent.parent.parent / "wheels"
-        if not wheels_path.is_dir():
-            raise RuntimeError(
-                "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory does not exist:\n"
-                + str(wheels_path)
-            )
-        wheels_path_package_names = {
-            path.split("-", 1)[0] for path in os.listdir(wheels_path) if path.endswith(".whl")
-        }
-        if wheels_path_package_names != {
-            "openjd_adaptor_runtime",
-            "deadline",
-            "deadline_cloud_for_nuke",
-        }:
-            raise RuntimeError(
-                "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory contains the wrong wheels:\n"
-                "Expected: openjd_adaptor_runtime, deadline, and deadline_cloud_for_nuke\n"
-                f"Actual: {wheels_path_package_names}"
-            )
+            # Read DEVELOPMENT.md for instructions to create the wheels directory.
+            wheels_path = Path(__file__).parent.parent.parent.parent / "wheels"
+            if not wheels_path.is_dir():
+                raise RuntimeError(
+                    "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory does not exist:\n"
+                    + str(wheels_path)
+                )
+            wheels_path_package_names = {
+                path.split("-", 1)[0] for path in os.listdir(wheels_path) if path.endswith(".whl")
+            }
+            if wheels_path_package_names != {
+                "openjd_adaptor_runtime",
+                "deadline",
+                "deadline_cloud_for_nuke",
+            }:
+                raise RuntimeError(
+                    "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory contains the wrong wheels:\n"
+                    + "Expected: openjd_adaptor_runtime, deadline, and deadline_cloud_for_nuke\n"
+                    + f"Actual: {wheels_path_package_names}"
+                )
 
-        override_adaptor_name_param = [
-            param
-            for param in override_environment["parameterDefinitions"]
-            if param["name"] == "OverrideAdaptorName"
-        ][0]
-        override_adaptor_name_param["default"] = "NukeAdaptor"
+            override_adaptor_name_param = [
+                param
+                for param in override_environment["parameterDefinitions"]
+                if param["name"] == "OverrideAdaptorName"
+            ][0]
+            override_adaptor_name_param["default"] = "NukeAdaptor"
 
-        # There are no parameter conflicts between these two templates, so this works
-        job_template["parameterDefinitions"].extend(override_environment["parameterDefinitions"])
-
-        # Add the environment to the end of the template's job environments
-        if "jobEnvironments" not in job_template:
-            job_template["jobEnvironments"] = []
-        job_template["jobEnvironments"].append(override_environment["environment"])
-
-    # Determine whether this is a movie render. If it is, we want to ensure that the entire Nuke
-    # evaluation is placed on one task.
-    write_node, write_node_name = _get_write_node(settings)
-    movie_render = "file_type" in write_node.knobs() and write_node["file_type"].value() in [
-        "mov",
-        "mxf",
-    ]
-    if movie_render:
-        frame_list = _get_frame_list(settings, write_node, write_node_name)
-        match = re.match(r"(\d+)-(\d+)", frame_list)
-        if not match:
-            raise DeadlineOperationError(
-                f"Invalid frame range {frame_list} for evaluating a MOV render. Frame range must follow the format 'startFrame - endFrame'"
+            # There are no parameter conflicts between these two templates, so this works
+            job_template["parameterDefinitions"].extend(
+                override_environment["parameterDefinitions"]
             )
 
-        start_frame = match.group(1)
-        end_frame = match.group(2)
+            # Add the environment to the end of the template's job environments
+            if "jobEnvironments" not in job_template:
+                job_template["jobEnvironments"] = []
+            job_template["jobEnvironments"].append(override_environment["environment"])
 
-        # Remove the Frame parameter space and update the script data with the desired start and end frame
-        for step in job_template["steps"]:
-            del step["parameterSpace"]
-            step["script"]["embeddedFiles"][0]["data"] = f"frameRange: {start_frame}-{end_frame}\n"
+        # Determine whether this is a movie render. If it is, we want to ensure that the entire Nuke
+        # evaluation is placed on one task.
+        write_node, write_node_name = _get_write_node(settings)
+        movie_render = "file_type" in write_node.knobs() and write_node["file_type"].value() in [
+            "mov",
+            "mxf",
+        ]
+        if movie_render:
+            frame_list = _get_frame_list(settings, write_node, write_node_name)
+            match = re.match(r"(\d+)-(\d+)", frame_list)
+            if not match:
+                raise DeadlineOperationError(
+                    f"Invalid frame range {frame_list} for evaluating a MOV render. Frame range must follow the format 'startFrame - endFrame'"
+                )
+
+            start_frame = match.group(1)
+            end_frame = match.group(2)
+
+            # Remove the Frame parameter space and update the script data with the desired start and end frame
+            for step in job_template["steps"]:
+                del step["parameterSpace"]
+                step["script"]["embeddedFiles"][0][
+                    "data"
+                ] = f"frameRange: {start_frame}-{end_frame}\n"
 
     return job_template
 
 
 def _get_parameter_values(
-    settings: RenderSubmitterUISettings,
+    settings: SubmitterUISettings,
+    queue_parameters: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    job_type = settings.get_job_type()
+
+    if job_type == JobType.RENDER:
+        return _get_render_parameter_values(settings=settings, queue_parameters=queue_parameters)
+    else:
+        return _get_copycat_training_parameter_values(
+            settings=settings, queue_parameters=queue_parameters
+        )
+
+
+def _get_copycat_training_parameter_values(
+    settings: SubmitterUISettings,
+    queue_parameters: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    parameter_values: list[dict[str, Any]] = []
+
+    copycat_settings = settings.jobtype_specific_settings
+
+    copycat_node = nuke.toNode(copycat_settings.copycat_node)  # type: ignore[union-attr]
+
+    # Set the Nuke script file value
+    parameter_values.append({"name": "NukeScriptFile", "value": get_nuke_script_file()})
+    parameter_values.append({"name": "CopyCatNode", "value": copycat_settings.copycat_node})  # type: ignore[union-attr]
+    parameter_values.append(
+        {"name": "DataDir", "value": copycat_node.knob("dataDirectory").getEvaluatedValue()}
+    )
+    parameter_values.append(
+        {
+            "name": "CopyCatAdaptor",
+            "value": "C:\\Users\\npmac\\Documents\\deadline-cloud-for-nuke\\src\\deadline\\nuke_adaptor\\copycat_adaptor.py",
+        }
+    )
+
+    parameter_values.extend(
+        {"name": param["name"], "value": param["value"]} for param in queue_parameters
+    )
+
+    return parameter_values
+
+
+def _get_render_parameter_values(
+    settings: SubmitterUISettings,
     queue_parameters: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     parameter_values: list[dict[str, Any]] = []
@@ -277,17 +342,25 @@ def _get_parameter_values(
         parameter_values.append({"name": "WriteNode", "value": write_node_name})
 
     # Set the View parameter value
-    if settings.view_selection:
-        parameter_values.append({"name": "View", "value": settings.view_selection})
+    if settings.jobtype_specific_settings.view_selection:  # type: ignore[union-attr]
+        parameter_values.append(
+            {"name": "View", "value": settings.jobtype_specific_settings.view_selection}  # type: ignore[union-attr]
+        )
 
     # Set the ProxyMode parameter default
     parameter_values.append(
-        {"name": "ProxyMode", "value": "true" if settings.is_proxy_mode else "false"}
+        {
+            "name": "ProxyMode",
+            "value": "true" if settings.jobtype_specific_settings.is_proxy_mode else "false",  # type: ignore[union-attr]
+        }
     )
 
     # Set the ContinueOnError parameter default
     parameter_values.append(
-        {"name": "ContinueOnError", "value": "true" if settings.continue_on_error else "false"}
+        {
+            "name": "ContinueOnError",
+            "value": "true" if settings.jobtype_specific_settings.continue_on_error else "false",  # type: ignore[union-attr]
+        }
     )
 
     # Set the OCIO config path value
@@ -345,13 +418,14 @@ def _get_parameter_values(
 
 
 def _get_frame_list(
-    settings: RenderSubmitterUISettings,
+    settings: SubmitterUISettings,
     write_node: Node,
     write_node_name: Optional[str],
 ) -> str:
+    assert settings.get_job_type() == JobType.RENDER
     # Set the Frames parameter value
-    if settings.override_frame_range:
-        frame_list = settings.frame_list
+    if settings.jobtype_specific_settings.override_frame_range:  # type: ignore[union-attr]
+        frame_list = settings.jobtype_specific_settings.frame_list  # type: ignore[union-attr]
     else:
         # frame range from project setting
         frame_list = str(nuke.root().frameRange())
@@ -362,9 +436,11 @@ def _get_frame_list(
     return frame_list
 
 
-def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> SubmitJobToDeadlineDialog:
-    global g_submitter_dialog
-
+def _show_nuke_render_submitter(
+    parent, job_type: JobType, f=Qt.WindowFlags()
+) -> SubmitJobToDeadlineDialog:
+    global g_render_submitter_dialog
+    global g_copycat_submitter_dialog
     # Initialize telemetry client, opt-out is respected
     get_deadline_cloud_library_telemetry_client().update_common_details(
         {
@@ -383,12 +459,18 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> SubmitJobToDeadlin
             "The Nuke Script has unsaved changes. Please save it before opening the submitter dialog."
         )
 
-    render_settings = RenderSubmitterUISettings()
+    render_settings = SubmitterUISettings()
+
+    # Set settings based on the job type
+    if job_type == JobType.RENDER:
+        render_settings.jobtype_specific_settings = RenderSettings()
+    elif job_type == JobType.COPYCAT_TRAINING:
+        render_settings.jobtype_specific_settings = CopyCatTrainingSettings()
 
     # Set the setting defaults that come from the scene
     render_settings.name = Path(script_path).name
-    render_settings.frame_list = str(nuke.root().frameRange())
-    render_settings.is_proxy_mode = nuke.root().proxy()
+    render_settings.jobtype_specific_settings.frame_list = str(nuke.root().frameRange())  # type: ignore[union-attr]
+    render_settings.jobtype_specific_settings.is_proxy_mode = nuke.root().proxy()  # type: ignore[union-attr]
 
     # Load the sticky settings
     render_settings.load_sticky_settings(script_path)
@@ -396,7 +478,7 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> SubmitJobToDeadlin
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,
         job_bundle_dir: str,
-        settings: RenderSubmitterUISettings,
+        settings: SubmitterUISettings,
         queue_parameters: list[dict[str, Any]],
         asset_references: AssetReferences,
         host_requirements: Optional[dict[str, Any]] = None,
@@ -482,15 +564,21 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> SubmitJobToDeadlin
     else:
         attachments = AssetReferences()
 
-    if not g_submitter_dialog:
+    submitter_dialog = (
+        g_render_submitter_dialog if job_type == JobType.RENDER else g_copycat_submitter_dialog
+    )
+
+    if not submitter_dialog:
         nuke_version = nuke.env["NukeVersionMajor"]
         adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
 
         # Need Nuke and the Nuke OpenJD application interface adaptor
         rez_packages = f"nuke-{nuke_version} deadline_cloud_for_nuke"
-        conda_packages = f"nuke={nuke_version}.* nuke-openjd={adaptor_version}.*"
+        conda_packages = f"nuke={nuke_version}.*"
+        if job_type == JobType.RENDER:
+            conda_packages += f" nuke-openjd={adaptor_version}.*"
 
-        g_submitter_dialog = SubmitJobToDeadlineDialog(
+        submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,
             initial_job_settings=render_settings,
             initial_shared_parameter_values={
@@ -504,12 +592,19 @@ def show_nuke_render_submitter(parent, f=Qt.WindowFlags()) -> SubmitJobToDeadlin
             f=f,
             show_host_requirements_tab=True,
         )
+
+        if job_type == JobType.RENDER:
+            submitter_dialog.setWindowTitle("Submit Rendering to AWS Deadline Cloud")
+            g_render_submitter_dialog = submitter_dialog
+        else:
+            submitter_dialog.setWindowTitle("Submit CopyCat Training to AWS Deadline Cloud")
+            g_copycat_submitter_dialog = submitter_dialog
     else:
-        g_submitter_dialog.refresh(
+        submitter_dialog.refresh(
             job_settings=render_settings,
             auto_detected_attachments=asset_references_parsing_outcome.asset_references,
             attachments=attachments,
         )
 
-    g_submitter_dialog.show()
-    return g_submitter_dialog
+    submitter_dialog.show()
+    return submitter_dialog

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -51,7 +51,7 @@ except ImportError:
 from deadline.client.ui import gui_error_handler
 from deadline.client.ui.dialogs import submit_job_to_deadline_dialog
 from deadline.client.exceptions import DeadlineOperationError
-from .deadline_submitter_for_nuke import show_nuke_render_submitter_noargs
+from .deadline_submitter_for_nuke import show_nuke_render_submitter
 
 
 # The following functions expose a DCC interface to the job bundle output test logic.
@@ -120,7 +120,9 @@ def _copy_dcc_scene_file(source_filename: str, dest_filename: str):
 
 def _show_deadline_cloud_submitter(mainwin: Any):
     """Shows the Deadline Cloud Submitter for Nuke."""
-    return show_nuke_render_submitter_noargs()
+    from deadline.nuke_submitter.data_classes import JobType
+
+    return show_nuke_render_submitter(JobType.RENDER)
 
 
 # The following functions implement the test logic.

--- a/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/nuke_submitter/ui/components/scene_settings_tab.py
@@ -40,8 +40,16 @@ except ImportError:
         QSpinBox,
     )
 
-from ...assets import find_all_write_nodes
-from ...data_classes import RenderSubmitterUISettings
+from ...assets import (
+    find_all_write_nodes,
+    find_all_copycat_nodes,
+)
+from ...data_classes import (
+    JobType,
+    SubmitterUISettings,
+    RenderSettings,
+    CopyCatTrainingSettings,
+)
 
 
 class SceneSettingsWidget(QWidget):
@@ -49,19 +57,22 @@ class SceneSettingsWidget(QWidget):
     Widget containing all top level scene settings.
     """
 
-    def __init__(self, initial_settings: RenderSubmitterUISettings, parent=None):
+    def __init__(self, initial_settings: SubmitterUISettings, parent=None):
         super().__init__(parent=parent)
 
         self.developer_options = (
             os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE"
         )
 
+        self._job_type = (
+            JobType.RENDER
+            if type(initial_settings.jobtype_specific_settings) is RenderSettings
+            else JobType.COPYCAT_TRAINING
+        )
         self._build_ui()
         self.refresh_ui(initial_settings)
 
-    def _build_ui(self):
-        lyt = QGridLayout(self)
-
+    def _build_render_ui_options(self, lyt: QGridLayout):
         self.write_node_box = QComboBox(self)
         self._rebuild_write_node_drop_down()
         lyt.addWidget(QLabel("Write nodes"), 0, 0)
@@ -86,6 +97,20 @@ class SceneSettingsWidget(QWidget):
             "Allow Nuke to continue rendering when it encounters non-fatal errors in the graph"
         )
         lyt.addWidget(self.continue_on_error_check, 4, 0)
+
+    def _build_copycat_ui_options(self, lyt: QGridLayout):
+        self.copycat_node_box = QComboBox(self)
+        self._rebuild_copycat_node_drop_down()
+        lyt.addWidget(QLabel("CopyCat Node"), 0, 0)
+        lyt.addWidget(self.copycat_node_box, 0, 1, 1, -1)
+
+    def _build_ui(self):
+        lyt = QGridLayout(self)
+
+        if self._job_type == JobType.RENDER:
+            self._build_render_ui_options(lyt)
+        elif self._job_type == JobType.COPYCAT_TRAINING:
+            self._build_copycat_ui_options(lyt)
 
         self.timeout_checkbox = QCheckBox("Use timeouts", self)
         self.timeout_checkbox.setChecked(True)
@@ -202,6 +227,14 @@ class SceneSettingsWidget(QWidget):
             + timeout_boxes[3].value() * 60
         )
 
+    def _rebuild_copycat_node_drop_down(self) -> None:
+        self.copycat_node_box.clear()
+        for copycat_node in sorted(
+            find_all_copycat_nodes(), key=lambda copycat_node: copycat_node.fullName()
+        ):
+            # Set data value as fullName since this is the value we want to store in the settings
+            self.copycat_node_box.addItem(copycat_node.fullName(), copycat_node.fullName())
+
     def _rebuild_write_node_drop_down(self) -> None:
         self.write_node_box.clear()
         self.write_node_box.addItem("All write nodes", None)
@@ -229,7 +262,7 @@ class SceneSettingsWidget(QWidget):
     def on_exit_timeout_seconds(self):
         return self._calculate_timeout_seconds(self.on_exit_timeouts)
 
-    def refresh_ui(self, settings: RenderSubmitterUISettings):
+    def _refresh_render_ui(self, settings: RenderSettings):
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
@@ -250,6 +283,16 @@ class SceneSettingsWidget(QWidget):
 
         self.proxy_mode_check.setChecked(settings.is_proxy_mode)
         self.continue_on_error_check.setChecked(settings.continue_on_error)
+
+    def _refresh_copycat_ui(self, settings: CopyCatTrainingSettings):
+        pass
+
+    def refresh_ui(self, settings: SubmitterUISettings):
+
+        if self._job_type == JobType.RENDER:
+            self._refresh_render_ui(settings.jobtype_specific_settings)  # type: ignore[arg-type]
+        elif self._job_type == JobType.COPYCAT_TRAINING:
+            self._refresh_copycat_ui(settings.jobtype_specific_settings)  # type: ignore[arg-type]
 
         self.timeout_checkbox.setChecked(settings.timeouts_enabled)
 
@@ -272,10 +315,7 @@ class SceneSettingsWidget(QWidget):
 
         self.activate_timeout_changed(warn=False)  # don't warn when loading from sticky settings
 
-    def update_settings(self, settings: RenderSubmitterUISettings):
-        """
-        Update a scene settings object with the latest values.
-        """
+    def _update_render_settings(self, settings: RenderSettings):
         settings.override_frame_range = self.frame_override_chck.isChecked()
         settings.frame_list = self.frame_override_txt.text()
 
@@ -283,6 +323,21 @@ class SceneSettingsWidget(QWidget):
         settings.view_selection = self.views_box.currentData()
         settings.is_proxy_mode = self.proxy_mode_check.isChecked()
         settings.continue_on_error = self.continue_on_error_check.isChecked()
+
+    def _update_copycat_training_settings(self, settings: CopyCatTrainingSettings):
+        settings.copycat_node = self.copycat_node_box.currentData()
+
+    def update_settings(self, settings: SubmitterUISettings):
+        """
+        Update a scene settings object with the latest values.
+        """
+
+        if self._job_type == JobType.RENDER:
+            settings.jobtype_specific_settings = RenderSettings()
+            self._update_render_settings(settings.jobtype_specific_settings)
+        elif self._job_type == JobType.COPYCAT_TRAINING:
+            settings.jobtype_specific_settings = CopyCatTrainingSettings()
+            self._update_copycat_training_settings(settings.jobtype_specific_settings)
 
         settings.timeouts_enabled = self.timeout_checkbox.isChecked()
         settings.on_run_timeout_seconds = self.on_run_timeout_seconds

--- a/src/menu.py
+++ b/src/menu.py
@@ -24,16 +24,16 @@ try:
     aws_deadline_menu.addCommand(
         "Submit to Deadline Cloud", lambda: show_nuke_render_submitter(JobType.RENDER), ""
     )
+    aws_deadline_menu.addCommand(
+        "Run Nuke Submitter Job Bundle Output Tests...",
+        run_render_submitter_job_bundle_output_test,
+        "",
+    )
     # Set the environment variable DEADLINE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
     if os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
         aws_deadline_menu.addCommand(
             "Submit CopyCat Training to Deadline Cloud",
             lambda: show_nuke_render_submitter(JobType.COPYCAT_TRAINING),
-            "",
-        )
-        aws_deadline_menu.addCommand(
-            "Run Nuke Submitter Job Bundle Output Tests...",
-            run_render_submitter_job_bundle_output_test,
             "",
         )
 

--- a/src/menu.py
+++ b/src/menu.py
@@ -14,15 +14,23 @@ try:
     import os
 
     from deadline.nuke_submitter import (
-        show_nuke_render_submitter_noargs,
+        show_nuke_render_submitter,
         run_render_submitter_job_bundle_output_test,
+        JobType,
     )
 
     menu_bar = nuke.menu("Nuke")
     aws_deadline_menu = menu_bar.addMenu("&AWS Deadline")
-    aws_deadline_menu.addCommand("Submit to Deadline Cloud", show_nuke_render_submitter_noargs, "")
+    aws_deadline_menu.addCommand(
+        "Submit to Deadline Cloud", lambda: show_nuke_render_submitter(JobType.RENDER), ""
+    )
     # Set the environment variable DEADLINE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
     if os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
+        aws_deadline_menu.addCommand(
+            "Submit CopyCat Training to Deadline Cloud",
+            lambda: show_nuke_render_submitter(JobType.COPYCAT_TRAINING),
+            "",
+        )
         aws_deadline_menu.addCommand(
             "Run Nuke Submitter Job Bundle Output Tests...",
             run_render_submitter_job_bundle_output_test,

--- a/src/menu.py
+++ b/src/menu.py
@@ -25,15 +25,15 @@ try:
         "Submit to Deadline Cloud", lambda: show_nuke_render_submitter(JobType.RENDER), ""
     )
     aws_deadline_menu.addCommand(
-        "Run Nuke Submitter Job Bundle Output Tests...",
-        run_render_submitter_job_bundle_output_test,
+        "Submit CopyCat Training to Deadline Cloud",
+        lambda: show_nuke_render_submitter(JobType.COPYCAT_TRAINING),
         "",
     )
     # Set the environment variable DEADLINE_ENABLE_DEVELOPER_OPTIONS to "true" to get this menu.
     if os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE":
         aws_deadline_menu.addCommand(
-            "Submit CopyCat Training to Deadline Cloud",
-            lambda: show_nuke_render_submitter(JobType.COPYCAT_TRAINING),
+            "Run Nuke Submitter Job Bundle Output Tests...",
+            run_render_submitter_job_bundle_output_test,
             "",
         )
 

--- a/test/unit/deadline_submitter_for_nuke/test_data_classes.py
+++ b/test/unit/deadline_submitter_for_nuke/test_data_classes.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from deadline.nuke_submitter.data_classes import (
+    SubmitterUISettings,
+    RenderSettings,
+    CopyCatTrainingSettings,
+)
+
+
+class TestSubmitterUISettings:
+    @pytest.mark.parametrize(
+        "job_type,settings_class,specific_settings",
+        [
+            (
+                "render",
+                RenderSettings,
+                {
+                    "override_frame_range": True,
+                    "frame_list": "1-10",
+                    "write_node_selection": "",
+                    "view_selection": "",
+                    "is_proxy_mode": False,
+                    "continue_on_error": False,
+                },
+            ),
+            (
+                "copycat",
+                CopyCatTrainingSettings,
+                {
+                    "copycat_node": "test_node",
+                },
+            ),
+        ],
+    )
+    def test_get_sticky_settings_dict(self, job_type, settings_class, specific_settings):
+        """Test that sticky settings are correctly serialized to a dictionary."""
+        settings = SubmitterUISettings()
+        settings.jobtype_specific_settings = settings_class()
+        settings.name = "test_job"
+        settings.description = "test description"
+
+        # Set job-specific settings
+        for key, value in specific_settings.items():
+            setattr(settings.jobtype_specific_settings, key, value)
+
+        result = settings._get_sticky_settings_dict()
+
+        # Common settings should always be present
+        assert result["name"] == "test_job"
+        assert result["description"] == "test description"
+        assert result["input_filenames"] == []
+        assert result["input_directories"] == []
+        assert result["output_directories"] == []
+        assert result["timeouts_enabled"] is True
+        assert result["on_run_timeout_seconds"] == 518400
+        assert result["on_enter_timeout_seconds"] == 86400
+        assert result["on_exit_timeout_seconds"] == 3600
+        assert result["include_gizmos_in_job_bundle"] is False
+        assert result["include_adaptor_wheels"] is False
+
+        # Job-specific settings should be present
+        for key, value in specific_settings.items():
+            assert result[key] == value
+
+    @pytest.mark.parametrize(
+        "job_type,settings_class,sticky_data",
+        [
+            (
+                "render",
+                RenderSettings,
+                {
+                    "name": "loaded_job",
+                    "description": "loaded description",
+                    "override_frame_range": True,
+                    "frame_list": "5-15",
+                    "timeouts_enabled": False,
+                    "include_gizmos_in_job_bundle": True,
+                },
+            ),
+            (
+                "copycat",
+                CopyCatTrainingSettings,
+                {
+                    "name": "copycat_job",
+                    "description": "copycat description",
+                    "copycat_node": "test_copycat_node",
+                    "timeouts_enabled": False,
+                },
+            ),
+        ],
+    )
+    def test_load_sticky_settings_from_dict(self, job_type, settings_class, sticky_data):
+        """Test that sticky settings are correctly loaded from a dictionary."""
+        settings = SubmitterUISettings()
+        settings.jobtype_specific_settings = settings_class()
+
+        settings._load_sticky_settings_from_dict(sticky_data)
+
+        # Check common settings
+        for key in ["name", "description", "timeouts_enabled", "include_gizmos_in_job_bundle"]:
+            if key in sticky_data:
+                assert getattr(settings, key) == sticky_data[key]
+
+        # Check job-specific settings
+        for key in sticky_data:
+            if hasattr(settings.jobtype_specific_settings, key):
+                assert getattr(settings.jobtype_specific_settings, key) == sticky_data[key]
+
+    def test_load_sticky_settings_ignores_non_sticky_fields(self):
+        """Test that non-sticky fields are ignored when loading from dictionary."""
+        settings = SubmitterUISettings()
+        original_submitter_name = settings.submitter_name
+
+        sticky_data = {
+            "name": "test_job",
+            "submitter_name": "should_be_ignored",  # non-sticky field
+            "unknown_field": "should_be_ignored",  # unknown field
+        }
+
+        settings._load_sticky_settings_from_dict(sticky_data)
+
+        assert settings.name == "test_job"
+        assert settings.submitter_name == original_submitter_name  # unchanged
+
+    def test_get_sticky_settings_dict_excludes_non_sticky_fields(self):
+        """Test that non-sticky fields are excluded from the settings dictionary."""
+        settings = SubmitterUISettings()
+        settings.submitter_name = "CustomSubmitter"  # non-sticky field
+        settings.name = "test_job"  # sticky field
+
+        result = settings._get_sticky_settings_dict()
+
+        assert "name" in result
+        assert "submitter_name" not in result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to add support for CopyCat. To support this in a useful way, we need to add UI support for submitting a job to run copycat training.

### What was the solution? (How)
Added a new button under Deadline Cloud menu. Users can select between submitting a Rendering Job, or a CopyCat job.

<img width="1030" height="224" alt="image" src="https://github.com/user-attachments/assets/b923db56-39f1-4041-9597-ea58b904fcb7" />

Clicking this option creates a job submission very similar to the flow for submitting a job to rendering. Job specific parameters in the UI are adjusted to accounted for different options.

<img width="861" height="891" alt="image" src="https://github.com/user-attachments/assets/5ea7b601-8032-4787-ae76-f1a3e13a9953" />

### What is the impact of this change?

Users will be able to submit copycat training jobs via the UI.

### How was this change tested?
tested submitting a rendering job. confirmed it rendered correctly
tested submitting a copycat training job, confirmed the results were correct and that I could load the results into the DataDir and that the progress UI was updated correctly.

<img width="848" height="999" alt="image" src="https://github.com/user-attachments/assets/08b787dc-d31e-4eb6-8718-633c7d00456d" />
 
#### Please run the integration tests and paste the results below
`141 passed, 8 skipped in 15.22s`


#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

4 passed, 9 skipped in 108.22s (0:01:48)

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

yes, all 6 passed.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

### Is this a breaking change?

no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
