### PR TITLE
feat: enable deadline-cloud-v2 conda channel in submitter

### DIFF
--- a/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
+++ b/src/deadline/nuke_submitter/deadline_submitter_for_nuke.py
@@ -660,6 +660,7 @@ def _show_nuke_render_submitter(
             parent=parent,
             f=f,
             show_host_requirements_tab=True,
+            use_deadline_cloud_v2_channel=True,
         )
 
         if job_type == JobType.RENDER:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Nuke submitter does not prepend the `deadline-cloud-v2` conda channel to submitted jobs, so jobs from the Nuke submitter cannot resolve packages from the new channel. The Nuke conda packages (including Nuke 17) are now built and deployed to the `deadline-cloud-v2` channel, and the other integrated submitters (Maya, Cinema4D, Blender, VRED, Unreal) already opt in.

### What was the solution? (How)

Pass `use_deadline_cloud_v2_channel=True` to the `SubmitJobToDeadlineDialog` call in `_show_nuke_render_submitter`, matching the other submitters. The dialog flag was introduced in `deadline` 0.59 and this package's dependency floor (`deadline >= 0.60.1`) already includes it.

### What is the impact of this change?

Jobs submitted from the Nuke submitter default their Conda Channels parameter to `deadline-cloud-v2 deadline-cloud` (when the queue has the Conda queue environment), enabling package resolution from the v2 channel with fallback to the original channel. Users can still edit the channel list in the dialog before submitting.

### How was this change tested?

- Unit tests: 176 passed, coverage 73.75% (above the 69% floor).
- End-to-end on a Deadline Cloud farm (Nuke 16.0v7, macOS submitter): submitted a render job via the in-Nuke submitter and confirmed from the worker session logs that the environment used `CondaChannels: deadline-cloud-v2 deadline-cloud`, resolved the `conda-v2/deadline-cloud-v2` S3 channel, solved `nuke=16.* nuke-openjd=0.18.*`, and rendered successfully.
- Visual check: with a queue that has the Conda queue environment, the submitter dialog's Conda Channels field shows `deadline-cloud-v2 deadline-cloud`.
<img width="542" height="725" alt="Screenshot 2026-07-14 at 3 51 32 PM" src="https://github.com/user-attachments/assets/7518fd74-262f-4135-b790-0755620e74eb" />



#### Please run the integration tests and paste the results below

Squish integration tests: not yet run — will update the PR with results (draft until then).

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

Not applicable — no installer changes and no files added/removed from `src/` (single-line change to an existing file).

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Timestamp: 2026-07-14T15:18:58.164799-07:00
Running job bundle output test: /Volumes/workplace/Bea-57276-deadline-cloud-for-nuke/job_bundle_output_tests/group-read

group-read
Test succeeded

Timestamp: 2026-07-14T15:18:58.494021-07:00
Running job bundle output test: /Volumes/workplace/Bea-57276-deadline-cloud-for-nuke/job_bundle_output_tests/noise-saver

noise-saver
Test succeeded

Timestamp: 2026-07-14T15:18:58.763258-07:00
Running job bundle output test: /Volumes/workplace/Bea-57276-deadline-cloud-for-nuke/job_bundle_output_tests/multi-load-save

multi-load-save
Test succeeded

Timestamp: 2026-07-14T15:18:58.964740-07:00
Running job bundle output test: /Volumes/workplace/Bea-57276-deadline-cloud-for-nuke/job_bundle_output_tests/frame

frame
Test succeeded

Timestamp: 2026-07-14T15:18:59.156539-07:00
Running job bundle output test: /Volumes/workplace/Bea-57276-deadline-cloud-for-nuke/job_bundle_output_tests/ocio

ocio
Test succeeded

Timestamp: 2026-07-14T15:18:59.385558-07:00
Running job bundle output test: /Volumes/workplace/Bea-57276-deadline-cloud-for-nuke/job_bundle_output_tests/cwd-path

cwd-path
Test succeeded

All tests passed, ran 6 total.
Timestamp: 2026-07-14T15:19:14.244763-07:00
```

### Was this change documented?

No documentation change needed — behavior matches the other integrated submitters and the channel default is visible/editable in the dialog.

### Is this a breaking change?

No. Queues resolve from `deadline-cloud-v2` first with fallback to `deadline-cloud`, and the channel list remains user-editable at submission time.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
