### PR TITLE
test: port the frame-range and write-node Squish cases 

### DIFF
--- a/test/nuke_submitter_ui/README.md
+++ b/test/nuke_submitter_ui/README.md
@@ -63,5 +63,22 @@ canonically, in the `pages.py` module docstring.
 
 ## Status
 
-Ported Squish cases: `basic_workflow_gui` (as case `basic_workflow`).
-Remaining: 8 cases — see `test/squish/suite_nuke_submitter/`.
+Ported Squish cases:
+
+| Squish case | case(s) here |
+| --- | --- |
+| `basic_workflow_gui` | `basic_workflow` |
+| `custom_frame_range_gui` | `custom_frame_range` |
+| `default_frame_range_gui` | `default_frame_range` |
+| `write_node_limit_gui` | `write_node_frame_limit` |
+| `write_node_gui` | `write_node_selection_single`, `write_node_selection_all` |
+
+`write_node_gui` submitted twice from one scene; since a case here exports one
+bundle, each submission became its own case.
+
+Remaining: `custom_settings_gui`, `manual_attachments_gui`, `ocio_gui`,
+`invalid_conda_gui`. Squish stays until they are ported.
+
+Scenes are built programmatically rather than opening the Squish `.nk` sample
+files, so the suite needs no Git LFS assets and each case's inputs are
+readable in its `scene.py`.

--- a/test/nuke_submitter_ui/pages.py
+++ b/test/nuke_submitter_ui/pages.py
@@ -49,6 +49,7 @@ from deadline_test_fixtures.xa11y import SharedSubmitterDialog
 from deadline_test_fixtures.xa11y.controls import (
     TAB_JOB_SPECIFIC,
     TAB_SHARED,
+    is_checked,
     set_checkbox,
     set_text_field,
     switch_to_tab,
@@ -328,6 +329,18 @@ class NukeSubmitterDialog(SharedSubmitterDialog):
     def set_override_frame_range(self, enabled: bool) -> None:
         self._front()
         set_checkbox(self.window, CHECKBOX_OVERRIDE_FRAME_RANGE, enabled, timeout=WIDGET_TIMEOUT)
+
+    def override_frame_range_enabled(self) -> bool:
+        """Whether the frame-range override is checked.
+
+        Cases that verify range inheritance assert this is off rather than
+        forcing it, so a change to the dialog's default surfaces as a failure
+        instead of being silently overwritten.
+        """
+        self._front()
+        box = self.window.descendant(f'check_box[name="{CHECKBOX_OVERRIDE_FRAME_RANGE}"]')
+        box.wait_visible(timeout=WIDGET_TIMEOUT)
+        return is_checked(box)
 
     def set_frame_range(self, frame_range: str) -> None:
         """Enable the override and type a frame range (e.g. ``1-5``)."""

--- a/test/nuke_submitter_ui/test_cases/basic_workflow/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/basic_workflow/input/configure.py
@@ -17,6 +17,7 @@ def configure(dialog) -> None:
     dialog.set_job_name("Basic Workflow Submission Test")
     dialog.set_job_description("Basic Workflow Test Description")
     dialog.switch_to_job_specific_tab()
-    assert dialog.selected_write_node() == "All write nodes"
+    opened_with = dialog.selected_write_node()
+    assert opened_with == "All write nodes", f"dialog opened showing {opened_with!r}"
     dialog.select_write_node("Write1")
     dialog.set_chunk_size(5)

--- a/test/nuke_submitter_ui/test_cases/custom_frame_range/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/custom_frame_range/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/custom_frame_range/actual/custom_frame_range.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/custom_frame_range/actual/renders
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/custom_frame_range/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/custom_frame_range/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,23 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/custom_frame_range/actual/custom_frame_range.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/custom_frame_range/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/custom_frame_range/expected/job_bundle/template.yaml
@@ -1,0 +1,153 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Custom Frame Range Job
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: This test verifies that a custom frame range can be specified

--- a/test/nuke_submitter_ui/test_cases/custom_frame_range/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/custom_frame_range/input/configure.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Dialog configurator for the custom_frame_range case.
+
+Port of the Squish custom_frame_range_gui case: enable the frame-range
+override and submit a range (1-10) narrower than the scene's own 1-100, so
+the golden's Frames parameter proves the override was applied rather than
+the scene range inherited.
+"""
+
+FRAME_RANGE = "1-10"
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Custom Frame Range Job")
+    dialog.set_job_description("This test verifies that a custom frame range can be specified")
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write1")
+    dialog.set_frame_range(FRAME_RANGE)
+    assert (
+        dialog.frame_range_field().element().value == FRAME_RANGE
+    ), "frame-range override did not take the typed value"

--- a/test/nuke_submitter_ui/test_cases/custom_frame_range/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/custom_frame_range/input/scene.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene script for the custom_frame_range case — executed INSIDE GUI Nuke
+by the suite's opener hook (test/nuke_submitter_ui/_opener/menu.py).
+
+Contract: build the scene, then save it to the path named by the
+NUKE_SUBMITTER_UI_SCENE_FILE environment variable. Keep everything
+deterministic — the exported bundle is compared against committed goldens.
+
+The scene range (1-100) is deliberately wider than the range the
+configurator overrides it with, so the golden's Frames parameter can only
+be produced by the override actually taking effect.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(100)
+
+color_wheel = nuke.nodes.ColorWheel()
+write_node = nuke.nodes.Write(name="Write1")
+write_node.setInput(0, color_wheel)
+write_node["file"].setValue(os.path.join(scene_dir, "renders", "custom_frame_range.####.exr"))
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_cases/default_frame_range/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/default_frame_range/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/default_frame_range/actual/default_frame_range.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/default_frame_range/actual/renders
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/default_frame_range/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/default_frame_range/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,23 @@
+parameterValues:
+- name: Frames
+  value: 25-75
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/default_frame_range/actual/default_frame_range.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/default_frame_range/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/default_frame_range/expected/job_bundle/template.yaml
@@ -1,0 +1,154 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Default Frame Range Job
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: This test verifies that the default frame range specified in the Nuke
+  Script is used

--- a/test/nuke_submitter_ui/test_cases/default_frame_range/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/default_frame_range/input/configure.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Dialog configurator for the default_frame_range case.
+
+Port of the Squish default_frame_range_gui case: submit WITHOUT touching
+the frame-range controls, so the golden's Frames parameter proves the
+scene's own root range (25-75, set by scene.py) is inherited. The override
+checkbox is asserted off rather than set, since inheriting the scene range
+is exactly what this case verifies.
+"""
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Default Frame Range Job")
+    dialog.set_job_description(
+        "This test verifies that the default frame range specified in the Nuke Script is used"
+    )
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write1")
+    assert not dialog.override_frame_range_enabled(), (
+        "the frame-range override is on by default in this dialog; this case must submit with it "
+        "off to prove the scene range is inherited"
+    )

--- a/test/nuke_submitter_ui/test_cases/default_frame_range/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/default_frame_range/input/scene.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene script for the default_frame_range case — executed INSIDE GUI Nuke
+by the suite's opener hook (test/nuke_submitter_ui/_opener/menu.py).
+
+Contract: build the scene, then save it to the path named by the
+NUKE_SUBMITTER_UI_SCENE_FILE environment variable. Keep everything
+deterministic — the exported bundle is compared against committed goldens.
+
+The range here (25-75) is deliberately not the Nuke default and differs
+from every other case's, so the golden's Frames parameter can only come
+from this scene's own root range.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+
+nuke.root()["first_frame"].setValue(25)
+nuke.root()["last_frame"].setValue(75)
+
+color_wheel = nuke.nodes.ColorWheel()
+write_node = nuke.nodes.Write(name="Write1")
+write_node.setInput(0, color_wheel)
+write_node["file"].setValue(os.path.join(scene_dir, "renders", "default_frame_range.####.exr"))
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_cases/write_node_frame_limit/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_frame_limit/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_frame_limit/actual/write_node_frame_limit.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_frame_limit/actual/renders
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/write_node_frame_limit/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_frame_limit/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,23 @@
+parameterValues:
+- name: Frames
+  value: 5-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_frame_limit/actual/write_node_frame_limit.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/write_node_frame_limit/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_frame_limit/expected/job_bundle/template.yaml
@@ -1,0 +1,153 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Write Node Frame Range Limits Job
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: Verify that the Write node frame range limits are respected

--- a/test/nuke_submitter_ui/test_cases/write_node_frame_limit/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_frame_limit/input/configure.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Dialog configurator for the write_node_frame_limit case.
+
+Port of the Squish write_node_limit_gui case: select the write node that
+declares its own frame-range limit (5-10, set in scene.py) and submit with
+the frame-range override off, so the golden's Frames parameter proves the
+node's limit wins over the wider scene range (1-100).
+"""
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Write Node Frame Range Limits Job")
+    dialog.set_job_description("Verify that the Write node frame range limits are respected")
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write1")
+    assert (
+        not dialog.override_frame_range_enabled()
+    ), "the override must stay off for the write node's own limit to apply"

--- a/test/nuke_submitter_ui/test_cases/write_node_frame_limit/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_frame_limit/input/scene.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene script for the write_node_frame_limit case — executed INSIDE GUI
+Nuke by the suite's opener hook (test/nuke_submitter_ui/_opener/menu.py).
+
+Contract: build the scene, then save it to the path named by the
+NUKE_SUBMITTER_UI_SCENE_FILE environment variable. Keep everything
+deterministic — the exported bundle is compared against committed goldens.
+
+Write1 carries its own frame-range limit (use_limit, 5-10) inside a much
+wider scene range (1-100). The submitter prefers a selected write node's
+own limit over the scene range when the override is off, so the golden's
+Frames parameter (5-10) can only be produced by that limit being honored.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(100)
+
+color_wheel = nuke.nodes.ColorWheel()
+write_node = nuke.nodes.Write(name="Write1")
+write_node.setInput(0, color_wheel)
+write_node["file"].setValue(os.path.join(scene_dir, "renders", "write_node_frame_limit.####.exr"))
+write_node["use_limit"].setValue(True)
+write_node["first"].setValue(5)
+write_node["last"].setValue(10)
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,10 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_all/actual/write_node_selection_all.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_all/actual/renders/write1
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_all/actual/renders/write2
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,21 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_all/actual/write_node_selection_all.nk
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/expected/job_bundle/template.yaml
@@ -1,0 +1,154 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Multiple Write Node Submission Test
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+  - Write2
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: All write nodes option selected for submission

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/configure.py
@@ -6,10 +6,11 @@ Second half of the Squish write_node_gui case (see
 write_node_selection_single for the split). Submits every write node from the
 same two-node scene.
 
-"All write nodes" is the dialog default, and the assertion comes first for
-that reason: selecting before checking would quietly correct a changed
-default and the check could never fail. The select call stays so the case
-still states what it submits, and is a no-op while the default holds.
+The combo is driven to Write1 and back so this exercises switching to
+all-nodes, as the Squish case did on its second submission in the same
+session. Each case here starts from a fresh dialog, so without that detour
+the selection would already be the default and nothing would be exercised.
+The default is checked first, before anything moves it.
 """
 
 from pages import WRITE_NODES_ALL
@@ -19,5 +20,11 @@ def configure(dialog) -> None:
     dialog.set_job_name("Multiple Write Node Submission Test")
     dialog.set_job_description("All write nodes option selected for submission")
     dialog.switch_to_job_specific_tab()
-    assert dialog.selected_write_node() == WRITE_NODES_ALL
+
+    opened_with = dialog.selected_write_node()
+    assert opened_with == WRITE_NODES_ALL, f"dialog opened showing {opened_with!r}"
+
+    dialog.select_write_node("Write1")
     dialog.select_write_node(WRITE_NODES_ALL)
+    selected = dialog.selected_write_node()
+    assert selected == WRITE_NODES_ALL, f"write-node combo shows {selected!r}"

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/configure.py
@@ -3,10 +3,13 @@
 """Dialog configurator for the write_node_selection_all case.
 
 Second half of the Squish write_node_gui case (see
-write_node_selection_single for the split). Submits every write node from
-the same two-node scene. "All write nodes" is the dialog default, so the
-selection is asserted rather than clicked — a real regression here would be
-the default silently changing, which the assertion catches.
+write_node_selection_single for the split). Submits every write node from the
+same two-node scene.
+
+"All write nodes" is the dialog default, and the assertion comes first for
+that reason: selecting before checking would quietly correct a changed
+default and the check could never fail. The select call stays so the case
+still states what it submits, and is a no-op while the default holds.
 """
 
 from pages import WRITE_NODES_ALL
@@ -16,5 +19,5 @@ def configure(dialog) -> None:
     dialog.set_job_name("Multiple Write Node Submission Test")
     dialog.set_job_description("All write nodes option selected for submission")
     dialog.switch_to_job_specific_tab()
-    dialog.select_write_node(WRITE_NODES_ALL)
     assert dialog.selected_write_node() == WRITE_NODES_ALL
+    dialog.select_write_node(WRITE_NODES_ALL)

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/configure.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Dialog configurator for the write_node_selection_all case.
+
+Second half of the Squish write_node_gui case (see
+write_node_selection_single for the split). Submits every write node from
+the same two-node scene. "All write nodes" is the dialog default, so the
+selection is asserted rather than clicked — a real regression here would be
+the default silently changing, which the assertion catches.
+"""
+
+from pages import WRITE_NODES_ALL
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Multiple Write Node Submission Test")
+    dialog.set_job_description("All write nodes option selected for submission")
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node(WRITE_NODES_ALL)
+    assert dialog.selected_write_node() == WRITE_NODES_ALL

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_all/input/scene.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene script for the write_node_selection_all case — executed INSIDE GUI
+Nuke by the suite's opener hook (test/nuke_submitter_ui/_opener/menu.py).
+
+Contract: build the scene, then save it to the path named by the
+NUKE_SUBMITTER_UI_SCENE_FILE environment variable. Keep everything
+deterministic — the exported bundle is compared against committed goldens.
+
+Intentionally identical to write_node_selection_single's scene (cases are
+self-contained by design, so it is duplicated rather than imported): with
+the scene held constant, the difference between the two cases' goldens is
+exactly the effect of the write-node selection.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+renders_dir = os.path.join(scene_dir, "renders")
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(10)
+
+color_wheel = nuke.nodes.ColorWheel()
+for node_name in ("Write1", "Write2"):
+    write_node = nuke.nodes.Write(name=node_name)
+    write_node.setInput(0, color_wheel)
+    # A directory per write node, so the exported asset references show
+    # which nodes the submission actually covers.
+    write_node["file"].setValue(
+        os.path.join(renders_dir, node_name.lower(), f"{node_name.lower()}.####.exr")
+    )
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_single/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_single/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,10 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_single/actual/write_node_selection_single.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_single/actual/renders/write1
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_single/actual/renders/write2
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_single/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_single/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,23 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/write_node_selection_single/actual/write_node_selection_single.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_single/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_single/expected/job_bundle/template.yaml
@@ -1,0 +1,154 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Single Write Node Submission Test
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+  - Write2
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: Selected single write node for submission

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_single/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_single/input/configure.py
@@ -21,4 +21,5 @@ def configure(dialog) -> None:
     dialog.set_job_description("Selected single write node for submission")
     dialog.switch_to_job_specific_tab()
     dialog.select_write_node("Write1")
-    assert dialog.selected_write_node() == "Write1"
+    selected = dialog.selected_write_node()
+    assert selected == "Write1", f"write-node combo shows {selected!r}"

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_single/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_single/input/configure.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Dialog configurator for the write_node_selection_single case.
+
+First half of the Squish write_node_gui case, which submitted twice from one
+multi-write-node scene. Each submission is a case here (the runner exports
+one bundle per case): this one selects a single write node, and
+write_node_selection_all selects every node from the identical scene.
+
+Note on this case's golden: the scene gives each write node its own output
+directory, and the exported asset references list BOTH of them even though
+only Write1 is submitted — output scanning is scene-wide, not scoped to the
+selected write node. That is current behavior, pinned here deliberately; if
+scanning is ever scoped to the selection, this golden changes and the
+difference becomes a conscious decision rather than a silent one.
+"""
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Single Write Node Submission Test")
+    dialog.set_job_description("Selected single write node for submission")
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write1")
+    assert dialog.selected_write_node() == "Write1"

--- a/test/nuke_submitter_ui/test_cases/write_node_selection_single/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/write_node_selection_single/input/scene.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene script for the write_node_selection_single case — executed INSIDE
+GUI Nuke by the suite's opener hook (test/nuke_submitter_ui/_opener/menu.py).
+
+Contract: build the scene, then save it to the path named by the
+NUKE_SUBMITTER_UI_SCENE_FILE environment variable. Keep everything
+deterministic — the exported bundle is compared against committed goldens.
+
+Two write nodes with distinct outputs. The companion
+write_node_selection_all case builds the same scene and differs only in the
+dialog selection, so the two goldens isolate exactly what selecting one
+node versus all nodes changes in the bundle.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+renders_dir = os.path.join(scene_dir, "renders")
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(10)
+
+color_wheel = nuke.nodes.ColorWheel()
+for node_name in ("Write1", "Write2"):
+    write_node = nuke.nodes.Write(name=node_name)
+    write_node.setInput(0, color_wheel)
+    # A directory per write node, so the exported asset references show
+    # which nodes the submission actually covers.
+    write_node["file"].setValue(
+        os.path.join(renders_dir, node_name.lower(), f"{node_name.lower()}.####.exr")
+    )
+
+nuke.scriptSaveAs(scene_file, overwrite=1)


### PR DESCRIPTION
Second in a series porting the Squish GUI cases onto the xa11y chassis from #330, after #339.

### What was the problem/requirement? (What/Why)

The Squish suite needs a commercial license, a Squish-for-Qt build matching Nuke's Qt, and a real farm with credentials. #330 replaced the first case with an offline equivalent. The rest have to move before Squish can go.

### What was the solution? (How)

Five cases: `custom_frame_range`, `default_frame_range`, `write_node_frame_limit`, and both halves of `write_node_gui`, which submitted twice from one scene (a case here exports one bundle, so each submission is its own case).

Each golden hinges on one thing, so a failure points at its cause:

| case | golden proves |
| --- | --- |
| `custom_frame_range` | `Frames: 1-10` from a 1-100 scene, so the override applied |
| `default_frame_range` | `Frames: 25-75` inherited from the scene |
| `write_node_frame_limit` | `Frames: 5-10` from the node's own `use_limit`, not the 1-100 scene |
| `write_node_selection_single` / `_all` | same two-node scene; `WriteNode: Write1` versus no such parameter |

Scenes are built in Python instead of opening the Squish `.nk` files, so there are no Git LFS assets and each case's setup is readable in its `scene.py`.

Adds one accessor, `override_frame_range_enabled`, so the two inheritance cases can assert the override is off instead of forcing it off. If the dialog's default changes, the case fails instead of hiding it.

One thing to flag: `write_node_selection_single`'s golden lists both write nodes' output directories even though only `Write1` is submitted, because output scanning is scene-wide. That is existing behaviour, pinned here so scoping it later is a deliberate change. Happy to file an issue if you want it tracked.

### What is the impact of this change?

Test-only and additive. Squish is untouched and stays until parity.

### How was this change tested?

macOS 15.7.7, Nuke 16.0v7: `6 passed in 98s` (these five plus `basic_workflow`), no leftover Nuke processes. Goldens were generated with `NUKE_SUBMITTER_UI_UPDATE_GOLDENS=1`, reviewed by hand, then re-verified in comparison mode against current mainline.

`ruff` and `black --check` clean. `mypy` clean on the changed files; the `conftest.py` missing-return it reports locally comes from running mypy without pytest installed and does not happen in CI.

#### Please run the integration tests and paste the results below

Not applicable. This adds cases to the opt-in GUI suite, whose result is above. That suite is not in CI: it needs a licensed GUI Nuke and a machine nobody is touching.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

Not applicable, nothing under `installer/` or `src/` changed.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. Nothing under `src/` changed, so bundle output cannot differ, and these goldens are exported bundles compared on every run.

### Was this change documented?

README status table, plus each case's `scene.py` and `configure.py`.

### Is this a breaking change?

No. Test-only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
