### PR TITLE
test: port the custom-settings Squish case

### DIFF
--- a/test/nuke_submitter_ui/README.md
+++ b/test/nuke_submitter_ui/README.md
@@ -72,12 +72,12 @@ Ported Squish cases:
 | `default_frame_range_gui` | `default_frame_range` |
 | `write_node_limit_gui` | `write_node_frame_limit` |
 | `write_node_gui` | `write_node_selection_single`, `write_node_selection_all` |
+| `custom_settings_gui` | `custom_settings` |
 
 `write_node_gui` submitted twice from one scene; since a case here exports one
 bundle, each submission became its own case.
 
-Remaining: `custom_settings_gui`, `manual_attachments_gui`, `ocio_gui`,
-`invalid_conda_gui`. Squish stays until they are ported.
+Remaining: `manual_attachments_gui`, `ocio_gui`, `invalid_conda_gui`. Squish stays until they are ported.
 
 Scenes are built programmatically rather than opening the Squish `.nk` sample
 files, so the suite needs no Git LFS assets and each case's inputs are

--- a/test/nuke_submitter_ui/pages.py
+++ b/test/nuke_submitter_ui/pages.py
@@ -70,6 +70,14 @@ _SPIN_CHUNK_SIZE = 1
 _SPIN_TARGET_CHUNK_DURATION = 2
 _TEXT_FRAME_RANGE = 1
 
+# Positional within the shared tab's "Job Properties" group, in document order
+# (1-based). That group lives in the shared client's UI, so its name is the
+# stable anchor and only the order inside it is positional.
+_GROUP_JOB_PROPERTIES = "Job Properties"
+_SPIN_PRIORITY = 1
+_SPIN_MAX_FAILED_TASKS = 2
+_SPIN_MAX_RETRIES = 3
+
 # Accessible names that exist today (Qt auto-derived from label/text).
 CHECKBOX_OVERRIDE_FRAME_RANGE = "Override frame range"
 CHECKBOX_PROXY_MODE = "Use proxy mode"
@@ -369,15 +377,26 @@ class NukeSubmitterDialog(SharedSubmitterDialog):
         spin.wait_visible(timeout=WIDGET_TIMEOUT)
         return spin
 
-    def _set_spin(self, index: int, target: int, attempts: int = 5) -> None:
-        """Type *target* into the spin box at *index* (see module notes on
-        spin boxes: AX increment/decrement step by 10% of range)."""
+    def _type_into_spin(
+        self,
+        locate: Callable[[], xa11y.Locator],
+        target: int,
+        description: str,
+        attempts: int = 5,
+    ) -> None:
+        """Type *target* into the spin box *locate* returns.
+
+        Typed rather than stepped: AX increment/decrement move by 10% of the
+        widget's range (see module notes), so most values are unreachable.
+        *locate* is a callable because the element must be re-resolved per
+        attempt, as the AX tree churns when frontmost state changes.
+        """
         sim = xa11y.input_sim()
         last_seen = "<never read>"
         for _ in range(attempts):
             self._front()
             try:
-                element = self._spin(index).element()
+                element = locate().element()
                 bounds = element.bounds
                 text_spot = (int(bounds.x + bounds.width * 0.3), int(bounds.y + bounds.height / 2))
                 sim.click(text_spot)
@@ -389,13 +408,47 @@ class NukeSubmitterDialog(SharedSubmitterDialog):
                 sim.press("Tab")
                 time.sleep(0.5)
                 self._front()
-                last_seen = str(self._spin(index).element().value or "")
+                last_seen = str(locate().element().value or "")
                 if last_seen == str(target):
                     return
             except Exception as exc:
                 last_seen = f"<error: {exc!r}>"
                 time.sleep(1.0)
-        raise AssertionError(f"Spin button {index} did not reach {target}; last: {last_seen}")
+        raise AssertionError(f"{description} did not reach {target}; last: {last_seen}")
+
+    def _set_spin(self, index: int, target: int, attempts: int = 5) -> None:
+        self._type_into_spin(
+            lambda: self._spin(index), target, f"Spin button {index}", attempts=attempts
+        )
+
+    def _job_properties_spin(self, index: int) -> xa11y.Locator:
+        """A spin box in the shared tab's Job Properties group."""
+        self._front()
+        spin = (
+            self.window.descendant(f'group[name="{_GROUP_JOB_PROPERTIES}"]')
+            .descendant("spin_button")
+            .nth(index)
+        )
+        spin.wait_visible(timeout=WIDGET_TIMEOUT)
+        return spin
+
+    def _set_job_properties_spin(self, index: int, value: int, description: str) -> None:
+        self.switch_to_shared_tab()
+        self._type_into_spin(lambda: self._job_properties_spin(index), value, description)
+
+    def set_priority(self, value: int) -> None:
+        """Set job priority.
+
+        Not the shared fixtures' ``set_priority``, which steps with AX
+        increment and so cannot land on most values here.
+        """
+        self._set_job_properties_spin(_SPIN_PRIORITY, value, "Priority")
+
+    def set_max_failed_tasks(self, value: int) -> None:
+        self._set_job_properties_spin(_SPIN_MAX_FAILED_TASKS, value, "Maximum failed tasks")
+
+    def set_max_retries(self, value: int) -> None:
+        self._set_job_properties_spin(_SPIN_MAX_RETRIES, value, "Maximum retries per task")
 
     def set_chunk_size(self, chunk_size: int) -> None:
         self._set_spin(_SPIN_CHUNK_SIZE, chunk_size)

--- a/test/nuke_submitter_ui/test_cases/custom_settings/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/custom_settings/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/custom_settings/actual/custom_settings.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/custom_settings/actual/renders
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/custom_settings/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/custom_settings/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,23 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/custom_settings/actual/custom_settings.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'true'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 10
+- name: deadline:maxRetriesPerTask
+  value: 3
+- name: deadline:priority
+  value: 75

--- a/test/nuke_submitter_ui/test_cases/custom_settings/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/custom_settings/expected/job_bundle/template.yaml
@@ -1,0 +1,153 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Custom Setting Submission
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: This test verifies submission with modified settings

--- a/test/nuke_submitter_ui/test_cases/custom_settings/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/custom_settings/input/configure.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Dialog configurator for the custom_settings case.
+
+Port of the Squish custom_settings_gui case: override the job properties
+(priority, max failed tasks, max retries per task) and enable continue-on
+-error, then let the golden bundle prove each value reached the submission.
+
+The values are deliberately not multiples of the spin boxes' AX step: the
+platform's increment/decrement jumps by 10% of a widget's range, so a
+stepping implementation could not produce 75 or 3 at all (see the spin-box
+note in pages.py). Typed entry is what makes these values reachable.
+"""
+
+PRIORITY = 75
+MAX_RETRIES_PER_TASK = 3
+MAX_FAILED_TASKS = 10
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Custom Setting Submission")
+    dialog.set_job_description("This test verifies submission with modified settings")
+    dialog.set_priority(PRIORITY)
+    dialog.set_max_failed_tasks(MAX_FAILED_TASKS)
+    dialog.set_max_retries(MAX_RETRIES_PER_TASK)
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write1")
+    dialog.set_continue_on_error(True)

--- a/test/nuke_submitter_ui/test_cases/custom_settings/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/custom_settings/input/scene.py
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene script for the custom_settings case — executed INSIDE GUI Nuke by
+the suite's opener hook (test/nuke_submitter_ui/_opener/menu.py).
+
+Contract: build the scene, then save it to the path named by the
+NUKE_SUBMITTER_UI_SCENE_FILE environment variable. Keep everything
+deterministic — the exported bundle is compared against committed goldens.
+
+A minimal single-write-node scene: this case is about the job properties
+set in the dialog, so the scene is kept as plain as possible.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(10)
+
+color_wheel = nuke.nodes.ColorWheel()
+write_node = nuke.nodes.Write(name="Write1")
+write_node.setInput(0, color_wheel)
+write_node["file"].setValue(os.path.join(scene_dir, "renders", "custom_settings.####.exr"))
+
+nuke.scriptSaveAs(scene_file, overwrite=1)


### PR DESCRIPTION
Third in a series porting the Squish GUI cases to the xa11y suite from #330, after #339 and #340.

### What was the problem/requirement? (What/Why)

The Squish suite needs a commercial license, a Squish-for-Qt build matching Nuke's Qt, and a real farm with credentials. This ports `custom_settings_gui` so Squish is one case closer to retirement.

### What was the solution? (How)

One case, `custom_settings`. It sets priority, max failed tasks and max retries per task, turns on continue-on-error, and the golden records all four: priority 75, `maxFailedTasksCount` 10, `maxRetriesPerTask` 3, `ContinueOnError` true.

Those values need typed entry. The shared fixtures set these spin boxes by AX increment, which jumps 10% of the widget range, so 75 and 3 are not reachable by stepping. `pages.py` already typed values into the Job-specific tab's spin boxes for chunk size, so that code now takes any spin locator and is reused for the shared tab's Job Properties group. The case picks values that are not multiples of the step, so a regression back to stepping fails instead of passing by luck.

### What is the impact of this change?

Test-only and additive: one case folder, three accessors, a README row.

### How was this change tested?

macOS 15.7.7, Nuke 16.0v7, against current mainline: `7 passed in 97s`, no leftover Nuke processes.

The golden was generated with `NUKE_SUBMITTER_UI_UPDATE_GOLDENS=1`, checked by hand for the four values, then re-verified in comparison mode.

`ruff` and `black --check` clean. `mypy` clean on the changed files. It also reports a missing return in `conftest.py`, which only happens when mypy runs without pytest installed, not in CI.

#### Please run the integration tests and paste the results below

Not applicable. This adds a case to the opt-in GUI suite, and that result is above. The suite is not in CI because it needs a licensed GUI Nuke and an idle machine.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

Not applicable, nothing under `installer/` or `src/` changed.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. Nothing under `src/` changed, so bundle output cannot differ. This case's golden is an exported bundle, compared on every run.

### Was this change documented?

README status row, plus the case's `scene.py` and `configure.py`.

### Is this a breaking change?

No. Test-only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
