### PR TITLE
chore: update docs for nuke17 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ AWS Deadline Cloud for Nuke is a python package that allows users to create [AWS
 
 This library requires:
 
-1. Nuke 15 or 16,
-1. Python 3.9 or higher; and
+1. Nuke 15, 16, or 17.
+1. Python 3.9 or higher.
 1. Linux, Windows, or a macOS operating system.
 
 ## Submitter

--- a/docs/user_guide/installation/index.md
+++ b/docs/user_guide/installation/index.md
@@ -3,7 +3,7 @@
 To install the AWS Deadline Cloud for Nuke submitter, you will need:
 
 - A Windows, MacOS, or Linux workstation
-- Nuke 14, 15 or 16. We recommend Nuke 15 or 16 over Nuke 14, as these versions are supported by the [default Conda queue environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment) on service-managed fleets. To use Nuke 14 with a service-managed fleet you will need to make Nuke 14 available to the worker. The recommended way of doing this would be to create your own Conda package following the documentation [here](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/conda-package.html).
+- Nuke 14, 15, 16, or 17. We recommend Nuke 15+ over Nuke 14, as these versions are supported by the [default Conda queue environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment) on service-managed fleets. To use Nuke 14 with a service-managed fleet you will need to make Nuke 14 available to the worker. The recommended way of doing this would be to create your own Conda package following the documentation [here](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/conda-package.html).
 
 There are two ways to install the Deadline Cloud for Nuke submitter:
 

--- a/install_builder/deadline-cloud-for-nuke.xml
+++ b/install_builder/deadline-cloud-for-nuke.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_nuke</name>
-    <description>Deadline Cloud for Nuke 14.0-16.0</description>
-    <detailedDescription>Nuke plugin for submitting jobs to AWS Deadline Cloud. Compatible with Nuke 14.0-16.0</detailedDescription>
+    <description>Deadline Cloud for Nuke 14.0-17.0</description>
+    <detailedDescription>Nuke plugin for submitting jobs to AWS Deadline Cloud. Compatible with Nuke 14.0-17.0</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -53,8 +53,8 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_nuke_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Nuke 14.0-16.0
-- Compatible with Nuke 14.0-16.0
+			<value>Deadline Cloud for Nuke 14.0-17.0
+- Compatible with Nuke 14.0-17.0
 - Install the integrated Nuke submitter files to the installation directory
 - Register the plug-in with Nuke by creating or updating the NUKE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We support nuke17 with our submitter, but some of our documentation still indicates that nuke16 is the latest supported version

### What was the solution? (How)
update documentation

### What is the impact of this change?
more accurate documentation

### How was this change tested?
searched the repository for "16". Added nuke 17 to the relevant locations.

#### Please run the integration tests and paste the results below

n/a

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

n/a

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

n/a

### Was this change documented?

yes

### Is this a breaking change?

no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
