### PR TITLE
chore: bump deadline-cloud version, switch to renamed function names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.57.0,< 0.58",
+    "deadline >= 0.55.1,< 0.58",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.56",
+    "deadline >= 0.57.0,< 0.58",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.58",
+    "deadline >= 0.57.0,< 0.58",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
+++ b/test/squish/suite_nuke_submitter/shared/scripts/api_helpers.py
@@ -192,12 +192,12 @@ def download_output(farm_id, queue_id, job_id):
         )
 
         # Get output paths
-        output_paths = downloader.get_output_paths_by_root()
+        output_paths = downloader.get_paths_by_root()
         print("Output paths by root:", output_paths)
 
         if output_paths:
             # Download output files
-            download_summary = downloader.download_job_output()
+            download_summary = downloader.download()
             print(
                 f"Downloaded {download_summary.processed_files} files totaling {download_summary.processed_bytes} bytes"
             )


### PR DESCRIPTION
https://github.com/aws-deadline/deadline-cloud-for-nuke/pull/306

helping out the dependable update to allow using deadline cloud version 0.57. There was a breaking change on a few functions, so a small amount of renaming had to be done: https://github.com/aws-deadline/deadline-cloud-job-attachments/releases/tag/0.1.0