### PR TITLE
chore: remove unreleased 0.18.17 from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,3 @@
-## 0.18.17 (Unreleased)
-
-
-### Features
-* feat: Add task chunking support to Nuke submitter. Frames are now rendered using
-  the OpenJD TASK_CHUNKING extension with contiguous chunks. Chunk size defaults to 1
-  (one frame per task, same as before). Increase chunk size to group frames and reduce
-  per-task overhead. Optional target chunk duration enables dynamic chunk sizing.
-
-### Important
-* This version requires a worker agent that supports the TASK_CHUNKING extension.
-  Service-managed fleets always use a compatible version. If you use customer-managed
-  fleets, ensure your worker agents are updated before submitting jobs.
-
 ## 0.18.16 (2026-01-20)
 
 Added support for training CopyCat nodes. Users are now able to select to submit a CopyCat training job. A CopyCat training job will perform CopyCat training on the render farm, rather than on the local system.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was an earlier failed release for 0.18.17. Trying to cut another release is going to result in a confusing changelog. Removing 0.18.17 from the changelog first, then going to cut a new release for 0.18.17.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
