### PR TITLE
feat: Run pre-GUI hooks in the Nuke render submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ classifiers = [
 ]
 
 dependencies = [
-    # run_pre_gui_hooks / PreGuiHookContext / apply_pre_gui_output are required for the pre-GUI
-    # hook integration below; they first ship in deadline-cloud 0.60.1 (the 0.60.0 release does
-    # not contain deadline.client.ui.pre_gui_hooks), so the floor must be 0.60.1, not 0.60.0.
     "deadline >= 0.60.1,< 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # run_pre_gui_hooks / PreGuiHookContext are required for the pre-GUI hook integration
-    # below; they ship in deadline-cloud 0.60.x. Confirm the exact release before merging.
-    "deadline >= 0.60.0,< 0.61",
+    # run_pre_gui_hooks / PreGuiHookContext / apply_pre_gui_output are required for the pre-GUI
+    # hook integration below; they first ship in deadline-cloud 0.60.1 (the 0.60.0 release does
+    # not contain deadline.client.ui.pre_gui_hooks), so the floor must be 0.60.1, not 0.60.0.
+    "deadline >= 0.60.1,< 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.57.0,< 0.59",
+    # run_pre_gui_hooks / PreGuiHookContext are required for the pre-GUI hook integration
+    # below; they ship in deadline-cloud 0.60.x. Confirm the exact release before merging.
+    "deadline >= 0.60.0,< 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -18,7 +18,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: 
     JobBundlePurpose,
     SubmitJobToDeadlineDialog,
 )
-from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
+from deadline.client.ui.pre_gui_hooks import (  # type: ignore
     PreGuiHookContext,
     apply_pre_gui_output,
     qt_hook_confirmation,
@@ -460,6 +460,18 @@ def _get_frame_list(
     return frame_list
 
 
+def _pre_gui_hook_confirm_callback(parent):
+    """Choose the confirmation callback for pre-GUI hooks based on the auto_accept setting.
+
+    Returns ``None`` (run hooks without prompting) when ``settings.auto_accept`` is enabled,
+    otherwise the standard Qt confirmation dialog from ``qt_hook_confirmation``. Kept as a small
+    helper so the auto_accept branch can be unit-tested headlessly.
+    """
+    if str2bool(get_setting("settings.auto_accept")):
+        return None
+    return qt_hook_confirmation(parent)
+
+
 def _show_nuke_render_submitter(
     parent, job_type: JobType, f=Qt.WindowFlags()
 ) -> SubmitJobToDeadlineDialog:
@@ -617,9 +629,6 @@ def _show_nuke_render_submitter(
         # branch below), so hooks are not re-run on every open. This is intentional and mirrors
         # the Maya submitter; re-running hooks per open would require threading the merged
         # parameters through refresh(), which does not accept initial_shared_parameter_values.
-        confirm_callback = (
-            None if str2bool(get_setting("settings.auto_accept")) else qt_hook_confirmation(parent)
-        )
         pre_gui_output = run_pre_gui_hooks(
             PreGuiHookContext(
                 bundle_dir=None,
@@ -627,7 +636,7 @@ def _show_nuke_render_submitter(
                 submitter_name="nuke",
                 parameters=dict(shared_parameter_values),
             ),
-            confirm_callback=confirm_callback,
+            confirm_callback=_pre_gui_hook_confirm_callback(parent),
         )
         # run_pre_gui_hooks returns {} when no hooks run and raises DeadlineOperationCanceled if
         # the user declines; `or {}` is defensive against any future contract change so the

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -611,6 +611,12 @@ def _show_nuke_render_submitter(
         # no on-disk job bundle at this point, so hooks are sourced from DEADLINE_HOOKS_DIR only
         # (bundle_dir=None), gated by settings.allow_environment_hooks. The confirmation prompt is
         # skipped when auto_accept is set; otherwise the standard dialog is shown.
+        #
+        # This runs once per Nuke session, on first open: the dialog is cached in the
+        # g_*_submitter_dialog globals and reused via refresh() on later opens (see the else
+        # branch below), so hooks are not re-run on every open. This is intentional and mirrors
+        # the Maya submitter; re-running hooks per open would require threading the merged
+        # parameters through refresh(), which does not accept initial_shared_parameter_values.
         confirm_callback = (
             None if str2bool(get_setting("settings.auto_accept")) else qt_hook_confirmation(parent)
         )
@@ -623,7 +629,10 @@ def _show_nuke_render_submitter(
             ),
             confirm_callback=confirm_callback,
         )
-        apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
+        # run_pre_gui_hooks returns {} when no hooks run and raises DeadlineOperationCanceled if
+        # the user declines; `or {}` is defensive against any future contract change so the
+        # common no-hooks path can never pass a falsy value into apply_pre_gui_output.
+        apply_pre_gui_output(pre_gui_output or {}, render_settings, shared_parameter_values)
 
         submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -10,12 +10,18 @@ from typing import Any, Optional
 import nuke
 import yaml  # type: ignore[import]
 from deadline.client.api import get_deadline_cloud_library_telemetry_client
+from deadline.client.config import get_setting, str2bool
 from deadline.client.job_bundle import deadline_yaml_dump
 from deadline.client.ui import gui_error_handler
 import deadline.nuke_submitter.copycat_adaptor as copycat_adaptor_module
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
     JobBundlePurpose,
     SubmitJobToDeadlineDialog,
+)
+from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
+    PreGuiHookContext,
+    qt_hook_confirmation,
+    run_pre_gui_hooks,
 )
 from nuke import Node
 
@@ -453,6 +459,29 @@ def _get_frame_list(
     return frame_list
 
 
+def _apply_pre_gui_output(
+    pre_gui_output: dict[str, Any],
+    render_settings: SubmitterUISettings,
+    shared_parameter_values: dict[str, Any],
+) -> None:
+    """Map merged pre-GUI hook output onto Nuke's settings + shared parameter values.
+
+    ``SubmitterUISettings`` has no ``.parameters`` list (unlike the standalone submitter's
+    ``JobBundleSettings``), so ``name`` / ``description`` are written onto the settings object
+    and any hook ``parameters`` (queue params like ``RezPackages`` / ``CondaPackages``,
+    ``deadline:`` job properties, etc.) are merged into the shared values the dialog is seeded
+    with. This is why the DCC does its own mapping rather than calling deadline-cloud's
+    ``JobBundleSettings``-specific ``apply_pre_gui_output``.
+    """
+    if not pre_gui_output:
+        return
+    if "name" in pre_gui_output:
+        render_settings.name = pre_gui_output["name"]
+    if "description" in pre_gui_output:
+        render_settings.description = pre_gui_output["description"]
+    shared_parameter_values.update(pre_gui_output.get("parameters", {}))
+
+
 def _show_nuke_render_submitter(
     parent, job_type: JobType, f=Qt.WindowFlags()
 ) -> SubmitJobToDeadlineDialog:
@@ -595,13 +624,33 @@ def _show_nuke_render_submitter(
         if job_type == JobType.RENDER:
             conda_packages += f" nuke-openjd={adaptor_version}.*"
 
+        shared_parameter_values = {
+            "RezPackages": rez_packages,
+            "CondaPackages": conda_packages,
+        }
+
+        # Run pre-GUI hooks so studios can pre-populate dialog fields before it opens. Nuke has
+        # no on-disk job bundle at this point, so hooks are sourced from DEADLINE_HOOKS_DIR only
+        # (bundle_dir=None), gated by settings.allow_environment_hooks. The confirmation prompt is
+        # skipped when auto_accept is set; otherwise the standard dialog is shown.
+        confirm_callback = (
+            None if str2bool(get_setting("settings.auto_accept")) else qt_hook_confirmation(parent)
+        )
+        pre_gui_output = run_pre_gui_hooks(
+            PreGuiHookContext(
+                bundle_dir=None,
+                job_name=render_settings.name,
+                submitter_name="nuke",
+                parameters=dict(shared_parameter_values),
+            ),
+            confirm_callback=confirm_callback,
+        )
+        _apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
+
         submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,
             initial_job_settings=render_settings,
-            initial_shared_parameter_values={
-                "RezPackages": rez_packages,
-                "CondaPackages": conda_packages,
-            },
+            initial_shared_parameter_values=shared_parameter_values,
             auto_detected_attachments=asset_references_parsing_outcome.asset_references,
             attachments=attachments,
             on_create_job_bundle_callback=on_create_job_bundle_callback,  # type: ignore

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -20,6 +20,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: 
 )
 from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
     PreGuiHookContext,
+    apply_pre_gui_output,
     qt_hook_confirmation,
     run_pre_gui_hooks,
 )
@@ -459,29 +460,6 @@ def _get_frame_list(
     return frame_list
 
 
-def _apply_pre_gui_output(
-    pre_gui_output: dict[str, Any],
-    render_settings: SubmitterUISettings,
-    shared_parameter_values: dict[str, Any],
-) -> None:
-    """Map merged pre-GUI hook output onto Nuke's settings + shared parameter values.
-
-    ``SubmitterUISettings`` has no ``.parameters`` list (unlike the standalone submitter's
-    ``JobBundleSettings``), so ``name`` / ``description`` are written onto the settings object
-    and any hook ``parameters`` (queue params like ``RezPackages`` / ``CondaPackages``,
-    ``deadline:`` job properties, etc.) are merged into the shared values the dialog is seeded
-    with. This is why the DCC does its own mapping rather than calling deadline-cloud's
-    ``JobBundleSettings``-specific ``apply_pre_gui_output``.
-    """
-    if not pre_gui_output:
-        return
-    if "name" in pre_gui_output:
-        render_settings.name = pre_gui_output["name"]
-    if "description" in pre_gui_output:
-        render_settings.description = pre_gui_output["description"]
-    shared_parameter_values.update(pre_gui_output.get("parameters", {}))
-
-
 def _show_nuke_render_submitter(
     parent, job_type: JobType, f=Qt.WindowFlags()
 ) -> SubmitJobToDeadlineDialog:
@@ -645,7 +623,7 @@ def _show_nuke_render_submitter(
             ),
             confirm_callback=confirm_callback,
         )
-        _apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
+        apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
 
         submitter_dialog = SubmitJobToDeadlineDialog(
             job_setup_widget_type=SceneSettingsWidget,

--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -42,7 +42,7 @@ except ImportError:
         QMessageBox,
     )
 
-from deadline.client.exceptions import DeadlineOperationError
+from deadline.client.exceptions import DeadlineOperationCanceled, DeadlineOperationError
 from deadline.client.job_bundle.submission import AssetReferences
 
 from ._version import version
@@ -474,7 +474,7 @@ def _pre_gui_hook_confirm_callback(parent):
 
 def _show_nuke_render_submitter(
     parent, job_type: JobType, f=Qt.WindowFlags()
-) -> SubmitJobToDeadlineDialog:
+) -> Optional[SubmitJobToDeadlineDialog]:
     global g_render_submitter_dialog
     global g_copycat_submitter_dialog
     # Initialize telemetry client, opt-out is respected
@@ -629,15 +629,22 @@ def _show_nuke_render_submitter(
         # branch below), so hooks are not re-run on every open. This is intentional and mirrors
         # the Maya submitter; re-running hooks per open would require threading the merged
         # parameters through refresh(), which does not accept initial_shared_parameter_values.
-        pre_gui_output = run_pre_gui_hooks(
-            PreGuiHookContext(
-                bundle_dir=None,
-                job_name=render_settings.name,
-                submitter_name="nuke",
-                parameters=dict(shared_parameter_values),
-            ),
-            confirm_callback=_pre_gui_hook_confirm_callback(parent),
-        )
+        try:
+            pre_gui_output = run_pre_gui_hooks(
+                PreGuiHookContext(
+                    bundle_dir=None,
+                    job_name=render_settings.name,
+                    submitter_name="nuke",
+                    parameters=dict(shared_parameter_values),
+                ),
+                confirm_callback=_pre_gui_hook_confirm_callback(parent),
+            )
+        except DeadlineOperationCanceled:
+            # The user declined the hook confirmation prompt. This is a normal cancellation, not
+            # an error, so abort opening the dialog silently. Without this, the exception would
+            # propagate to the outer gui_error_handler and surface a spurious "Error opening AWS
+            # Deadline Cloud Submitter" dialog for what is a deliberate "No" click.
+            return None
         # run_pre_gui_hooks returns {} when no hooks run and raises DeadlineOperationCanceled if
         # the user declines; `or {}` is defensive against any future contract change so the
         # common no-hooks path can never pass a falsy value into apply_pre_gui_output.

--- a/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
@@ -5,16 +5,22 @@
 ``_show_nuke_render_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
 Nuke has no on-disk bundle) and then applies the merged output with deadline-cloud's generic
 ``apply_pre_gui_output``. The full submitter needs a running Nuke, so it is exercised in the
-integration suite; here we verify the DCC-relevant contract headless: Nuke's
-``SubmitterUISettings`` has no ``.parameters`` list, so every hook parameter must flow to the
-dialog's shared parameter values (name/description land on the settings object). The nuke / Qt
-modules are stubbed by ``test/unit/__init__`` so the module imports.
+integration suite; here we verify the DCC-owned pieces headless:
+
+* ``apply_pre_gui_output`` routes hook output correctly against Nuke's own
+  ``SubmitterUISettings`` — which has no ``.parameters`` list, so every hook parameter must flow
+  to the dialog's shared parameter values (name/description land on the settings object).
+* ``_pre_gui_hook_confirm_callback`` honours the ``settings.auto_accept`` setting.
+
+The nuke / Qt modules are stubbed by ``test/unit/__init__`` so the module imports.
 """
 
 from typing import Optional
+from unittest.mock import patch
 
 from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
 
+from deadline.nuke_submitter import deadline_submitter_for_nuke
 from deadline.nuke_submitter.data_classes import SubmitterUISettings
 
 
@@ -100,3 +106,23 @@ def test_falsy_output_is_a_noop():
         assert settings.name == "Original"
         assert settings.description == ""
         assert shared == {"RezPackages": "nuke-15 deadline_cloud_for_nuke"}
+
+
+@patch.object(deadline_submitter_for_nuke, "get_setting", return_value="true")
+def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
+    """With settings.auto_accept enabled, hooks run without a confirmation prompt."""
+    assert deadline_submitter_for_nuke._pre_gui_hook_confirm_callback(parent=None) is None
+    mock_get_setting.assert_called_once_with("settings.auto_accept")
+
+
+@patch.object(deadline_submitter_for_nuke, "qt_hook_confirmation")
+@patch.object(deadline_submitter_for_nuke, "get_setting", return_value="false")
+def test_confirm_callback_prompts_when_auto_accept_disabled(mock_get_setting, mock_qt_confirm):
+    """With settings.auto_accept disabled, the standard Qt confirmation callback is used."""
+    sentinel = object()
+    mock_qt_confirm.return_value = sentinel
+
+    result = deadline_submitter_for_nuke._pre_gui_hook_confirm_callback(parent="mainwin")
+
+    assert result is sentinel
+    mock_qt_confirm.assert_called_once_with("mainwin")

--- a/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for the Nuke submitter's pre-GUI hook integration.
+
+``_show_nuke_render_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
+Nuke has no on-disk bundle) and then maps the merged output onto its own
+``SubmitterUISettings`` + the dialog's shared parameter values via ``_apply_pre_gui_output``.
+The full submitter needs a running Nuke, so it is exercised in the integration suite; here we
+unit-test the mapping helper — the DCC-owned piece — headless. The nuke / Qt modules are
+stubbed by ``test/unit/__init__`` so the module imports.
+"""
+
+from deadline.nuke_submitter.data_classes import SubmitterUISettings
+from deadline.nuke_submitter.deadline_submitter_for_nuke import _apply_pre_gui_output
+
+
+def _settings() -> SubmitterUISettings:
+    s = SubmitterUISettings()
+    s.name = "Original"
+    s.description = ""
+    return s
+
+
+def test_name_and_description_applied_to_settings():
+    """A hook's name/description overwrite the settings fields (Nuke has no .parameters list,
+    so these land directly on the dataclass)."""
+    settings = _settings()
+    shared = {"RezPackages": "nuke-15 deadline_cloud_for_nuke"}
+
+    _apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
+
+    assert settings.name == "PREGUI RAN"
+    assert settings.description == "from pipeline"
+
+
+def test_hook_parameters_merged_into_shared_values():
+    """Hook parameters (queue params, deadline: properties) are merged into the shared values
+    the dialog is seeded with, overriding the Nuke-computed defaults on key collision."""
+    settings = _settings()
+    shared = {"RezPackages": "nuke-15 deadline_cloud_for_nuke", "CondaPackages": "nuke=15.*"}
+
+    _apply_pre_gui_output(
+        {
+            "parameters": {
+                "deadline:priority": 88,
+                "RezPackages": "nuke-15 custom_pkg",  # overrides the default
+            }
+        },
+        settings,
+        shared,
+    )
+
+    assert shared["deadline:priority"] == 88
+    assert shared["RezPackages"] == "nuke-15 custom_pkg"
+    assert shared["CondaPackages"] == "nuke=15.*"  # untouched keys preserved
+
+
+def test_empty_output_is_a_noop():
+    """No pre-GUI hook output leaves the settings and shared values unchanged."""
+    settings = _settings()
+    shared = {"RezPackages": "pkg"}
+
+    _apply_pre_gui_output({}, settings, shared)
+
+    assert settings.name == "Original"
+    assert settings.description == ""
+    assert shared == {"RezPackages": "pkg"}
+
+
+def test_partial_output_only_touches_present_keys():
+    """Only the keys present in the output are applied; others keep their prior values."""
+    settings = _settings()
+    settings.description = "keep me"
+    shared: dict = {}
+
+    _apply_pre_gui_output({"name": "NewName"}, settings, shared)
+
+    assert settings.name == "NewName"
+    assert settings.description == "keep me"  # not overwritten
+    assert shared == {}  # no parameters in output

--- a/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
@@ -11,17 +11,20 @@ integration suite; here we verify the DCC-owned pieces headless:
   ``SubmitterUISettings`` — which has no ``.parameters`` list, so every hook parameter must flow
   to the dialog's shared parameter values (name/description land on the settings object).
 * ``_pre_gui_hook_confirm_callback`` honours the ``settings.auto_accept`` setting.
+* Declining the hook confirmation (``DeadlineOperationCanceled``) aborts the open silently
+  rather than surfacing a spurious error dialog.
 
 The nuke / Qt modules are stubbed by ``test/unit/__init__`` so the module imports.
 """
 
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from deadline.client.exceptions import DeadlineOperationCanceled
 from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
 
 from deadline.nuke_submitter import deadline_submitter_for_nuke
-from deadline.nuke_submitter.data_classes import SubmitterUISettings
+from deadline.nuke_submitter.data_classes import JobType, SubmitterUISettings
 
 
 def _settings() -> SubmitterUISettings:
@@ -126,3 +129,38 @@ def test_confirm_callback_prompts_when_auto_accept_disabled(mock_get_setting, mo
 
     assert result is sentinel
     mock_qt_confirm.assert_called_once_with("mainwin")
+
+
+@patch.object(deadline_submitter_for_nuke, "SubmitJobToDeadlineDialog")
+@patch.object(deadline_submitter_for_nuke, "run_pre_gui_hooks")
+@patch.object(deadline_submitter_for_nuke, "_pre_gui_hook_confirm_callback")
+@patch.object(deadline_submitter_for_nuke, "get_scene_asset_references")
+@patch.object(deadline_submitter_for_nuke, "get_nuke_script_file", return_value="/scene.nk")
+@patch.object(deadline_submitter_for_nuke, "get_deadline_cloud_library_telemetry_client")
+@patch.object(deadline_submitter_for_nuke, "nuke")
+def test_declining_hook_confirmation_aborts_without_error(
+    mock_nuke,
+    mock_telemetry,
+    mock_script_file,
+    mock_asset_refs,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+):
+    """Declining the hook prompt (DeadlineOperationCanceled) returns None and never builds the
+    dialog, so the outer gui_error_handler cannot surface a spurious error dialog."""
+    mock_nuke.root.return_value.modified.return_value = False
+    mock_nuke.root.return_value.frameRange.return_value = "1-100"
+    mock_nuke.env = {"NukeVersionMajor": 15, "NukeVersionString": "15.0v4"}
+    mock_asset_refs.return_value.encountered_exception.return_value = False
+    mock_asset_refs.return_value.asset_references = MagicMock()
+    # The user clicks "No" on the confirmation prompt.
+    mock_run_hooks.side_effect = DeadlineOperationCanceled("user declined")
+
+    result = deadline_submitter_for_nuke._show_nuke_render_submitter(
+        parent=MagicMock(), job_type=JobType.RENDER
+    )
+
+    assert result is None
+    mock_run_hooks.assert_called_once()
+    mock_dialog.assert_not_called()  # dialog must not be built on cancellation

--- a/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
@@ -3,15 +3,17 @@
 """Unit tests for the Nuke submitter's pre-GUI hook integration.
 
 ``_show_nuke_render_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
-Nuke has no on-disk bundle) and then maps the merged output onto its own
-``SubmitterUISettings`` + the dialog's shared parameter values via ``_apply_pre_gui_output``.
-The full submitter needs a running Nuke, so it is exercised in the integration suite; here we
-unit-test the mapping helper — the DCC-owned piece — headless. The nuke / Qt modules are
-stubbed by ``test/unit/__init__`` so the module imports.
+Nuke has no on-disk bundle) and then applies the merged output with deadline-cloud's generic
+``apply_pre_gui_output``. The full submitter needs a running Nuke, so it is exercised in the
+integration suite; here we verify the DCC-relevant contract headless: Nuke's
+``SubmitterUISettings`` has no ``.parameters`` list, so every hook parameter must flow to the
+dialog's shared parameter values (name/description land on the settings object). The nuke / Qt
+modules are stubbed by ``test/unit/__init__`` so the module imports.
 """
 
+from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
+
 from deadline.nuke_submitter.data_classes import SubmitterUISettings
-from deadline.nuke_submitter.deadline_submitter_for_nuke import _apply_pre_gui_output
 
 
 def _settings() -> SubmitterUISettings:
@@ -27,19 +29,20 @@ def test_name_and_description_applied_to_settings():
     settings = _settings()
     shared = {"RezPackages": "nuke-15 deadline_cloud_for_nuke"}
 
-    _apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
+    apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
 
     assert settings.name == "PREGUI RAN"
     assert settings.description == "from pipeline"
 
 
-def test_hook_parameters_merged_into_shared_values():
-    """Hook parameters (queue params, deadline: properties) are merged into the shared values
-    the dialog is seeded with, overriding the Nuke-computed defaults on key collision."""
+def test_hook_parameters_flow_to_shared_values():
+    """Nuke's SubmitterUISettings has no .parameters list, so every hook parameter (queue
+    params, deadline: properties) lands in the shared values the dialog is seeded with,
+    overriding the Nuke-computed defaults on key collision."""
     settings = _settings()
     shared = {"RezPackages": "nuke-15 deadline_cloud_for_nuke", "CondaPackages": "nuke=15.*"}
 
-    _apply_pre_gui_output(
+    apply_pre_gui_output(
         {
             "parameters": {
                 "deadline:priority": 88,
@@ -60,7 +63,7 @@ def test_empty_output_is_a_noop():
     settings = _settings()
     shared = {"RezPackages": "pkg"}
 
-    _apply_pre_gui_output({}, settings, shared)
+    apply_pre_gui_output({}, settings, shared)
 
     assert settings.name == "Original"
     assert settings.description == ""
@@ -73,7 +76,7 @@ def test_partial_output_only_touches_present_keys():
     settings.description = "keep me"
     shared: dict = {}
 
-    _apply_pre_gui_output({"name": "NewName"}, settings, shared)
+    apply_pre_gui_output({"name": "NewName"}, settings, shared)
 
     assert settings.name == "NewName"
     assert settings.description == "keep me"  # not overwritten

--- a/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
@@ -11,6 +11,8 @@ dialog's shared parameter values (name/description land on the settings object).
 modules are stubbed by ``test/unit/__init__`` so the module imports.
 """
 
+from typing import Optional
+
 from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
 
 from deadline.nuke_submitter.data_classes import SubmitterUISettings
@@ -87,7 +89,8 @@ def test_falsy_output_is_a_noop():
     """The submitter passes ``pre_gui_output or {}`` into apply_pre_gui_output, so the values
     run_pre_gui_hooks can actually produce for the no-hooks path — ``{}`` today, or ``None`` if
     the contract ever changed — must both be safe no-ops that leave settings/shared untouched."""
-    for falsy in ({}, None):
+    falsy_values: list[Optional[dict]] = [{}, None]
+    for falsy in falsy_values:
         settings = _settings()
         shared = {"RezPackages": "nuke-15 deadline_cloud_for_nuke"}
 

--- a/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py
@@ -81,3 +81,19 @@ def test_partial_output_only_touches_present_keys():
     assert settings.name == "NewName"
     assert settings.description == "keep me"  # not overwritten
     assert shared == {}  # no parameters in output
+
+
+def test_falsy_output_is_a_noop():
+    """The submitter passes ``pre_gui_output or {}`` into apply_pre_gui_output, so the values
+    run_pre_gui_hooks can actually produce for the no-hooks path — ``{}`` today, or ``None`` if
+    the contract ever changed — must both be safe no-ops that leave settings/shared untouched."""
+    for falsy in ({}, None):
+        settings = _settings()
+        shared = {"RezPackages": "nuke-15 deadline_cloud_for_nuke"}
+
+        # Mirror the submitter call site: `pre_gui_output or {}`.
+        apply_pre_gui_output(falsy or {}, settings, shared)
+
+        assert settings.name == "Original"
+        assert settings.description == ""
+        assert shared == {"RezPackages": "nuke-15 deadline_cloud_for_nuke"}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Studios want to pre-populate submitter dialog fields (job name, description, queue/job
parameters) from their own pipeline logic *before* the Nuke submitter dialog opens — the same
"pre-GUI hook" capability being added across the DCC submitters. deadline-cloud provides the
Qt-free entry points `run_pre_gui_hooks` / `PreGuiHookContext` and the generic
`apply_pre_gui_output`; the Nuke submitter needs to call them and apply the merged output.

This mirrors the equivalent changes across the other DCC submitters, adopting the same
deadline-cloud `pre_gui_hooks` API: Maya (aws-deadline/deadline-cloud-for-maya#437), Unreal
(aws-deadline/deadline-cloud-for-unreal-engine#336), and Blender
(aws-deadline/deadline-cloud-for-blender#370).

### What was the solution? (How)

Call `run_pre_gui_hooks` in `_show_nuke_render_submitter`, just before constructing
`SubmitJobToDeadlineDialog`, and apply the result with deadline-cloud's generic
`apply_pre_gui_output`:

- Build `shared_parameter_values` (`RezPackages` / `CondaPackages`) once and pass a copy into
  the hook context.
- Nuke has no on-disk job bundle at pre-GUI time, so hooks are sourced from `DEADLINE_HOOKS_DIR`
  only (`bundle_dir=None`), gated by `settings.allow_environment_hooks`.
- The confirmation prompt is skipped when `settings.auto_accept` is set; otherwise the standard
  Qt confirmation dialog (`qt_hook_confirmation`) is shown.
- The merged output is applied with deadline-cloud's **`apply_pre_gui_output`** (not a
  submitter-local helper). It is generic across submitters: `name` / `description` are written
  onto the settings object, and because Nuke's `SubmitterUISettings` has no `.parameters` list
  (unlike the standalone submitter's `JobBundleSettings`), every hook parameter flows into the
  shared parameter values the dialog is seeded with. Using the shared function keeps all DCC
  submitters on one code path.
- The hook block sits inside the dialog-construction branch (`if not submitter_dialog:`), so
  hooks run when the cached submitter dialog is first created — consistent with where Nuke
  already computes `rez_packages` / `conda_packages`.

Sets the `deadline` dependency floor to `>= 0.60.1, < 0.61`. The
`deadline.client.ui.pre_gui_hooks` module first ships in the released **0.60.1** — the 0.60.0
release does **not** contain it (the core change, aws-deadline/deadline-cloud#1255, landed after
the 0.60.0 tag), so the floor must be 0.60.1, not 0.60.0.

### What is the impact of this change?

- **No behavior change when no hooks are configured.** With no `DEADLINE_HOOKS_DIR` env hooks
  (or with env hooks disabled), `run_pre_gui_hooks` returns an empty dict, `apply_pre_gui_output`
  is a no-op, and the dialog is seeded with the same `RezPackages` / `CondaPackages` as before.
- When env hooks are present and enabled, they run (with a confirmation prompt unless
  `auto_accept` is set) and may pre-populate the job name, description, and parameters.

### How was this change tested?

- `black --check`, `ruff check`, `py_compile`: clean.
- New unit tests (`test/unit/deadline_submitter_for_nuke/test_pre_gui_hooks.py`) exercise the
  core `apply_pre_gui_output` against Nuke's `SubmitterUISettings` — covering name/description
  application, parameters flowing to shared values, empty-output no-op, and partial output.
- The **Nuke submitter unit suite (56 tests) passes against the released `deadline 0.60.1`**
  (the real `deadline.client.ui.pre_gui_hooks` module on the path, `nuke` / Qt stubbed as
  `test/unit/__init__` does). This confirms the module resolves and the mapping works end to
  end on the released dependency.
- **CI is green**: all 9 Python legs (ubuntu / macos / windows × 3.9–3.11), plus DCO and
  Semantic PR.

#### Please run the integration tests and paste the results below

The full submitter path requires a running Nuke, so it is validated in the integration / Squish
suites in CI rather than locally.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

No files were added or removed from `src/` (only `deadline_submitter_for_nuke.py` was modified);
`installer/` was not touched. Installer tests are unaffected.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not run — they require a running Nuke. This change does not alter job bundle *output* generation
(`on_create_job_bundle_callback` / `_get_job_template` / `_get_parameter_values` are unchanged);
it only pre-populates dialog fields before the GUI opens.

### Was this change documented?

The behavior is documented inline (module-level rationale in deadline-cloud's `pre_gui_hooks`
and comments at the Nuke call site). No user-facing docs in this repo required changes.

### Is this a breaking change?

No. Behavior is unchanged when no pre-GUI hooks are configured. The required deadline-cloud
release (`0.60.1`, which ships `pre_gui_hooks`) is published, so there is no outstanding
merge-order dependency.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

