### PR TITLE
chore: add global ignore_missing_imports to mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ packages = [
 check_untyped_defs = true
 show_error_codes = true
 pretty = true
+ignore_missing_imports = true
 # Tell mypy that there's a namespace package at src/deadline
 namespace_packages = true
 explicit_package_bases = true


### PR DESCRIPTION
Fixes: N/A (CI infra fix)

### What was the problem/requirement? (What/Why)

The `Code Quality` workflow (`mypy src test`) is currently failing on `mainline` for every PR, independent of the change being proposed. mypy reports 4 errors of the form:

```
src/deadline/nuke_submitter/__init__.py:4: error: Skipping analyzing "deadline.nuke_submitter._version": module is installed, but missing library stubs
...
Found 4 errors in 4 files (checked 67 source files)
```

These are the hatch-vcs generated `_version` modules. In CI they resolve to an installed copy that mypy treats as missing type stubs. This was reproduced on a pristine branch cut directly from `mainline` with only an empty commit (no source changes) — all Python matrix jobs failed identically — confirming it is a pre-existing mainline regression, not specific to any feature change. The last green `Code Quality` run on mainline was 2026-05-26.

### What was the solution? (How)

Add `ignore_missing_imports = true` to the top-level `[tool.mypy]` section. Currently nuke only sets this inside a per-module override (scoped to `nuke.*`, `PySide2.*`, etc.), which does not cover the generated `_version` modules. This change brings nuke in line with the sibling integration repos (deadline-cloud-for-maya, -blender, -houdini, -unreal-engine), all of which already set `ignore_missing_imports = true` globally and are not affected by this failure.

### What is the impact of this change?

Unblocks the `Code Quality` workflow on `mainline` and all open PRs. No runtime or source code impact — this is a static-analysis configuration change only.

### How was this change tested?

- `hatch run lint` passes locally (`ruff`, `black`, and `mypy` — "Success: no issues found in 70 source files")
- Validated `pyproject.toml` parses correctly
- Confirmed the same global setting is present in the 4 sibling integration repos whose CI passes

### Was this change documented?

No documentation change required — this is a tooling configuration fix.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*