### PR TITLE
fix: reap Nuke's process group in UI test cleanup

### DIFF
--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -237,6 +237,14 @@ class NukeSession:
         The launch puts Nuke in its own process group precisely so the whole
         tree can be signalled here; the main process is still signalled
         directly as a fallback (and on Windows, where there is no group).
+
+        Every group signal is confined to the branch that stops a live
+        process. A process group is identified by its leader's pid, so once
+        the group is empty and the leader reaped, that id can be recycled by
+        an unrelated process — and signalling a long-dead session's group
+        would then kill somebody else's. Signalling only around a
+        ``terminate()`` we just issued keeps the whole sequence inside a
+        window measured in milliseconds.
         """
         if self.process.poll() is None:
             _signal_process_group(self.process_group)
@@ -247,8 +255,9 @@ class NukeSession:
                 _signal_process_group(self.process_group, force=True)
                 self.process.kill()
                 self.process.wait(timeout=5)
-        # Children can outlive the parent's exit, so sweep the group again.
-        _signal_process_group(self.process_group, force=True)
+            # Children can outlive the parent, so sweep the group once more
+            # now that it is stopped.
+            _signal_process_group(self.process_group, force=True)
 
     def tail_logs(self, max_chars: int = 2000) -> str:
         chunks = []
@@ -321,11 +330,11 @@ def launch_nuke_with_submitter(
     except BaseException:
         if session is not None:
             session.close()
-        else:
+        elif process.poll() is None:
             # Failed before the session existed (e.g. the AX bridge never
             # resolved). Nuke's children need reaping here too, or they
-            # outlive the failure and break the next launch.
-            if process.poll() is None:
-                process.terminate()
+            # outlive the failure and break the next launch. Only while the
+            # process is alive: see close() on recycled group ids.
+            process.terminate()
             _signal_process_group(process_group, force=True)
         raise

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -187,13 +187,13 @@ class NukeSession:
         See ``_process.stop_process_tree`` for the teardown sequence and the
         process-group reuse rules it relies on.
 
-        The captured group is dropped afterwards so this is effectively
-        one-shot: by the time anything calls ``close()`` again the group is
-        empty, and an empty group's id is free to be handed to an unrelated
-        process, which must never be signalled.
+        The captured group is kept rather than cleared afterwards. Teardown is
+        best-effort and can return with survivors, and the group id is the
+        only way to reach them, so a retry needs it. Signalling a group whose
+        id may have been reassigned is prevented by the checks inside
+        ``sweep_process_group``, which run on every call.
         """
         stop_process_tree(self.process, self.process_group)
-        self.process_group = None
 
     def tail_logs(self, max_chars: int = 2000) -> str:
         chunks = []

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -177,13 +178,45 @@ class NukeSession:
         return _activate_app(self.process.pid)
 
     def close(self) -> None:
+        """Stop Nuke and the helper processes it spawned.
+
+        Nuke starts children that outlive a plain ``terminate()`` of the main
+        process — the frame server worker and the crash handler. Left behind,
+        they accumulate across a multi-case run and interfere with later
+        launches (they hold the license and the frame server's fixed port).
+        The launch puts Nuke in its own process group precisely so the whole
+        tree can be signalled here; the main process is still signalled
+        directly as a fallback (and on Windows, where there is no group).
+        """
         if self.process.poll() is None:
+            self._signal_process_group(signal.SIGTERM)
             self.process.terminate()
             try:
                 self.process.wait(timeout=15)
             except subprocess.TimeoutExpired:
+                self._signal_process_group(signal.SIGKILL)
                 self.process.kill()
                 self.process.wait(timeout=5)
+        # Children can outlive the parent's exit, so sweep the group again.
+        self._signal_process_group(signal.SIGKILL)
+
+    def _signal_process_group(self, sig: int) -> None:
+        """Best-effort signal to Nuke's process group (POSIX only)."""
+        if sys.platform == "win32" or not hasattr(os, "killpg"):
+            return
+        try:
+            group = os.getpgid(self.process.pid)
+        except (ProcessLookupError, PermissionError):
+            return
+        if group == os.getpgrp():
+            # Never signal our own group: that would take down pytest. This
+            # means start_new_session did not take effect, so leave the
+            # children to the direct terminate/kill above.
+            return
+        try:
+            os.killpg(group, sig)
+        except (ProcessLookupError, PermissionError):
+            pass
 
     def tail_logs(self, max_chars: int = 2000) -> str:
         chunks = []

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -173,8 +173,7 @@ class NukeSession:
     app: xa11y.App
     work_dir: Path
     opener_status: str
-    # Resolved at launch; see capture_process_group. None on Windows, which
-    # has no process groups, and when the lookup failed.
+    # None on Windows, and when the lookup failed. See capture_process_group.
     process_group: Optional[int] = None
 
     def activate(self) -> bool:
@@ -182,16 +181,10 @@ class NukeSession:
         return _activate_app(self.process.pid)
 
     def close(self) -> None:
-        """Stop Nuke and the helper processes it spawned.
+        """Stop Nuke and the helpers it spawned (see _process).
 
-        See ``_process.stop_process_tree`` for the teardown sequence and the
-        process-group reuse rules it relies on.
-
-        The captured group is kept rather than cleared afterwards. Teardown is
-        best-effort and can return with survivors, and the group id is the
-        only way to reach them, so a retry needs it. Signalling a group whose
-        id may have been reassigned is prevented by the checks inside
-        ``sweep_process_group``, which run on every call.
+        The group id is kept, not cleared: teardown is best effort and a retry
+        needs it to reach any survivors.
         """
         stop_process_tree(self.process, self.process_group)
 
@@ -230,8 +223,7 @@ def launch_nuke_with_submitter(
         # (and should) be closed regardless of whether Popen succeeded.
         stdout_log.close()
         stderr_log.close()
-    # Resolve the process group now, while the child is known to be alive:
-    # see capture_process_group.
+    # While the child is known alive: see capture_process_group.
     process_group = capture_process_group(process)
     session: Optional[NukeSession] = None
     try:
@@ -267,8 +259,6 @@ def launch_nuke_with_submitter(
         if session is not None:
             session.close()
         else:
-            # Failed before the session existed (e.g. the AX bridge never
-            # resolved). Nuke's children need stopping here too, or they
-            # outlive the failure and break the next launch.
+            # Failed before the session existed, so close() cannot do it.
             stop_process_tree(process, process_group)
         raise

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import os
 import re
-import signal
 import subprocess
 import sys
 import time
@@ -35,6 +34,8 @@ from typing import Mapping, Optional
 import xa11y
 from deadline_test_fixtures.deadline_mock import build_mock_environment
 from deadline_test_fixtures.xa11y import find_accessibility_app
+
+from _process import capture_process_group, stop_process_tree
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 OPENER_DIR = Path(__file__).resolve().parent / "_opener"
@@ -164,88 +165,6 @@ def _activate_app(pid: int, timeout: float = ACTIVATE_TIMEOUT) -> bool:
     return False
 
 
-def _capture_process_group(process: subprocess.Popen) -> Optional[int]:
-    """The child's process group, resolved while it is known to be alive.
-
-    Captured once at launch rather than per signal. Once the child has been
-    reaped, ``os.getpgid`` on its pid either fails or — if the OS has
-    recycled the pid — reports an unrelated process's group, so re-resolving
-    later would make the post-exit sweep a no-op at best and a signal to
-    somebody else's group at worst. ``start_new_session`` makes the child a
-    group leader, so this value stays valid for the whole session.
-    """
-    if sys.platform == "win32":
-        return None
-    try:
-        return os.getpgid(process.pid)
-    except (ProcessLookupError, PermissionError):
-        # Raced with an immediate exit, or not ours to inspect. Cleanup falls
-        # back to signalling the process directly.
-        return None
-
-
-def _signal_process_group(group: Optional[int], *, force: bool = False) -> None:
-    """Best-effort signal to a captured process group (POSIX only).
-
-    The signal is resolved inside the platform guard because Windows has no
-    ``SIGKILL`` at all, so naming it in a caller would not type-check there —
-    and, worse, would raise ``AttributeError`` at the call site before the
-    guard could run.
-    """
-    if sys.platform == "win32" or group is None:
-        return
-    if group == os.getpgrp():
-        # Never signal our own group: that would take down pytest. This means
-        # start_new_session did not take effect, so leave the children to the
-        # direct terminate/kill instead.
-        return
-    try:
-        os.killpg(group, signal.SIGKILL if force else signal.SIGTERM)
-    except ProcessLookupError:
-        # Nothing left in the group — the expected outcome of the final sweep
-        # when the first signal already stopped every child.
-        pass
-    except PermissionError:
-        # Not ours to signal. Cleanup is best-effort and must never mask the
-        # test's own failure.
-        pass
-
-
-def _stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
-    """Stop *process* and every child in its process *group*.
-
-    Nuke starts children that outlive a plain ``terminate()`` of the main
-    process — the frame server worker and the crash handler. Left behind,
-    they accumulate across a multi-case run and interfere with later launches
-    (they hold the license and the frame server's fixed port). The launch puts
-    Nuke in its own process group precisely so the whole tree can be stopped
-    here; the main process is still signalled directly as a fallback (and on
-    Windows, where there is no group).
-
-    Nothing is signalled unless the process is still running. A process group
-    is named by its leader's pid, so once the group is empty and the leader
-    reaped, that id can be recycled by an unrelated process — signalling a
-    long-dead session's group would then kill somebody else's. Confining
-    every signal to a live process keeps the sequence within milliseconds of
-    the ``terminate()`` just issued.
-    """
-    if process.poll() is not None:
-        return
-    _signal_process_group(group)
-    process.terminate()
-    try:
-        # Also reaps the process: skipping this would leave a zombie for the
-        # rest of the pytest run, once per launch.
-        process.wait(timeout=15)
-    except subprocess.TimeoutExpired:
-        _signal_process_group(group, force=True)
-        process.kill()
-        process.wait(timeout=5)
-    # Children can outlive the parent, so sweep the group once more now that
-    # it is stopped.
-    _signal_process_group(group, force=True)
-
-
 @dataclass
 class NukeSession:
     """A running GUI Nuke process with its accessibility handle."""
@@ -254,7 +173,7 @@ class NukeSession:
     app: xa11y.App
     work_dir: Path
     opener_status: str
-    # Resolved at launch; see _capture_process_group. None on Windows, which
+    # Resolved at launch; see capture_process_group. None on Windows, which
     # has no process groups, and when the lookup failed.
     process_group: Optional[int] = None
 
@@ -265,10 +184,16 @@ class NukeSession:
     def close(self) -> None:
         """Stop Nuke and the helper processes it spawned.
 
-        See _stop_process_tree for the sequence and why every group signal is
-        confined to a process that is still running.
+        See ``_process.stop_process_tree`` for the teardown sequence and the
+        process-group reuse rules it relies on.
+
+        The captured group is dropped afterwards so this is effectively
+        one-shot: by the time anything calls ``close()`` again the group is
+        empty, and an empty group's id is free to be handed to an unrelated
+        process, which must never be signalled.
         """
-        _stop_process_tree(self.process, self.process_group)
+        stop_process_tree(self.process, self.process_group)
+        self.process_group = None
 
     def tail_logs(self, max_chars: int = 2000) -> str:
         chunks = []
@@ -306,8 +231,8 @@ def launch_nuke_with_submitter(
         stdout_log.close()
         stderr_log.close()
     # Resolve the process group now, while the child is known to be alive:
-    # see _capture_process_group.
-    process_group = _capture_process_group(process)
+    # see capture_process_group.
+    process_group = capture_process_group(process)
     session: Optional[NukeSession] = None
     try:
         app = find_accessibility_app(process.pid, timeout=NUKE_STARTUP_TIMEOUT)
@@ -345,5 +270,5 @@ def launch_nuke_with_submitter(
             # Failed before the session existed (e.g. the AX bridge never
             # resolved). Nuke's children need stopping here too, or they
             # outlive the failure and break the next launch.
-            _stop_process_tree(process, process_group)
+            stop_process_tree(process, process_group)
         raise

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -189,21 +189,27 @@ class NukeSession:
         directly as a fallback (and on Windows, where there is no group).
         """
         if self.process.poll() is None:
-            self._signal_process_group(signal.SIGTERM)
+            self._signal_process_group()
             self.process.terminate()
             try:
                 self.process.wait(timeout=15)
             except subprocess.TimeoutExpired:
-                self._signal_process_group(signal.SIGKILL)
+                self._signal_process_group(force=True)
                 self.process.kill()
                 self.process.wait(timeout=5)
         # Children can outlive the parent's exit, so sweep the group again.
-        self._signal_process_group(signal.SIGKILL)
+        self._signal_process_group(force=True)
 
-    def _signal_process_group(self, sig: int) -> None:
-        """Best-effort signal to Nuke's process group (POSIX only)."""
-        if sys.platform == "win32" or not hasattr(os, "killpg"):
+    def _signal_process_group(self, *, force: bool = False) -> None:
+        """Best-effort signal to Nuke's process group (POSIX only).
+
+        The signal is resolved inside the platform guard because Windows has
+        no ``SIGKILL`` at all, so naming it in a caller would not type-check
+        there even though the call never runs.
+        """
+        if sys.platform == "win32":
             return
+        sig = signal.SIGKILL if force else signal.SIGTERM
         try:
             group = os.getpgid(self.process.pid)
         except (ProcessLookupError, PermissionError):

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -164,6 +164,53 @@ def _activate_app(pid: int, timeout: float = ACTIVATE_TIMEOUT) -> bool:
     return False
 
 
+def _capture_process_group(process: subprocess.Popen) -> Optional[int]:
+    """The child's process group, resolved while it is known to be alive.
+
+    Captured once at launch rather than per signal. Once the child has been
+    reaped, ``os.getpgid`` on its pid either fails or — if the OS has
+    recycled the pid — reports an unrelated process's group, so re-resolving
+    later would make the post-exit sweep a no-op at best and a signal to
+    somebody else's group at worst. ``start_new_session`` makes the child a
+    group leader, so this value stays valid for the whole session.
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        return os.getpgid(process.pid)
+    except (ProcessLookupError, PermissionError):
+        # Raced with an immediate exit, or not ours to inspect. Cleanup falls
+        # back to signalling the process directly.
+        return None
+
+
+def _signal_process_group(group: Optional[int], *, force: bool = False) -> None:
+    """Best-effort signal to a captured process group (POSIX only).
+
+    The signal is resolved inside the platform guard because Windows has no
+    ``SIGKILL`` at all, so naming it in a caller would not type-check there —
+    and, worse, would raise ``AttributeError`` at the call site before the
+    guard could run.
+    """
+    if sys.platform == "win32" or group is None:
+        return
+    if group == os.getpgrp():
+        # Never signal our own group: that would take down pytest. This means
+        # start_new_session did not take effect, so leave the children to the
+        # direct terminate/kill instead.
+        return
+    try:
+        os.killpg(group, signal.SIGKILL if force else signal.SIGTERM)
+    except ProcessLookupError:
+        # Nothing left in the group — the expected outcome of the final sweep
+        # when the first signal already stopped every child.
+        pass
+    except PermissionError:
+        # Not ours to signal. Cleanup is best-effort and must never mask the
+        # test's own failure.
+        pass
+
+
 @dataclass
 class NukeSession:
     """A running GUI Nuke process with its accessibility handle."""
@@ -172,6 +219,9 @@ class NukeSession:
     app: xa11y.App
     work_dir: Path
     opener_status: str
+    # Resolved at launch; see _capture_process_group. None on Windows, which
+    # has no process groups, and when the lookup failed.
+    process_group: Optional[int] = None
 
     def activate(self) -> bool:
         """(Re-)raise Nuke to the foreground (see pages.py platform notes)."""
@@ -189,40 +239,16 @@ class NukeSession:
         directly as a fallback (and on Windows, where there is no group).
         """
         if self.process.poll() is None:
-            self._signal_process_group()
+            _signal_process_group(self.process_group)
             self.process.terminate()
             try:
                 self.process.wait(timeout=15)
             except subprocess.TimeoutExpired:
-                self._signal_process_group(force=True)
+                _signal_process_group(self.process_group, force=True)
                 self.process.kill()
                 self.process.wait(timeout=5)
         # Children can outlive the parent's exit, so sweep the group again.
-        self._signal_process_group(force=True)
-
-    def _signal_process_group(self, *, force: bool = False) -> None:
-        """Best-effort signal to Nuke's process group (POSIX only).
-
-        The signal is resolved inside the platform guard because Windows has
-        no ``SIGKILL`` at all, so naming it in a caller would not type-check
-        there even though the call never runs.
-        """
-        if sys.platform == "win32":
-            return
-        sig = signal.SIGKILL if force else signal.SIGTERM
-        try:
-            group = os.getpgid(self.process.pid)
-        except (ProcessLookupError, PermissionError):
-            return
-        if group == os.getpgrp():
-            # Never signal our own group: that would take down pytest. This
-            # means start_new_session did not take effect, so leave the
-            # children to the direct terminate/kill above.
-            return
-        try:
-            os.killpg(group, sig)
-        except (ProcessLookupError, PermissionError):
-            pass
+        _signal_process_group(self.process_group, force=True)
 
     def tail_logs(self, max_chars: int = 2000) -> str:
         chunks = []
@@ -259,10 +285,19 @@ def launch_nuke_with_submitter(
         # (and should) be closed regardless of whether Popen succeeded.
         stdout_log.close()
         stderr_log.close()
+    # Resolve the process group now, while the child is known to be alive:
+    # see _capture_process_group.
+    process_group = _capture_process_group(process)
     session: Optional[NukeSession] = None
     try:
         app = find_accessibility_app(process.pid, timeout=NUKE_STARTUP_TIMEOUT)
-        session = NukeSession(process=process, app=app, work_dir=work_dir, opener_status="")
+        session = NukeSession(
+            process=process,
+            app=app,
+            work_dir=work_dir,
+            opener_status="",
+            process_group=process_group,
+        )
 
         status_file = Path(env[ENV_STATUS_FILE])
         deadline = time.monotonic() + OPENER_TIMEOUT
@@ -286,6 +321,11 @@ def launch_nuke_with_submitter(
     except BaseException:
         if session is not None:
             session.close()
-        elif process.poll() is None:
-            process.terminate()
+        else:
+            # Failed before the session existed (e.g. the AX bridge never
+            # resolved). Nuke's children need reaping here too, or they
+            # outlive the failure and break the next launch.
+            if process.poll() is None:
+                process.terminate()
+            _signal_process_group(process_group, force=True)
         raise

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -211,6 +211,41 @@ def _signal_process_group(group: Optional[int], *, force: bool = False) -> None:
         pass
 
 
+def _stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
+    """Stop *process* and every child in its process *group*.
+
+    Nuke starts children that outlive a plain ``terminate()`` of the main
+    process — the frame server worker and the crash handler. Left behind,
+    they accumulate across a multi-case run and interfere with later launches
+    (they hold the license and the frame server's fixed port). The launch puts
+    Nuke in its own process group precisely so the whole tree can be stopped
+    here; the main process is still signalled directly as a fallback (and on
+    Windows, where there is no group).
+
+    Nothing is signalled unless the process is still running. A process group
+    is named by its leader's pid, so once the group is empty and the leader
+    reaped, that id can be recycled by an unrelated process — signalling a
+    long-dead session's group would then kill somebody else's. Confining
+    every signal to a live process keeps the sequence within milliseconds of
+    the ``terminate()`` just issued.
+    """
+    if process.poll() is not None:
+        return
+    _signal_process_group(group)
+    process.terminate()
+    try:
+        # Also reaps the process: skipping this would leave a zombie for the
+        # rest of the pytest run, once per launch.
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(group, force=True)
+        process.kill()
+        process.wait(timeout=5)
+    # Children can outlive the parent, so sweep the group once more now that
+    # it is stopped.
+    _signal_process_group(group, force=True)
+
+
 @dataclass
 class NukeSession:
     """A running GUI Nuke process with its accessibility handle."""
@@ -230,34 +265,10 @@ class NukeSession:
     def close(self) -> None:
         """Stop Nuke and the helper processes it spawned.
 
-        Nuke starts children that outlive a plain ``terminate()`` of the main
-        process — the frame server worker and the crash handler. Left behind,
-        they accumulate across a multi-case run and interfere with later
-        launches (they hold the license and the frame server's fixed port).
-        The launch puts Nuke in its own process group precisely so the whole
-        tree can be signalled here; the main process is still signalled
-        directly as a fallback (and on Windows, where there is no group).
-
-        Every group signal is confined to the branch that stops a live
-        process. A process group is identified by its leader's pid, so once
-        the group is empty and the leader reaped, that id can be recycled by
-        an unrelated process — and signalling a long-dead session's group
-        would then kill somebody else's. Signalling only around a
-        ``terminate()`` we just issued keeps the whole sequence inside a
-        window measured in milliseconds.
+        See _stop_process_tree for the sequence and why every group signal is
+        confined to a process that is still running.
         """
-        if self.process.poll() is None:
-            _signal_process_group(self.process_group)
-            self.process.terminate()
-            try:
-                self.process.wait(timeout=15)
-            except subprocess.TimeoutExpired:
-                _signal_process_group(self.process_group, force=True)
-                self.process.kill()
-                self.process.wait(timeout=5)
-            # Children can outlive the parent, so sweep the group once more
-            # now that it is stopped.
-            _signal_process_group(self.process_group, force=True)
+        _stop_process_tree(self.process, self.process_group)
 
     def tail_logs(self, max_chars: int = 2000) -> str:
         chunks = []
@@ -330,11 +341,9 @@ def launch_nuke_with_submitter(
     except BaseException:
         if session is not None:
             session.close()
-        elif process.poll() is None:
+        else:
             # Failed before the session existed (e.g. the AX bridge never
-            # resolved). Nuke's children need reaping here too, or they
-            # outlive the failure and break the next launch. Only while the
-            # process is alive: see close() on recycled group ids.
-            process.terminate()
-            _signal_process_group(process_group, force=True)
+            # resolved). Nuke's children need stopping here too, or they
+            # outlive the failure and break the next launch.
+            _stop_process_tree(process, process_group)
         raise

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -35,7 +35,6 @@ import signal
 import subprocess
 import sys
 import time
-from contextlib import suppress
 from typing import Optional
 
 TERMINATE_TIMEOUT = 15.0
@@ -127,7 +126,12 @@ def group_has_members(group: Optional[int]) -> bool:
     return True
 
 
-def sweep_process_group(group: Optional[int], *, drain_timeout: float = DRAIN_TIMEOUT) -> None:
+def sweep_process_group(
+    group: Optional[int],
+    *,
+    drain_timeout: float = DRAIN_TIMEOUT,
+    group_is_ours: bool = False,
+) -> None:
     """Stop whatever is left in *group*, asking before insisting.
 
     SIGTERM first, because a frame server that shuts down releases its
@@ -139,8 +143,16 @@ def sweep_process_group(group: Optional[int], *, drain_timeout: float = DRAIN_TI
     The reuse check runs twice: once before signalling, and again after the
     wait, because the window is long enough for a freed group id to be handed
     to somebody else while we are draining.
+
+    Pass *group_is_ours* to skip those checks, which callers may do only with
+    independent proof that the id cannot have been handed out. There is
+    exactly one such proof: a leader that has not been reaped still occupies
+    the pid the group is named after. That case has to be spelled out,
+    because the check reads it backwards on its own — a live pid normally
+    means the id was reassigned, but an unreaped leader is the one situation
+    where a live pid means the opposite.
     """
-    if group_id_was_recycled(group):
+    if not group_is_ours and group_id_was_recycled(group):
         return
     signal_process_group(group)
     deadline = time.monotonic() + drain_timeout
@@ -148,7 +160,7 @@ def sweep_process_group(group: Optional[int], *, drain_timeout: float = DRAIN_TI
         if not group_has_members(group):
             return
         time.sleep(DRAIN_POLL_INTERVAL)
-    if group_id_was_recycled(group):
+    if not group_is_ours and group_id_was_recycled(group):
         return
     signal_process_group(group, force=True)
 
@@ -164,9 +176,11 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
     * The process has already exited — it crashed, or the launcher's startup
       loop observed an early exit. ``Popen.poll`` has reaped it already.
 
-    Either way the leader ends up reaped, so both paths finish the same way:
-    sweep the group for children that outlived it, unless the group id has
-    since been handed to somebody else.
+    Both paths finish by sweeping the group for children that outlived the
+    leader. Whether that sweep may signal depends on the leader having been
+    reaped, which is what makes its pid, and therefore the group id,
+    reusable; the one case where the leader survives its own SIGKILL is
+    called out below.
 
     The two signals sent while the leader is still alive are deliberately not
     guarded that way. ``group_id_was_recycled`` asks whether a live process
@@ -174,6 +188,7 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
     leader — so the guard would report every live session as recycled and
     suppress the very signals that stop it.
     """
+    leader_reaped = True
     if process.poll() is None:
         signal_process_group(group)
         process.terminate()
@@ -182,7 +197,9 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
         except subprocess.TimeoutExpired:
             signal_process_group(group, force=True)
             process.kill()
-            with suppress(subprocess.TimeoutExpired):
+            try:
+                process.wait(timeout=KILL_TIMEOUT)
+            except subprocess.TimeoutExpired:
                 # Already SIGKILLed, so reaching this means the process is
                 # wedged in the kernel — an uninterruptible read against a
                 # hung license server or file server, say. Nothing further
@@ -192,9 +209,12 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
                 # carries Nuke's log tails), and in a fixture it would turn
                 # a real assertion failure into a teardown error. The cost
                 # is one leaked zombie in a case that is already lost.
-                process.wait(timeout=KILL_TIMEOUT)
-    # The leader is reaped now, so the group id — which is its pid — is free
-    # for reuse the moment the group empties. Children still in the group
-    # keep the id ours (see the module docstring); a live process owning it
-    # means it was reassigned, and signalling it would hit a stranger.
-    sweep_process_group(group)
+                leader_reaped = False
+    # An unreaped leader still holds the pid the group is named after, which
+    # is proof the id cannot have been reassigned, so the sweep is told to
+    # skip its reuse checks: they read a live pid as evidence of reassignment
+    # and would otherwise suppress the sweep in the one case it is certainly
+    # safe. Where the leader was reaped, the id is free the moment the group
+    # empties, and the checks are exactly what keeps us off a stranger's
+    # group.
+    sweep_process_group(group, group_is_ours=not leader_reaped)

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Process-tree teardown for the launched DCC, independent of the GUI stack.
+
+Kept free of the accessibility and Deadline test dependencies (stdlib only)
+so the teardown rules can be unit tested on every build, rather than only
+where a licensed Nuke is installed. See
+``test/unit/test_nuke_submitter_ui_process.py``.
+
+Why a process *group* is involved at all: Nuke starts children that outlive a
+plain ``terminate()`` of the process the suite launched — the crash handler,
+the frame server worker and its render workers. Left behind, they accumulate
+across a multi-case run and interfere with later launches, because the frame
+server binds a fixed port and holds a license. The launcher therefore starts
+Nuke with ``start_new_session=True``, making it a process-group leader so the
+whole tree can be stopped by group.
+
+Process-group ids and reuse, since the safety of all of this turns on it
+(POSIX XBD 4.17, "Process ID Reuse"):
+
+* A process group id is the pid of its leader, and is NOT reused while any
+  process remains in the group. So a group that still exists is still ours,
+  even after its leader has exited — which is what makes cleanup safe in the
+  case that matters most, a Nuke that crashed while its frame server kept
+  running.
+* The leader's *pid*, by contrast, becomes reusable once the leader has been
+  reaped. A live process owning that pid therefore means the id has been
+  recycled and the group is somebody else's; it must be left alone.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from typing import Optional
+
+TERMINATE_TIMEOUT = 15.0
+KILL_TIMEOUT = 5.0
+
+
+def capture_process_group(process: subprocess.Popen) -> Optional[int]:
+    """The child's process group, resolved while it is known to be alive.
+
+    Captured once at launch rather than per signal: after the child has been
+    reaped, ``os.getpgid`` on its pid either fails or, if the pid has been
+    recycled, reports an unrelated process's group.
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        return os.getpgid(process.pid)
+    except (ProcessLookupError, PermissionError):
+        # Raced with an immediate exit, or not ours to inspect. Cleanup falls
+        # back to signalling the process directly.
+        return None
+
+
+def signal_process_group(group: Optional[int], *, force: bool = False) -> None:
+    """Best-effort signal to a captured process group (POSIX only).
+
+    The signal is resolved inside the platform guard because Windows has no
+    ``SIGKILL`` at all, so naming it in a caller would not type-check there —
+    and, worse, would raise ``AttributeError`` at the call site before the
+    guard could run.
+    """
+    if sys.platform == "win32" or group is None:
+        return
+    if group == os.getpgrp():
+        # Never signal our own group: that would take down pytest. This means
+        # start_new_session did not take effect, so leave the children to the
+        # direct terminate/kill instead.
+        return
+    try:
+        os.killpg(group, signal.SIGKILL if force else signal.SIGTERM)
+    except ProcessLookupError:
+        # Nothing left in the group — the expected outcome of a final sweep
+        # when the earlier signal already stopped every child.
+        pass
+    except PermissionError:
+        # Not ours to signal. Cleanup is best-effort and must never mask the
+        # test's own failure.
+        pass
+
+
+def group_id_was_recycled(group: Optional[int]) -> bool:
+    """Whether *group*'s id now belongs to an unrelated process.
+
+    Only meaningful once our leader has been reaped. A live process owning
+    the id means it was handed out again, so the group must not be signalled;
+    the id being free means any group still using it is ours (see the module
+    docstring on POSIX reuse rules).
+    """
+    if sys.platform == "win32" or group is None:
+        return False
+    try:
+        os.kill(group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The pid exists and belongs to another user, so it is certainly not
+        # our reaped leader.
+        return True
+    return True
+
+
+def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
+    """Stop *process* and every remaining process in its *group*.
+
+    Handles both shapes of teardown:
+
+    * The process is still running: signal the group, terminate, wait (which
+      also reaps it, so no zombie accumulates per launch), escalating to
+      ``SIGKILL`` if it does not go quietly, then sweep the group for
+      children that outlived it.
+    * The process has already exited — it crashed, or the launcher's startup
+      loop observed an early exit. Its children can still be running and
+      holding the license and the frame server's port, so the group is still
+      swept. This is safe because the group id cannot have been recycled
+      while those children keep the group alive; the one case that is left
+      alone is a group id that a live process has since taken over.
+    """
+    if process.poll() is None:
+        signal_process_group(group)
+        process.terminate()
+        try:
+            process.wait(timeout=TERMINATE_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            signal_process_group(group, force=True)
+            process.kill()
+            process.wait(timeout=KILL_TIMEOUT)
+        signal_process_group(group, force=True)
+        return
+    if not group_id_was_recycled(group):
+        signal_process_group(group, force=True)

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -40,9 +40,15 @@ from typing import Optional
 TERMINATE_TIMEOUT = 15.0
 KILL_TIMEOUT = 5.0
 # How long the group's survivors get to exit after SIGTERM before they are
-# killed. Short, because it is only ever spent on children that ignore
-# SIGTERM: a group that drains (the normal case) ends the wait immediately.
-DRAIN_TIMEOUT = 2.0
+# killed. Matched to TERMINATE_TIMEOUT because the frame server needs the
+# same kind of grace Nuke does: releasing its license seat means a round trip
+# to the license server before the process can exit, and killing it mid
+# handshake leaves the seat held, which is the residue this module exists to
+# clear. The window is spent on anything that has not finished exiting,
+# whether it ignores SIGTERM or is merely slow, but a longer one is close to
+# free: the poll ends the moment the group empties, measured at 0.00s for a
+# group whose children exit on SIGTERM.
+DRAIN_TIMEOUT = 15.0
 DRAIN_POLL_INTERVAL = 0.1
 
 
@@ -165,7 +171,12 @@ def sweep_process_group(
     signal_process_group(group, force=True)
 
 
-def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
+def stop_process_tree(
+    process: subprocess.Popen,
+    group: Optional[int],
+    *,
+    drain_timeout: float = DRAIN_TIMEOUT,
+) -> None:
     """Stop *process* and every remaining process in its *group*.
 
     Handles both shapes of teardown:
@@ -217,4 +228,4 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
     # safe. Where the leader was reaped, the id is free the moment the group
     # empties, and the checks are exactly what keeps us off a stranger's
     # group.
-    sweep_process_group(group, group_is_ours=not leader_reaped)
+    sweep_process_group(group, drain_timeout=drain_timeout, group_is_ours=not leader_reaped)

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -34,6 +34,7 @@ import os
 import signal
 import subprocess
 import sys
+from contextlib import suppress
 from typing import Optional
 
 TERMINATE_TIMEOUT = 15.0
@@ -134,7 +135,17 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
         except subprocess.TimeoutExpired:
             signal_process_group(group, force=True)
             process.kill()
-            process.wait(timeout=KILL_TIMEOUT)
+            with suppress(subprocess.TimeoutExpired):
+                # Already SIGKILLed, so reaching this means the process is
+                # wedged in the kernel — an uninterruptible read against a
+                # hung license server or file server, say. Nothing further
+                # can be done about it, and raising from teardown would
+                # replace whatever failure asked for the teardown: on the
+                # launcher's failure path that diagnostic is the point (it
+                # carries Nuke's log tails), and in a fixture it would turn
+                # a real assertion failure into a teardown error. The cost
+                # is one leaked zombie in a case that is already lost.
+                process.wait(timeout=KILL_TIMEOUT)
     # The leader is reaped now, so the group id — which is its pid — is free
     # for reuse the moment the group empties. Children still in the group
     # keep the id ours (see the module docstring); a live process owning it

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -113,17 +113,15 @@ def sweep_process_group(
     drain_timeout: float = DRAIN_TIMEOUT,
     group_is_ours: bool = False,
 ) -> None:
-    """Stop what remains in *group*: SIGTERM, drain, then SIGKILL.
+    """Wait for *group* to drain after SIGTERM, then SIGKILL what is left.
 
-    The reuse check runs before signalling and again after the drain, since a
-    freed id can change hands while we wait. *group_is_ours* skips both, and
-    is only sound with proof the id cannot have been reassigned: an unreaped
-    leader still occupies it. That case needs stating because the check reads
-    a live pid as reassignment, which is backwards for an unreaped leader.
+    The reuse check guards the SIGKILL, since by then the leader is reaped and
+    its pid, which is the group id, may have been handed out. *group_is_ours*
+    skips it, and is only sound with proof the id cannot have been reassigned:
+    an unreaped leader still occupies it. That case needs stating because the
+    check reads a live pid as reassignment, which is backwards for a leader
+    that never died.
     """
-    if not group_is_ours and group_id_was_recycled(group):
-        return
-    signal_process_group(group)
     deadline = time.monotonic() + drain_timeout
     while time.monotonic() < deadline:
         if not group_has_members(group):
@@ -134,11 +132,15 @@ def sweep_process_group(
     signal_process_group(group, force=True)
 
 
-def _stop_process(process: subprocess.Popen) -> bool:
-    """Terminate *process*, escalating to kill. False if it was not reaped."""
+def _reap(process: subprocess.Popen) -> bool:
+    """Wait for *process*, killing it if it ignored SIGTERM.
+
+    False if it survived even SIGKILL, which means it is wedged in the kernel.
+    Raising instead would replace the failure that asked for teardown, so the
+    zombie is accepted.
+    """
     if process.poll() is not None:
-        return True  # already exited and reaped by poll()
-    process.terminate()
+        return True
     try:
         process.wait(timeout=TERMINATE_TIMEOUT)
     except subprocess.TimeoutExpired:
@@ -146,10 +148,15 @@ def _stop_process(process: subprocess.Popen) -> bool:
         try:
             process.wait(timeout=KILL_TIMEOUT)
         except subprocess.TimeoutExpired:
-            # Survived SIGKILL, so it is wedged in the kernel. Raising would
-            # replace the failure that asked for teardown, so accept a zombie.
             return False
     return True
+
+
+def _stop_process(process: subprocess.Popen) -> bool:
+    """Stop *process* alone, for when there is no group to signal."""
+    if process.poll() is None:
+        process.terminate()
+    return _reap(process)
 
 
 def stop_process_tree(
@@ -160,14 +167,22 @@ def stop_process_tree(
 ) -> None:
     """Stop *process*, then anything left in its *group*.
 
-    The group sweep is what catches children, which do not exit with their
-    parent; stopping the process alone is enough only on Windows, where there
-    is no group to sweep.
+    The group is what catches children, which do not exit with their parent.
     """
     if sys.platform == "win32":
+        # No process groups: helpers Nuke spawned are unreachable.
         _stop_process(process)
         return
-    reaped = _stop_process(process)
-    # An unreaped leader still holds the group id, which is proof it was not
-    # reassigned and the sweep may skip its reuse checks.
+    if group is None or group == os.getpgrp():
+        # Capture failed, or start_new_session did not take effect and the
+        # group is our own, which must never be signalled.
+        _stop_process(process)
+        return
+    # A leader belongs to its own group, so this asks it and its children to
+    # exit together and no separate terminate() is needed.
+    signal_process_group(group)
+    reaped = _reap(process)
+    # The leader must be reaped before draining: until then it is a member of
+    # its own group, so the poll could never see the group empty. An unreaped
+    # leader still holds the group id, which proves it was not reassigned.
     sweep_process_group(group, drain_timeout=drain_timeout, group_is_ours=not reaped)

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -34,11 +34,17 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from contextlib import suppress
 from typing import Optional
 
 TERMINATE_TIMEOUT = 15.0
 KILL_TIMEOUT = 5.0
+# How long the group's survivors get to exit after SIGTERM before they are
+# killed. Short, because it is only ever spent on children that ignore
+# SIGTERM: a group that drains (the normal case) ends the wait immediately.
+DRAIN_TIMEOUT = 2.0
+DRAIN_POLL_INTERVAL = 0.1
 
 
 def capture_process_group(process: subprocess.Popen) -> Optional[int]:
@@ -106,6 +112,47 @@ def group_id_was_recycled(group: Optional[int]) -> bool:
     return True
 
 
+def group_has_members(group: Optional[int]) -> bool:
+    """Whether any process is still in *group* and signallable by us."""
+    if sys.platform == "win32" or group is None:
+        return False
+    try:
+        os.killpg(group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # It exists but is not ours to signal, so as far as cleanup is
+        # concerned there is nothing here to act on.
+        return False
+    return True
+
+
+def sweep_process_group(group: Optional[int], *, drain_timeout: float = DRAIN_TIMEOUT) -> None:
+    """Stop whatever is left in *group*, asking before insisting.
+
+    SIGTERM first, because a frame server that shuts down releases its
+    license seat, while one that is killed outright leaves the seat held
+    until the license server's heartbeat expires — which is the residue that
+    breaks the next launch, the whole reason this module exists. Anything
+    still there when the drain window closes is killed.
+
+    The reuse check runs twice: once before signalling, and again after the
+    wait, because the window is long enough for a freed group id to be handed
+    to somebody else while we are draining.
+    """
+    if group_id_was_recycled(group):
+        return
+    signal_process_group(group)
+    deadline = time.monotonic() + drain_timeout
+    while time.monotonic() < deadline:
+        if not group_has_members(group):
+            return
+        time.sleep(DRAIN_POLL_INTERVAL)
+    if group_id_was_recycled(group):
+        return
+    signal_process_group(group, force=True)
+
+
 def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
     """Stop *process* and every remaining process in its *group*.
 
@@ -150,5 +197,4 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
     # for reuse the moment the group empties. Children still in the group
     # keep the id ours (see the module docstring); a live process owning it
     # means it was reassigned, and signalling it would hit a stranger.
-    if not group_id_was_recycled(group):
-        signal_process_group(group, force=True)
+    sweep_process_group(group)

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -1,31 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""Process-tree teardown for the launched DCC, independent of the GUI stack.
+"""Stops the launched DCC and the helper processes it spawns.
 
-Kept free of the accessibility and Deadline test dependencies (stdlib only)
-so the teardown rules can be unit tested on every build, rather than only
-where a licensed Nuke is installed. See
-``test/unit/test_nuke_submitter_ui_process.py``.
+Stdlib only, so these rules are unit tested on every build instead of only
+where a licensed Nuke exists (``test/unit/test_nuke_submitter_ui_process.py``).
 
-Why a process *group* is involved at all: Nuke starts children that outlive a
-plain ``terminate()`` of the process the suite launched — the crash handler,
-the frame server worker and its render workers. Left behind, they accumulate
-across a multi-case run and interfere with later launches, because the frame
-server binds a fixed port and holds a license. The launcher therefore starts
-Nuke with ``start_new_session=True``, making it a process-group leader so the
-whole tree can be stopped by group.
+Nuke's crash handler, frame server and render workers outlive a plain
+``terminate()`` of the process the suite launched, and left running they break
+later launches: the frame server binds a fixed port and holds a license. The
+launcher therefore starts Nuke with ``start_new_session=True`` so teardown can
+work by process group.
 
-Process-group ids and reuse, since the safety of all of this turns on it
-(POSIX XBD 4.17, "Process ID Reuse"):
+Group ids and reuse (POSIX XBD 4.17) are what make that safe. A group id is
+its leader's pid and is not reused while any member remains, so a group that
+still exists is still ours even after the leader has gone. The leader's pid
+becomes reusable once reaped, so a live process owning it means the id was
+reassigned and the group is somebody else's.
 
-* A process group id is the pid of its leader, and is NOT reused while any
-  process remains in the group. So a group that still exists is still ours,
-  even after its leader has exited — which is what makes cleanup safe in the
-  case that matters most, a Nuke that crashed while its frame server kept
-  running.
-* The leader's *pid*, by contrast, becomes reusable once the leader has been
-  reaped. A live process owning that pid therefore means the id has been
-  recycled and the group is somebody else's; it must be left alone.
+Windows has no process groups, so teardown there stops the launched process
+only and leaves whatever it spawned. The suite does not run on Windows yet; a
+Job Object or ``taskkill /T`` would be the fix when it does.
 """
 
 from __future__ import annotations
@@ -39,70 +33,56 @@ from typing import Optional
 
 TERMINATE_TIMEOUT = 15.0
 KILL_TIMEOUT = 5.0
-# How long the group's survivors get to exit after SIGTERM before they are
-# killed. Matched to TERMINATE_TIMEOUT because the frame server needs the
-# same kind of grace Nuke does: releasing its license seat means a round trip
-# to the license server before the process can exit, and killing it mid
-# handshake leaves the seat held, which is the residue this module exists to
-# clear. The window is spent on anything that has not finished exiting,
-# whether it ignores SIGTERM or is merely slow, but a longer one is close to
-# free: the poll ends the moment the group empties, measured at 0.00s for a
-# group whose children exit on SIGTERM.
+# Grace for the group's survivors, matched to the leader's: releasing a
+# license seat means a round trip to the license server, and killing the frame
+# server mid handshake leaves the seat held. A long window is nearly free
+# because the poll ends as soon as the group empties (measured 0.00s when
+# children exit on SIGTERM).
 DRAIN_TIMEOUT = 15.0
 DRAIN_POLL_INTERVAL = 0.1
 
 
 def capture_process_group(process: subprocess.Popen) -> Optional[int]:
-    """The child's process group, resolved while it is known to be alive.
+    """The process's group, resolved while it is known to be alive.
 
-    Captured once at launch rather than per signal: after the child has been
-    reaped, ``os.getpgid`` on its pid either fails or, if the pid has been
-    recycled, reports an unrelated process's group.
+    Captured once at launch: after the process is reaped its pid, and so the
+    group id, may belong to somebody else.
     """
     if sys.platform == "win32":
         return None
     try:
         return os.getpgid(process.pid)
     except (ProcessLookupError, PermissionError):
-        # Raced with an immediate exit, or not ours to inspect. Cleanup falls
-        # back to signalling the process directly.
+        # Raced with an immediate exit, or not ours to inspect.
         return None
 
 
 def signal_process_group(group: Optional[int], *, force: bool = False) -> None:
-    """Best-effort signal to a captured process group (POSIX only).
+    """SIGTERM (or SIGKILL) *group*, best effort.
 
-    The signal is resolved inside the platform guard because Windows has no
-    ``SIGKILL`` at all, so naming it in a caller would not type-check there —
-    and, worse, would raise ``AttributeError`` at the call site before the
-    guard could run.
+    The signal is named inside the platform guard because Windows has no
+    ``SIGKILL``: naming it in a caller would raise ``AttributeError`` there.
     """
     if sys.platform == "win32" or group is None:
         return
     if group == os.getpgrp():
-        # Never signal our own group: that would take down pytest. This means
-        # start_new_session did not take effect, so leave the children to the
-        # direct terminate/kill instead.
+        # Signalling our own group would take down pytest.
         return
     try:
         os.killpg(group, signal.SIGKILL if force else signal.SIGTERM)
     except ProcessLookupError:
-        # Nothing left in the group — the expected outcome of a final sweep
-        # when the earlier signal already stopped every child.
+        # Group already empty, the usual outcome of a second pass.
         pass
     except PermissionError:
-        # Not ours to signal. Cleanup is best-effort and must never mask the
-        # test's own failure.
+        # Not ours. Cleanup must never mask the test's own failure.
         pass
 
 
 def group_id_was_recycled(group: Optional[int]) -> bool:
-    """Whether *group*'s id now belongs to an unrelated process.
+    """Whether a live process now owns *group*'s id.
 
-    Only meaningful once our leader has been reaped. A live process owning
-    the id means it was handed out again, so the group must not be signalled;
-    the id being free means any group still using it is ours (see the module
-    docstring on POSIX reuse rules).
+    Only meaningful once our leader has been reaped, since before that the
+    live process owning the id is the leader itself.
     """
     if sys.platform == "win32" or group is None:
         return False
@@ -111,23 +91,18 @@ def group_id_was_recycled(group: Optional[int]) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
-        # The pid exists and belongs to another user, so it is certainly not
-        # our reaped leader.
-        return True
+        return True  # exists, and owned by someone else
     return True
 
 
 def group_has_members(group: Optional[int]) -> bool:
-    """Whether any process is still in *group* and signallable by us."""
+    """Whether *group* still holds a process we may signal."""
     if sys.platform == "win32" or group is None:
         return False
     try:
         os.killpg(group, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        # It exists but is not ours to signal, so as far as cleanup is
-        # concerned there is nothing here to act on.
+    except (ProcessLookupError, PermissionError):
+        # Empty, or not ours to act on.
         return False
     return True
 
@@ -138,25 +113,13 @@ def sweep_process_group(
     drain_timeout: float = DRAIN_TIMEOUT,
     group_is_ours: bool = False,
 ) -> None:
-    """Stop whatever is left in *group*, asking before insisting.
+    """Stop what remains in *group*: SIGTERM, drain, then SIGKILL.
 
-    SIGTERM first, because a frame server that shuts down releases its
-    license seat, while one that is killed outright leaves the seat held
-    until the license server's heartbeat expires — which is the residue that
-    breaks the next launch, the whole reason this module exists. Anything
-    still there when the drain window closes is killed.
-
-    The reuse check runs twice: once before signalling, and again after the
-    wait, because the window is long enough for a freed group id to be handed
-    to somebody else while we are draining.
-
-    Pass *group_is_ours* to skip those checks, which callers may do only with
-    independent proof that the id cannot have been handed out. There is
-    exactly one such proof: a leader that has not been reaped still occupies
-    the pid the group is named after. That case has to be spelled out,
-    because the check reads it backwards on its own — a live pid normally
-    means the id was reassigned, but an unreaped leader is the one situation
-    where a live pid means the opposite.
+    The reuse check runs before signalling and again after the drain, since a
+    freed id can change hands while we wait. *group_is_ours* skips both, and
+    is only sound with proof the id cannot have been reassigned: an unreaped
+    leader still occupies it. That case needs stating because the check reads
+    a live pid as reassignment, which is backwards for an unreaped leader.
     """
     if not group_is_ours and group_id_was_recycled(group):
         return
@@ -171,61 +134,40 @@ def sweep_process_group(
     signal_process_group(group, force=True)
 
 
+def _stop_process(process: subprocess.Popen) -> bool:
+    """Terminate *process*, escalating to kill. False if it was not reaped."""
+    if process.poll() is not None:
+        return True  # already exited and reaped by poll()
+    process.terminate()
+    try:
+        process.wait(timeout=TERMINATE_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        try:
+            process.wait(timeout=KILL_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            # Survived SIGKILL, so it is wedged in the kernel. Raising would
+            # replace the failure that asked for teardown, so accept a zombie.
+            return False
+    return True
+
+
 def stop_process_tree(
     process: subprocess.Popen,
     group: Optional[int],
     *,
     drain_timeout: float = DRAIN_TIMEOUT,
 ) -> None:
-    """Stop *process* and every remaining process in its *group*.
+    """Stop *process*, then anything left in its *group*.
 
-    Handles both shapes of teardown:
-
-    * The process is still running: signal the group, terminate, wait (which
-      also reaps it, so no zombie accumulates per launch), escalating to
-      ``SIGKILL`` if it does not go quietly.
-    * The process has already exited — it crashed, or the launcher's startup
-      loop observed an early exit. ``Popen.poll`` has reaped it already.
-
-    Both paths finish by sweeping the group for children that outlived the
-    leader. Whether that sweep may signal depends on the leader having been
-    reaped, which is what makes its pid, and therefore the group id,
-    reusable; the one case where the leader survives its own SIGKILL is
-    called out below.
-
-    The two signals sent while the leader is still alive are deliberately not
-    guarded that way. ``group_id_was_recycled`` asks whether a live process
-    owns the id, and before the leader is reaped that process is our own
-    leader — so the guard would report every live session as recycled and
-    suppress the very signals that stop it.
+    The group sweep is what catches children, which do not exit with their
+    parent; stopping the process alone is enough only on Windows, where there
+    is no group to sweep.
     """
-    leader_reaped = True
-    if process.poll() is None:
-        signal_process_group(group)
-        process.terminate()
-        try:
-            process.wait(timeout=TERMINATE_TIMEOUT)
-        except subprocess.TimeoutExpired:
-            signal_process_group(group, force=True)
-            process.kill()
-            try:
-                process.wait(timeout=KILL_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                # Already SIGKILLed, so reaching this means the process is
-                # wedged in the kernel — an uninterruptible read against a
-                # hung license server or file server, say. Nothing further
-                # can be done about it, and raising from teardown would
-                # replace whatever failure asked for the teardown: on the
-                # launcher's failure path that diagnostic is the point (it
-                # carries Nuke's log tails), and in a fixture it would turn
-                # a real assertion failure into a teardown error. The cost
-                # is one leaked zombie in a case that is already lost.
-                leader_reaped = False
-    # An unreaped leader still holds the pid the group is named after, which
-    # is proof the id cannot have been reassigned, so the sweep is told to
-    # skip its reuse checks: they read a live pid as evidence of reassignment
-    # and would otherwise suppress the sweep in the one case it is certainly
-    # safe. Where the leader was reaped, the id is free the moment the group
-    # empties, and the checks are exactly what keeps us off a stranger's
-    # group.
-    sweep_process_group(group, drain_timeout=drain_timeout, group_is_ours=not leader_reaped)
+    if sys.platform == "win32":
+        _stop_process(process)
+        return
+    reaped = _stop_process(process)
+    # An unreaped leader still holds the group id, which is proof it was not
+    # reassigned and the sweep may skip its reuse checks.
+    sweep_process_group(group, drain_timeout=drain_timeout, group_is_ours=not reaped)

--- a/test/nuke_submitter_ui/_process.py
+++ b/test/nuke_submitter_ui/_process.py
@@ -112,14 +112,19 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
 
     * The process is still running: signal the group, terminate, wait (which
       also reaps it, so no zombie accumulates per launch), escalating to
-      ``SIGKILL`` if it does not go quietly, then sweep the group for
-      children that outlived it.
+      ``SIGKILL`` if it does not go quietly.
     * The process has already exited — it crashed, or the launcher's startup
-      loop observed an early exit. Its children can still be running and
-      holding the license and the frame server's port, so the group is still
-      swept. This is safe because the group id cannot have been recycled
-      while those children keep the group alive; the one case that is left
-      alone is a group id that a live process has since taken over.
+      loop observed an early exit. ``Popen.poll`` has reaped it already.
+
+    Either way the leader ends up reaped, so both paths finish the same way:
+    sweep the group for children that outlived it, unless the group id has
+    since been handed to somebody else.
+
+    The two signals sent while the leader is still alive are deliberately not
+    guarded that way. ``group_id_was_recycled`` asks whether a live process
+    owns the id, and before the leader is reaped that process is our own
+    leader — so the guard would report every live session as recycled and
+    suppress the very signals that stop it.
     """
     if process.poll() is None:
         signal_process_group(group)
@@ -130,7 +135,9 @@ def stop_process_tree(process: subprocess.Popen, group: Optional[int]) -> None:
             signal_process_group(group, force=True)
             process.kill()
             process.wait(timeout=KILL_TIMEOUT)
-        signal_process_group(group, force=True)
-        return
+    # The leader is reaped now, so the group id — which is its pid — is free
+    # for reuse the moment the group empties. Children still in the group
+    # keep the id ours (see the module docstring); a live process owning it
+    # means it was reassigned, and signalling it would hit a stranger.
     if not group_id_was_recycled(group):
         signal_process_group(group, force=True)

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -1,0 +1,163 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for the GUI test suite's process-tree teardown.
+
+The module under test is ``test/nuke_submitter_ui/_process.py``, which the
+xa11y submitter UI suite uses to stop Nuke and the helper processes it
+spawns. It is deliberately free of the GUI suite's dependencies so these
+tests run in the normal unit suite on every platform, instead of only where a
+licensed Nuke is installed — the teardown rules are subtle enough that they
+should not go unverified on machines that cannot run the GUI suite.
+
+A ``/bin/sh`` process that backgrounds a child stands in for Nuke and its
+frame server: a leader with a descendant that outlives it, in its own process
+group, which is the shape that makes teardown non-trivial.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Iterator, Optional, Tuple
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "nuke_submitter_ui" / "_process.py"
+
+
+def _load_process_module():
+    """Load the suite's _process module by path.
+
+    Imported this way rather than via ``sys.path`` because the GUI suite's
+    directory is not a package and importing its siblings would pull in xa11y
+    and the Deadline test fixtures, which the unit test environment does not
+    install.
+    """
+    spec = importlib.util.spec_from_file_location("nuke_submitter_ui_process", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None, f"cannot load {_MODULE_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+process_module = _load_process_module()
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX process groups; on Windows the teardown is a plain terminate()",
+)
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists, owned by somebody else.
+        return True
+    return True
+
+
+def _wait_until(predicate, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.fixture
+def leader_with_child(tmp_path: Path) -> Iterator[Tuple[subprocess.Popen, Optional[int], int]]:
+    """A process group holding a leader and a descendant that outlives it."""
+    child_pid_file = tmp_path / "child.pid"
+    process = subprocess.Popen(
+        ["/bin/sh", "-c", f"sleep 300 & echo $! > {child_pid_file}; sleep 300"],
+        start_new_session=True,
+    )
+    assert _wait_until(
+        lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()
+    ), "stand-in process never reported its child"
+    group = process_module.capture_process_group(process)
+    child_pid = int(child_pid_file.read_text().strip())
+    assert group == process.pid, "start_new_session should make the process a group leader"
+    assert _alive(child_pid)
+    try:
+        yield process, group, child_pid
+    finally:
+        for pid in (child_pid, process.pid):
+            try:
+                os.kill(pid, 9)
+            except (ProcessLookupError, PermissionError):
+                pass
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def test_stops_descendant_when_leader_is_running(leader_with_child) -> None:
+    process, group, child_pid = leader_with_child
+
+    process_module.stop_process_tree(process, group)
+
+    assert _wait_until(lambda: not _alive(child_pid)), "descendant outlived the teardown"
+    assert process.returncode is not None, "leader was not reaped, leaving a zombie"
+
+
+def test_stops_descendant_when_leader_already_exited(leader_with_child) -> None:
+    """The case that leaks if teardown gives up on an already-exited leader.
+
+    Nuke crashing, or exiting early enough for the launcher's startup loop to
+    notice, leaves the frame server running and holding its port and license.
+    """
+    process, group, child_pid = leader_with_child
+    process.terminate()
+    process.wait(timeout=10)
+    assert _alive(child_pid), "precondition: the descendant outlives its leader"
+
+    process_module.stop_process_tree(process, group)
+
+    assert _wait_until(lambda: not _alive(child_pid)), "descendant survived an exited leader"
+
+
+def test_group_id_is_not_signalled_once_recycled(leader_with_child) -> None:
+    """A group id taken over by a live process must be left alone."""
+    process, group, child_pid = leader_with_child
+
+    # The current process stands in for whatever took the id over; its pid is
+    # certainly live, which is the only signal the check has to go on.
+    assert process_module.group_id_was_recycled(os.getpid()) is True
+    # Our leader is alive here, so its id is genuinely still ours.
+    assert process_module.group_id_was_recycled(group) is True
+
+    process.terminate()
+    process.wait(timeout=10)
+    # Reaped, so the id is free: the surviving group must still be swept.
+    assert process_module.group_id_was_recycled(group) is False
+
+
+def test_teardown_is_inert_for_an_already_stopped_group(leader_with_child) -> None:
+    process, group, child_pid = leader_with_child
+
+    process_module.stop_process_tree(process, group)
+    assert _wait_until(lambda: not _alive(child_pid))
+
+    # Nothing left to signal; a second call must not raise.
+    process_module.stop_process_tree(process, group)
+
+
+def test_capture_returns_none_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(process_module.sys, "platform", "win32")
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        assert process_module.capture_process_group(process) is None
+        # Signalling a group is a no-op there rather than an error.
+        process_module.signal_process_group(None, force=True)
+    finally:
+        process.kill()
+        process.wait(timeout=5)

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
@@ -72,38 +73,41 @@ def _wait_until(predicate, timeout: float = 10.0) -> bool:
     return False
 
 
-@pytest.fixture
-def leader_with_child(tmp_path: Path) -> Iterator[Tuple[subprocess.Popen, Optional[int], int]]:
-    """A process group holding a leader and a descendant that outlives it."""
+@contextmanager
+def _stand_in_for_nuke(tmp_path: Path, child_command: str):
+    """A process group holding a leader and a descendant that outlives it.
+
+    Yields ``(process, group, child_pid)``. Teardown goes through
+    ``stop_process_tree`` rather than killing the recorded pids directly: by
+    then the leader has usually been reaped and its descendant collected by
+    init, so signalling those raw pids would risk hitting whatever has since
+    been given them — the very hazard this module exists to avoid. A test
+    that leaves the group alive is therefore cleaned up by the same guarded
+    path it exercises, and a test that already stopped it costs nothing.
+    """
     child_pid_file = tmp_path / "child.pid"
     process = subprocess.Popen(
-        ["/bin/sh", "-c", f"sleep 300 & echo $! > {child_pid_file}; sleep 300"],
+        ["/bin/sh", "-c", f"{child_command} & echo $! > {child_pid_file}; sleep 300"],
         start_new_session=True,
     )
-    assert _wait_until(
-        lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()
-    ), "stand-in process never reported its child"
-    group = process_module.capture_process_group(process)
-    child_pid = int(child_pid_file.read_text().strip())
-    assert group == process.pid, "start_new_session should make the process a group leader"
-    assert _alive(child_pid)
+    group: Optional[int] = None
     try:
+        assert _wait_until(
+            lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()
+        ), "stand-in process never reported its child"
+        group = process_module.capture_process_group(process)
+        child_pid = int(child_pid_file.read_text().strip())
+        assert group == process.pid, "start_new_session should make the process a group leader"
+        assert _alive(child_pid)
         yield process, group, child_pid
     finally:
-        for pid in (child_pid, process.pid):
-            try:
-                os.kill(pid, 9)
-            except ProcessLookupError:
-                # Already gone: the expected case, since the test under way
-                # is usually the thing that stopped it.
-                pass
-            except PermissionError:
-                # The pid was recycled between the test and this cleanup, so
-                # it is somebody else's process and must be left alone.
-                pass
-        if process.poll() is None:
-            process.kill()
-            process.wait(timeout=5)
+        process_module.stop_process_tree(process, group)
+
+
+@pytest.fixture
+def leader_with_child(tmp_path: Path) -> Iterator[Tuple[subprocess.Popen, Optional[int], int]]:
+    with _stand_in_for_nuke(tmp_path, "sleep 300") as stand_in:
+        yield stand_in
 
 
 def test_stops_descendant_when_leader_is_running(leader_with_child) -> None:
@@ -138,37 +142,13 @@ def test_stops_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
     the leader is gone and reaped, so its id is free, yet the group is still
     ours because the stubborn child remains in it.
     """
-    child_pid_file = tmp_path / "stubborn.pid"
-    process = subprocess.Popen(
-        [
-            "/bin/sh",
-            "-c",
-            f"/bin/sh -c 'trap \"\" TERM; sleep 300' & echo $! > {child_pid_file}; sleep 300",
-        ],
-        start_new_session=True,
-    )
-    try:
-        assert _wait_until(
-            lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()
-        ), "stand-in process never reported its child"
-        group = process_module.capture_process_group(process)
-        child_pid = int(child_pid_file.read_text().strip())
-        assert _alive(child_pid)
-
+    stubborn_child = "/bin/sh -c 'trap \"\" TERM; sleep 300'"
+    with _stand_in_for_nuke(tmp_path, stubborn_child) as (process, group, child_pid):
         process_module.stop_process_tree(process, group)
 
         assert _wait_until(
             lambda: not _alive(child_pid)
         ), "a SIGTERM-ignoring descendant was never escalated to SIGKILL"
-    finally:
-        try:
-            os.kill(int(child_pid_file.read_text().strip()), 9)
-        except (ValueError, OSError):
-            # Nothing to clean up: the test stopped it, or it never started.
-            pass
-        if process.poll() is None:
-            process.kill()
-            process.wait(timeout=5)
 
 
 def test_group_id_is_not_signalled_once_recycled(leader_with_child) -> None:

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -131,6 +131,46 @@ def test_stops_descendant_when_leader_already_exited(leader_with_child) -> None:
     assert _wait_until(lambda: not _alive(child_pid)), "descendant survived an exited leader"
 
 
+def test_stops_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
+    """The final sweep has to escalate for a child that refuses SIGTERM.
+
+    This is the path that reaches the sweep with the group still populated:
+    the leader is gone and reaped, so its id is free, yet the group is still
+    ours because the stubborn child remains in it.
+    """
+    child_pid_file = tmp_path / "stubborn.pid"
+    process = subprocess.Popen(
+        [
+            "/bin/sh",
+            "-c",
+            f"/bin/sh -c 'trap \"\" TERM; sleep 300' & echo $! > {child_pid_file}; sleep 300",
+        ],
+        start_new_session=True,
+    )
+    try:
+        assert _wait_until(
+            lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()
+        ), "stand-in process never reported its child"
+        group = process_module.capture_process_group(process)
+        child_pid = int(child_pid_file.read_text().strip())
+        assert _alive(child_pid)
+
+        process_module.stop_process_tree(process, group)
+
+        assert _wait_until(
+            lambda: not _alive(child_pid)
+        ), "a SIGTERM-ignoring descendant was never escalated to SIGKILL"
+    finally:
+        try:
+            os.kill(int(child_pid_file.read_text().strip()), 9)
+        except (ValueError, OSError):
+            # Nothing to clean up: the test stopped it, or it never started.
+            pass
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
 def test_group_id_is_not_signalled_once_recycled(leader_with_child) -> None:
     """A group id taken over by a live process must be left alone."""
     process, group, child_pid = leader_with_child

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -90,7 +90,7 @@ def _stand_in_for_nuke(tmp_path: Path, child_command: str):
     """
     child_pid_file = tmp_path / "child.pid"
     process = subprocess.Popen(
-        ["/bin/sh", "-c", f"{child_command} & echo $! > {child_pid_file}; sleep 300"],
+        ["/bin/sh", "-c", f"{child_command} & echo $! > '{child_pid_file}'; sleep 300"],
         start_new_session=True,
     )
     group: Optional[int] = None
@@ -155,6 +155,35 @@ def test_stops_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
         assert _wait_until(
             lambda: not _alive(child_pid)
         ), "a SIGTERM-ignoring descendant was never escalated to SIGKILL"
+
+
+@posix_only
+def test_survivors_get_a_chance_to_exit_cleanly(tmp_path: Path) -> None:
+    """The sweep asks the group to stop before it kills it.
+
+    Driven through the exited-leader path on purpose: there the sweep is the
+    only thing that signals the group, so the child's SIGTERM handler running
+    can only be the sweep's doing. (On the live-leader path the child would
+    receive SIGTERM before the leader is even terminated, which would prove
+    nothing about the sweep.)
+
+    It matters for the frame server specifically: shutting down releases its
+    license seat, whereas being killed leaves the seat held until the license
+    server's heartbeat expires.
+    """
+    farewell = tmp_path / "farewell"
+    graceful_child = f"/bin/sh -c 'trap \"echo bye > {farewell}; exit 0\" TERM; sleep 300'"
+    with _stand_in_for_nuke(tmp_path, graceful_child) as (process, group, child_pid):
+        # Stop the leader alone, so nothing has signalled the group yet.
+        process.terminate()
+        process.wait(timeout=10)
+        assert _alive(child_pid), "precondition: the descendant outlives its leader"
+        assert not farewell.exists(), "precondition: the descendant has not been signalled"
+
+        process_module.stop_process_tree(process, group)
+
+        assert _wait_until(lambda: not _alive(child_pid)), "descendant outlived the teardown"
+        assert farewell.is_file(), "descendant was killed without being asked to stop first"
 
 
 @posix_only

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -93,7 +93,13 @@ def leader_with_child(tmp_path: Path) -> Iterator[Tuple[subprocess.Popen, Option
         for pid in (child_pid, process.pid):
             try:
                 os.kill(pid, 9)
-            except (ProcessLookupError, PermissionError):
+            except ProcessLookupError:
+                # Already gone: the expected case, since the test under way
+                # is usually the thing that stopped it.
+                pass
+            except PermissionError:
+                # The pid was recycled between the test and this cleanup, so
+                # it is somebody else's process and must be left alone.
                 pass
         if process.poll() is None:
             process.kill()

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -1,17 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""Tests for the GUI test suite's process-tree teardown.
+"""Tests for test/nuke_submitter_ui/_process.py, the GUI suite's teardown.
 
-The module under test is ``test/nuke_submitter_ui/_process.py``, which the
-xa11y submitter UI suite uses to stop Nuke and the helper processes it
-spawns. It is deliberately free of the GUI suite's dependencies so these
-tests run in the normal unit suite on every platform, instead of only where a
-licensed Nuke is installed — the teardown rules are subtle enough that they
-should not go unverified on machines that cannot run the GUI suite.
-
-A ``/bin/sh`` process that backgrounds a child stands in for Nuke and its
-frame server: a leader with a descendant that outlives it, in its own process
-group, which is the shape that makes teardown non-trivial.
+A /bin/sh process that backgrounds a child stands in for Nuke and its frame
+server: a leader with a descendant that outlives it, in its own process group.
 """
 
 from __future__ import annotations
@@ -33,10 +25,8 @@ _MODULE_PATH = Path(__file__).resolve().parents[1] / "nuke_submitter_ui" / "_pro
 def _load_process_module():
     """Load the suite's _process module by path.
 
-    Imported this way rather than via ``sys.path`` because the GUI suite's
-    directory is not a package and importing its siblings would pull in xa11y
-    and the Deadline test fixtures, which the unit test environment does not
-    install.
+    By path rather than sys.path: the GUI suite's directory is not a package,
+    and its siblings import xa11y, which this environment does not install.
     """
     spec = importlib.util.spec_from_file_location("nuke_submitter_ui_process", _MODULE_PATH)
     assert spec is not None and spec.loader is not None, f"cannot load {_MODULE_PATH}"
@@ -47,17 +37,15 @@ def _load_process_module():
 
 process_module = _load_process_module()
 
-# Applied per test rather than to the module: the last test covers the
-# no-process-group path and must run everywhere, including on Windows, where
-# it is the real behaviour rather than a simulation.
+# Per test, not module-wide: the no-process-group case must also run on
+# Windows, where it is real behaviour rather than a simulation.
 posix_only = pytest.mark.skipif(
     sys.platform == "win32",
     reason="POSIX process groups; on Windows the teardown is a plain terminate()",
 )
 
 
-# Drain window for tests that deliberately spend it. The production default
-# is sized for a real frame server; these stand-ins need no grace at all.
+# For tests that deliberately spend the window; /bin/sh needs no grace.
 SHORT_DRAIN = 0.5
 
 
@@ -83,15 +71,10 @@ def _wait_until(predicate, timeout: float = 10.0) -> bool:
 
 @contextmanager
 def _stand_in_for_nuke(tmp_path: Path, child_command: str):
-    """A process group holding a leader and a descendant that outlives it.
+    """Yields (process, group, child_pid) for a leader with a live descendant.
 
-    Yields ``(process, group, child_pid)``. Teardown goes through
-    ``stop_process_tree`` rather than killing the recorded pids directly: by
-    then the leader has usually been reaped and its descendant collected by
-    init, so signalling those raw pids would risk hitting whatever has since
-    been given them — the very hazard this module exists to avoid. A test
-    that leaves the group alive is therefore cleaned up by the same guarded
-    path it exercises, and a test that already stopped it costs nothing.
+    Teardown goes through stop_process_tree rather than killing the recorded
+    pids, which by then may have been reassigned.
     """
     child_pid_file = tmp_path / "child.pid"
     process = subprocess.Popen(
@@ -100,11 +83,8 @@ def _stand_in_for_nuke(tmp_path: Path, child_command: str):
     )
     group: Optional[int] = None
     try:
-        # Captured before anything that can fail: start_new_session has
-        # already taken effect when Popen returns, and teardown needs the
-        # group to reach the backgrounded child. Waiting until after the
-        # assertion below would leak that child for its full sleep whenever
-        # the assertion fires.
+        # Before anything that can fail: teardown needs the group to reach
+        # the backgrounded child, so a failed assertion below would leak it.
         group = process_module.capture_process_group(process)
         assert _wait_until(
             lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -47,7 +47,10 @@ def _load_process_module():
 
 process_module = _load_process_module()
 
-pytestmark = pytest.mark.skipif(
+# Applied per test rather than to the module: the last test covers the
+# no-process-group path and must run everywhere, including on Windows, where
+# it is the real behaviour rather than a simulation.
+posix_only = pytest.mark.skipif(
     sys.platform == "win32",
     reason="POSIX process groups; on Windows the teardown is a plain terminate()",
 )
@@ -110,6 +113,7 @@ def leader_with_child(tmp_path: Path) -> Iterator[Tuple[subprocess.Popen, Option
         yield stand_in
 
 
+@posix_only
 def test_stops_descendant_when_leader_is_running(leader_with_child) -> None:
     process, group, child_pid = leader_with_child
 
@@ -119,6 +123,7 @@ def test_stops_descendant_when_leader_is_running(leader_with_child) -> None:
     assert process.returncode is not None, "leader was not reaped, leaving a zombie"
 
 
+@posix_only
 def test_stops_descendant_when_leader_already_exited(leader_with_child) -> None:
     """The case that leaks if teardown gives up on an already-exited leader.
 
@@ -135,6 +140,7 @@ def test_stops_descendant_when_leader_already_exited(leader_with_child) -> None:
     assert _wait_until(lambda: not _alive(child_pid)), "descendant survived an exited leader"
 
 
+@posix_only
 def test_stops_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
     """The final sweep has to escalate for a child that refuses SIGTERM.
 
@@ -151,6 +157,7 @@ def test_stops_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
         ), "a SIGTERM-ignoring descendant was never escalated to SIGKILL"
 
 
+@posix_only
 def test_group_id_is_not_signalled_once_recycled(leader_with_child) -> None:
     """A group id taken over by a live process must be left alone."""
     process, group, child_pid = leader_with_child
@@ -167,6 +174,7 @@ def test_group_id_is_not_signalled_once_recycled(leader_with_child) -> None:
     assert process_module.group_id_was_recycled(group) is False
 
 
+@posix_only
 def test_teardown_is_inert_for_an_already_stopped_group(leader_with_child) -> None:
     process, group, child_pid = leader_with_child
 
@@ -177,7 +185,7 @@ def test_teardown_is_inert_for_an_already_stopped_group(leader_with_child) -> No
     process_module.stop_process_tree(process, group)
 
 
-def test_capture_returns_none_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_capture_returns_none_without_process_groups(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(process_module.sys, "platform", "win32")
     process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
     try:

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -15,7 +15,7 @@ import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, Optional, Tuple, cast
 
 import pytest
 
@@ -189,7 +189,7 @@ def test_sweep_leaves_a_group_alone_when_the_id_may_be_reassigned(leader_with_ch
     """
     process, group, child_pid = leader_with_child
 
-    process_module.sweep_process_group(group)
+    process_module.sweep_process_group(group, drain_timeout=SHORT_DRAIN)
 
     assert _alive(child_pid), "the sweep signalled a group whose id might not be ours"
 
@@ -207,6 +207,43 @@ def test_sweep_runs_when_the_caller_knows_the_group_is_ours(leader_with_child) -
     process_module.sweep_process_group(group, drain_timeout=SHORT_DRAIN, group_is_ours=True)
 
     assert _wait_until(lambda: not _alive(child_pid)), "descendant survived a sanctioned sweep"
+
+
+class _NeverReaps:
+    """A process whose wait() always times out, standing in for a wedged Nuke.
+
+    Real uninterruptible sleep cannot be staged on demand, and this is the
+    input that matters: teardown cannot reap the leader, so the group id is
+    still ours and the sweep must go ahead anyway.
+    """
+
+    def __init__(self, process: subprocess.Popen) -> None:
+        self._process = process
+
+    def poll(self) -> None:
+        return None
+
+    def terminate(self) -> None:
+        self._process.terminate()
+
+    def kill(self) -> None:
+        self._process.kill()
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        raise subprocess.TimeoutExpired(cmd="stand-in", timeout=timeout or 0)
+
+
+@posix_only
+def test_stops_descendant_when_the_leader_cannot_be_reaped(tmp_path: Path) -> None:
+    stubborn_child = "/bin/sh -c 'trap \"\" TERM; sleep 300'"
+    with _stand_in_for_nuke(tmp_path, stubborn_child) as (process, group, child_pid):
+        wedged = cast(subprocess.Popen, _NeverReaps(process))
+
+        process_module.stop_process_tree(wedged, group, drain_timeout=SHORT_DRAIN)
+
+        assert _wait_until(
+            lambda: not _alive(child_pid)
+        ), "descendant survived a leader that could not be reaped"
 
 
 @posix_only

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -95,10 +95,15 @@ def _stand_in_for_nuke(tmp_path: Path, child_command: str):
     )
     group: Optional[int] = None
     try:
+        # Captured before anything that can fail: start_new_session has
+        # already taken effect when Popen returns, and teardown needs the
+        # group to reach the backgrounded child. Waiting until after the
+        # assertion below would leak that child for its full sleep whenever
+        # the assertion fires.
+        group = process_module.capture_process_group(process)
         assert _wait_until(
             lambda: child_pid_file.is_file() and child_pid_file.read_text().strip().isdigit()
         ), "stand-in process never reported its child"
-        group = process_module.capture_process_group(process)
         child_pid = int(child_pid_file.read_text().strip())
         assert group == process.pid, "start_new_session should make the process a group leader"
         assert _alive(child_pid)
@@ -184,6 +189,37 @@ def test_survivors_get_a_chance_to_exit_cleanly(tmp_path: Path) -> None:
 
         assert _wait_until(lambda: not _alive(child_pid)), "descendant outlived the teardown"
         assert farewell.is_file(), "descendant was killed without being asked to stop first"
+
+
+@posix_only
+def test_sweep_leaves_a_group_alone_when_the_id_may_be_reassigned(leader_with_child) -> None:
+    """With a live pid owning the group id, the sweep must not signal.
+
+    Standing in for the case it exists to prevent: our leader was reaped and
+    the id has since been handed to an unrelated process. That cannot be
+    staged directly, since pid reuse is not controllable, so this uses the
+    same input the check sees, a live process owning the id.
+    """
+    process, group, child_pid = leader_with_child
+
+    process_module.sweep_process_group(group)
+
+    assert _alive(child_pid), "the sweep signalled a group whose id might not be ours"
+
+
+@posix_only
+def test_sweep_runs_when_the_caller_knows_the_group_is_ours(leader_with_child) -> None:
+    """An unreaped leader is proof the id was not reassigned.
+
+    Without ``group_is_ours`` this is indistinguishable from a recycled id,
+    so the sweep would skip and leave the group running. That is the state
+    teardown is in when the leader survives its own SIGKILL.
+    """
+    process, group, child_pid = leader_with_child
+
+    process_module.sweep_process_group(group, group_is_ours=True)
+
+    assert _wait_until(lambda: not _alive(child_pid)), "descendant survived a sanctioned sweep"
 
 
 @posix_only

--- a/test/unit/test_nuke_submitter_ui_process.py
+++ b/test/unit/test_nuke_submitter_ui_process.py
@@ -56,6 +56,11 @@ posix_only = pytest.mark.skipif(
 )
 
 
+# Drain window for tests that deliberately spend it. The production default
+# is sized for a real frame server; these stand-ins need no grace at all.
+SHORT_DRAIN = 0.5
+
+
 def _alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -155,7 +160,9 @@ def test_stops_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
     """
     stubborn_child = "/bin/sh -c 'trap \"\" TERM; sleep 300'"
     with _stand_in_for_nuke(tmp_path, stubborn_child) as (process, group, child_pid):
-        process_module.stop_process_tree(process, group)
+        # A short window keeps this quick: the production default is sized for
+        # a frame server releasing a license seat, not for /bin/sh.
+        process_module.stop_process_tree(process, group, drain_timeout=SHORT_DRAIN)
 
         assert _wait_until(
             lambda: not _alive(child_pid)
@@ -217,7 +224,7 @@ def test_sweep_runs_when_the_caller_knows_the_group_is_ours(leader_with_child) -
     """
     process, group, child_pid = leader_with_child
 
-    process_module.sweep_process_group(group, group_is_ours=True)
+    process_module.sweep_process_group(group, drain_timeout=SHORT_DRAIN, group_is_ours=True)
 
     assert _wait_until(lambda: not _alive(child_pid)), "descendant survived a sanctioned sweep"
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`NukeSession.close()` signalled only the Nuke process the suite launched. Nuke's children outlive it (crash handler, frame server, render workers), so every case left 6 processes behind and they accumulated across a run.

The frame server binds a fixed port and holds a license, so leftovers break later launches: Nuke starts, the opener reports success, but the submitter dialog never reaches the accessibility tree and the case fails with an unrelated-looking `wait_visible` timeout.

### What was the solution? (How)

Stop Nuke by process group, which the launch already allows (`start_new_session=True` makes it a group leader). `stop_process_tree()` is the single entry point, used by `close()` and by the launcher's pre-session failure path: signal the group, `terminate()`, `wait()` (which reaps, so no zombie per launch), escalate to `SIGKILL` if needed, then sweep the group for surviving children.

Points worth checking:

* **When the sweep is safe** rests on POSIX [XBD 4.17](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_17). A group id is not reused while any member remains, so a surviving group is still ours even after its leader exits (the crashed-Nuke case). The leader's pid, which is the group id, does become reusable once reaped, so the guard is "does a live process own this id" (`group_id_was_recycled`), not "did the leader exit".
* The group is captured at launch, while the process is known alive. Resolving it later either fails or reports a stranger's group.
* Signals sent while the leader is alive are intentionally unguarded: that check would match our own leader and suppress them.
* Windows has no process groups and no `SIGKILL`, so signals are resolved behind a `sys.platform` guard. Naming `SIGKILL` at a call site raises `AttributeError` there, not just a typing error.
* Teardown never raises, including the `wait()` after `SIGKILL`. Reaching that means the process is wedged in the kernel, and raising would replace the failure that asked for teardown (on the launcher's failure path, `Nuke exited early` plus Nuke's log tails).

The rules live in a new `_process.py` with no GUI-suite dependencies, so they are unit tested in CI. The GUI test cannot reach these paths.

Two deliberate tradeoffs: the ownership check errs toward leaking rather than risking a wrongful kill, and an exited Nuke whose group id was taken over keeps its frame server. A leak is detectable and recoverable; `SIGKILL`ing a stranger's group is not.

### What is the impact of this change?

Test-only. Runs no longer leak processes, and the teardown rules are now covered by CI on all three platforms instead of only on a licensed workstation.

### How was this change tested?

macOS 15.7.7, Nuke 16.0v7.

Surviving Nuke processes after `pytest test/nuke_submitter_ui -o addopts= -q`, from zero strays: **6 before, 0 after**.

Both teardown shapes, against a `/bin/sh` stand-in that backgrounds a child in its own session:

```
live_leader:   descendant_stopped=True
exited_leader: descendant_stopped=True
```

`test/unit/test_nuke_submitter_ui_process.py` adds 6 tests: both shapes, a child that ignores `SIGTERM`, the recycled-id check, repeat calls, and the no-process-group path. 194 passed on Linux and macOS; on Windows the no-group case runs natively and the POSIX cases skip. Removing the group sweep fails two of them, so they are real regression tests.

GUI suite green (`1 passed`). `ruff`, `black --check`, and `mypy` clean, the last under `--platform win32`, `linux`, and `darwin`.

#### Please run the integration tests and paste the results below

Not applicable: this changes the opt-in GUI suite's teardown. That suite plus the new unit tests are the coverage, above.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

Not applicable, no changes under `installer/` or `src/`.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not run: test-harness teardown only, nothing under `src/` is modified, so bundle output cannot change.

### Was this change documented?

In `_process.py`: the module docstring records the process-group reuse rules, and each function documents why its guards exist. No user-facing docs apply.

### Is this a breaking change?

No. Test-only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
