### PR TITLE
feat: Notify customers if newer submitter is available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.49,< 0.56",
+    "deadline >= 0.55.1,< 0.56",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -40,6 +40,7 @@ from deadline.client.job_bundle.submission import AssetReferences
 
 from ._version import version
 from ._version import version_tuple as adaptor_version_tuple
+from .update_utils import check_and_show_update_dialog
 from .assets import (
     find_all_write_nodes,
     get_nuke_script_file,
@@ -58,12 +59,14 @@ g_render_submitter_dialog = None
 g_copycat_submitter_dialog = None
 
 
-def show_nuke_render_submitter(job_type: JobType) -> SubmitJobToDeadlineDialog:
+def show_nuke_render_submitter(job_type: JobType) -> Optional[SubmitJobToDeadlineDialog]:
     with gui_error_handler("Error opening AWS Deadline Cloud Submitter", None):
         # Get the main Nuke window so we can parent the submitter to it
         app = QApplication.instance()
         mainwin = [widget for widget in app.topLevelWidgets() if isinstance(widget, QMainWindow)][0]
     with gui_error_handler("Error opening AWS Deadline Cloud Submitter", mainwin):
+        if check_and_show_update_dialog():
+            return None
         return _show_nuke_render_submitter(mainwin, job_type=job_type, f=Qt.Tool)
 
 

--- a/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/nuke_submitter/job_bundle_output_test_runner.py
@@ -121,8 +121,12 @@ def _copy_dcc_scene_file(source_filename: str, dest_filename: str):
 def _show_deadline_cloud_submitter(mainwin: Any):
     """Shows the Deadline Cloud Submitter for Nuke."""
     from deadline.nuke_submitter.data_classes import JobType
+    from deadline.nuke_submitter import deadline_submitter_for_nuke
 
-    return show_nuke_render_submitter(JobType.RENDER)
+    with mock.patch.object(
+        deadline_submitter_for_nuke, "check_and_show_update_dialog", return_value=False
+    ):
+        return show_nuke_render_submitter(JobType.RENDER)
 
 
 # The following functions implement the test logic.

--- a/src/deadline/nuke_submitter/update_utils.py
+++ b/src/deadline/nuke_submitter/update_utils.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for checking and displaying update notifications."""
+
+import logging
+from dataclasses import dataclass
+
+from deadline.client.api import safe_check_for_updates, UpdateCheckResult, UpdateCheckStatus
+from deadline.client.ui.dialogs.update_available_dialog import UpdateAvailableDialog
+
+from ._version import version_tuple as adaptor_version_tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SessionState:
+    """Session-level state: once the user dismisses the update dialog,
+    don't show it again until Nuke is restarted."""
+
+    update_dismissed: bool = False
+
+
+_session_state = _SessionState()
+
+
+def _check_for_update() -> UpdateCheckResult:
+    """Check if a newer version of the Nuke submitter is available.
+
+    Returns:
+        An UpdateCheckResult describing whether an update is available.
+    """
+    current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
+    return safe_check_for_updates(
+        integration_name="deadline-cloud-for-nuke",
+        current_version=current_version,
+    )
+
+
+def check_and_show_update_dialog() -> bool:
+    """Check for updates and show the update dialog if one is available.
+
+    If the user previously dismissed the dialog in this Nuke session,
+    the check is skipped entirely.
+
+    Returns:
+        True if the user clicked Download (caller should skip opening the submitter),
+        False otherwise.
+    """
+    if _session_state.update_dismissed:
+        return False
+
+    update_result = _check_for_update()
+    if update_result.status == UpdateCheckStatus.SUCCESS and update_result.update_available:
+        update_dialog = UpdateAvailableDialog(
+            integration_name="Nuke",
+            current_version=update_result.current_version or "",
+            latest_version=update_result.latest_version or "",
+            download_url=update_result.download_url or "",
+            release_notes_url="https://github.com/aws-deadline/deadline-cloud-for-nuke/releases",
+        )
+        update_dialog.exec_()
+        if update_dialog.user_downloaded:
+            return True
+        # User dismissed — suppress for the rest of this Nuke session
+        _session_state.update_dismissed = True
+    return False

--- a/test/unit/deadline_submitter_for_nuke/test_update_utils.py
+++ b/test/unit/deadline_submitter_for_nuke/test_update_utils.py
@@ -1,0 +1,122 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from deadline.client.api import UpdateCheckResult, UpdateCheckStatus
+
+from deadline.nuke_submitter.update_utils import (
+    _check_for_update,
+    _session_state,
+    check_and_show_update_dialog,
+)
+
+MODULE = "deadline.nuke_submitter.update_utils"
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    """Reset session state before each test."""
+    _session_state.update_dismissed = False
+
+
+class TestCheckForUpdate:
+    """Tests for _check_for_update()."""
+
+    @patch(f"{MODULE}.safe_check_for_updates")
+    def test_passes_correct_integration_name(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+        )
+
+        # WHEN
+        _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["integration_name"] == "deadline-cloud-for-nuke"
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for check_and_show_update_dialog()."""
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_true_when_user_downloads(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is True
+        mock_dialog.exec_.assert_called_once()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_dismiss_sets_session_state(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        assert _session_state.update_dismissed is True
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_skips_check_when_previously_dismissed(self, mock_check):
+        # GIVEN
+        _session_state.update_dismissed = True
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        mock_check.assert_not_called()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_download_does_not_set_dismissed(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        check_and_show_update_dialog()
+
+        # THEN
+        assert _session_state.update_dismissed is False


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Customers did not know whether they were on the latest submitter or not. This means they would not have the latest bug fixes or features to work with our product. 

This is based off a similar PR for Cinema 4D: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/414

### What was the solution? (How)

Depends on: https://github.com/aws-deadline/deadline-cloud/pull/1070

This adds a dialog which checks our download manifests and if there's a new update available notifies customer  that. 

<img width="920" height="374" alt="image" src="https://github.com/user-attachments/assets/53142d27-3636-4659-97d1-91100c2ba995" />

### What is the impact of this change?

### How was this change tested?

Here's the test cases that I manually tested in Nuke on Windows:

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open Nuke → AWS Deadline Cloud → Submit to Deadline Cloud | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| 4 | No internet / firewall | Disconnect network → open submitter | Submitter opens normally, no crash, no visible error | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "Nuke", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 10 | Dialog timing | Observe launch order | Dialog appears before Cinema4D submitter window | YES |
| | **Dialog interactions — Dismiss** | | | |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | Nuke GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |
| 17 | Click "Don't remind me again" | Will dismiss and also never show the dialog again | No crash | YES |
| 18 | Click "Dismiss" | Does not show the dialog again for the session| No crash | YES | 


#### Please run the integration tests and paste the results below

WIP (Trying to figure out how to run the integration tests)

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
