### PR TITLE
test: port the OCIO Squish cases

### DIFF
--- a/test/nuke_submitter_ui/README.md
+++ b/test/nuke_submitter_ui/README.md
@@ -73,11 +73,12 @@ Ported Squish cases:
 | `write_node_limit_gui` | `write_node_frame_limit` |
 | `write_node_gui` | `write_node_selection_single`, `write_node_selection_all` |
 | `custom_settings_gui` | `custom_settings` |
+| `ocio_gui` | `ocio_stock_write1`, `ocio_stock_write2` |
 
 `write_node_gui` submitted twice from one scene; since a case here exports one
 bundle, each submission became its own case.
 
-Remaining: `manual_attachments_gui`, `ocio_gui`, `invalid_conda_gui`. Squish stays until they are ported.
+Remaining: `manual_attachments_gui`, `invalid_conda_gui`. Squish stays until they are ported.
 
 Scenes are built programmatically rather than opening the Squish `.nk` sample
 files, so the suite needs no Git LFS assets and each case's inputs are

--- a/test/nuke_submitter_ui/README.md
+++ b/test/nuke_submitter_ui/README.md
@@ -75,8 +75,9 @@ Ported Squish cases:
 | `custom_settings_gui` | `custom_settings` |
 | `ocio_gui` | `ocio_stock_write1`, `ocio_stock_write2` |
 
-`write_node_gui` submitted twice from one scene; since a case here exports one
-bundle, each submission became its own case.
+`write_node_gui` and `ocio_gui` each submitted twice from one scene; since a
+case here exports one bundle, each submission became its own case. The OCIO
+cases pin the `aces_1.2` stock config, as the Squish scene did.
 
 Remaining: `manual_attachments_gui`, `invalid_conda_gui`. Squish stays until they are ported.
 

--- a/test/nuke_submitter_ui/_launcher.py
+++ b/test/nuke_submitter_ui/_launcher.py
@@ -52,7 +52,14 @@ ENV_OPEN_DELAY_MS = "NUKE_SUBMITTER_UI_OPEN_DELAY_MS"
 
 # Inherited AWS settings that would override the mock credentials or point
 # at restricted files (e.g. agent credential sandboxes).
-_SCRUBBED_ENV_VARS = ("AWS_CONFIG_FILE", "AWS_SHARED_CREDENTIALS_FILE", "AWS_PROFILE")
+# OCIO is scrubbed because the submitter prefers an OCIO env var over the
+# scene's own config, so a host value would change what the OCIO cases test.
+_SCRUBBED_ENV_VARS = (
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_PROFILE",
+    "OCIO",
+)
 
 
 def _version_key(path: Path) -> tuple[int, ...]:

--- a/test/nuke_submitter_ui/_utils.py
+++ b/test/nuke_submitter_ui/_utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from datetime import datetime
 from pathlib import Path
@@ -22,6 +23,16 @@ _T0 = time.monotonic()
 PATH_PLACEHOLDER = "<REPO_ROOT>"
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# OCIO-managed scenes reference Nuke's stock config, whose path carries the
+# install location, the exact Nuke version and the platform's layout. Only the
+# tail (which config, which files) is worth pinning.
+OCIO_CONFIGS_PLACEHOLDER = "<NUKE_OCIO_CONFIGS>"
+# Applied at comparison time and when writing goldens, so committed files are
+# already canonical. Quotes are excluded so a quoted YAML scalar keeps them.
+_PATH_REGEX_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    (r"[^\s'\"]*/OCIOConfigs/configs", OCIO_CONFIGS_PLACEHOLDER),
+)
+
 
 def log(message: str) -> None:
     elapsed = time.monotonic() - _T0
@@ -33,7 +44,8 @@ def nuke_bundle_normalization() -> BundleNormalization:
     """Normalization applied to BOTH bundles before structural comparison.
 
     * Machine-specific absolute paths: committed goldens carry
-      ``PATH_PLACEHOLDER`` where the resolved repo root appears.
+      ``PATH_PLACEHOLDER`` where the resolved repo root appears, and
+      ``OCIO_CONFIGS_PLACEHOLDER`` where Nuke's stock OCIO config tree does.
     * Conda package pins: the integration's own version and the Nuke minor
       version churn with releases; both sides are mapped to a canonical
       form so goldens don't need updating on every version bump. Ordering
@@ -42,7 +54,8 @@ def nuke_bundle_normalization() -> BundleNormalization:
     """
     return BundleNormalization(
         replacements={PATH_PLACEHOLDER: str(_REPO_ROOT)},
-        regex_replacements=(
+        regex_replacements=_PATH_REGEX_REPLACEMENTS
+        + (
             (
                 r"nuke=\d+\.\d+ nuke-openjd=\d+\.\d+\.\*",
                 "nuke=VERSION nuke-openjd=VERSION",
@@ -87,7 +100,8 @@ def write_goldens_from_actual(actual_dir: Path, expected_dir: Path) -> None:
     # sidecar, which are not golden material.
     for name in ("template.yaml", "parameter_values.yaml", "asset_references.yaml"):
         text = (actual_dir / name).read_text(encoding="utf-8")
-        (expected_dir / name).write_text(
-            text.replace(str(_REPO_ROOT), PATH_PLACEHOLDER), encoding="utf-8"
-        )
+        text = text.replace(str(_REPO_ROOT), PATH_PLACEHOLDER)
+        for pattern, replacement in _PATH_REGEX_REPLACEMENTS:
+            text = re.sub(pattern, replacement, text)
+        (expected_dir / name).write_text(text, encoding="utf-8")
         log(f"golden written: {expected_dir / name}")

--- a/test/nuke_submitter_ui/_utils.py
+++ b/test/nuke_submitter_ui/_utils.py
@@ -28,9 +28,11 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 # tail (which config, which files) is worth pinning.
 OCIO_CONFIGS_PLACEHOLDER = "<NUKE_OCIO_CONFIGS>"
 # Applied at comparison time and when writing goldens, so committed files are
-# already canonical. Quotes are excluded so a quoted YAML scalar keeps them.
+# already canonical. Anchored on a root or drive rather than "no whitespace",
+# so a Windows install under "Program Files" still matches, and either
+# separator is accepted because the comparison normalizes them only afterwards.
 _PATH_REGEX_REPLACEMENTS: tuple[tuple[str, str], ...] = (
-    (r"[^\s'\"]*/OCIOConfigs/configs", OCIO_CONFIGS_PLACEHOLDER),
+    (r"(?:[A-Za-z]:)?[\\/][^\"'\n]*?[\\/]OCIOConfigs[\\/]configs", OCIO_CONFIGS_PLACEHOLDER),
 )
 
 

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,12 @@
+assetReferences:
+  inputs:
+    directories:
+    - <NUKE_OCIO_CONFIGS>/nuke-default/luts
+    filenames:
+    - <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write1/actual/ocio_stock_write1.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write1/actual/renders/write1
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write1/actual/renders/write2
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/asset_references.yaml
@@ -1,9 +1,9 @@
 assetReferences:
   inputs:
     directories:
-    - <NUKE_OCIO_CONFIGS>/nuke-default/luts
+    - <NUKE_OCIO_CONFIGS>/aces_1.2/luts
     filenames:
-    - <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+    - <NUKE_OCIO_CONFIGS>/aces_1.2/config.ocio
     - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write1/actual/ocio_stock_write1.nk
   outputs:
     directories:

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,25 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write1/actual/ocio_stock_write1.nk
+- name: WriteNode
+  value: Write1
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: OCIOConfigPath
+  value: <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/parameter_values.yaml
@@ -14,7 +14,7 @@ parameterValues:
 - name: TargetChunkDuration
   value: 0
 - name: OCIOConfigPath
-  value: <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+  value: <NUKE_OCIO_CONFIGS>/aces_1.2/config.ocio
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/expected/job_bundle/template.yaml
@@ -1,0 +1,163 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: OCIO Config Job Submission
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: OCIOConfigPath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The OCIO config file used by this job.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+  - Write2
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: This test includes a render that includes the use of OCIO color management.
+jobEnvironments:
+- name: Add OCIO Path to Environment Variable
+  variables:
+    OCIO: '{{Param.OCIOConfigPath}}'

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/input/configure.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Configurator for ocio_stock_write1.
+
+First half of the Squish ocio_gui case, which submitted the same OCIO scene
+once per write node.
+"""
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("OCIO Config Job Submission")
+    dialog.set_job_description(
+        "This test includes a render that includes the use of OCIO color management."
+    )
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write1")
+    selected = dialog.selected_write_node()
+    assert selected == "Write1", f"write-node combo shows {selected!r}"

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/input/scene.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene for ocio_stock_write1, run inside GUI Nuke by the opener hook.
+
+Colour management is set to OCIO with a stock config, so the submitter adds
+the config to the job's environment and input assets. Two write nodes, as the
+Squish ocio_gui case had; ocio_stock_write2 builds the same scene and selects
+the other one.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+renders_dir = os.path.join(os.path.dirname(scene_file), "renders")
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(10)
+nuke.root()["colorManagement"].setValue("OCIO")
+
+color_wheel = nuke.nodes.ColorWheel()
+for node_name in ("Write1", "Write2"):
+    write_node = nuke.nodes.Write(name=node_name)
+    write_node.setInput(0, color_wheel)
+    write_node["file"].setValue(
+        os.path.join(renders_dir, node_name.lower(), f"{node_name.lower()}.####.exr")
+    )
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write1/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write1/input/scene.py
@@ -2,7 +2,8 @@
 
 """Scene for ocio_stock_write1, run inside GUI Nuke by the opener hook.
 
-Colour management is set to OCIO with a stock config, so the submitter adds
+Colour management is set to OCIO with the aces_1.2 stock config, as the
+Squish case had, so the submitter adds
 the config to the job's environment and input assets. Two write nodes, as the
 Squish ocio_gui case had; ocio_stock_write2 builds the same scene and selects
 the other one.
@@ -18,6 +19,9 @@ renders_dir = os.path.join(os.path.dirname(scene_file), "renders")
 nuke.root()["first_frame"].setValue(1)
 nuke.root()["last_frame"].setValue(10)
 nuke.root()["colorManagement"].setValue("OCIO")
+# Pinned, not left at the default: the Squish case used aces_1.2, and its
+# larger search-path and LUT tree is what the asset scan walks.
+nuke.root()["OCIO_config"].setValue("aces_1.2")
 
 color_wheel = nuke.nodes.ColorWheel()
 for node_name in ("Write1", "Write2"):

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/asset_references.yaml
@@ -1,9 +1,9 @@
 assetReferences:
   inputs:
     directories:
-    - <NUKE_OCIO_CONFIGS>/nuke-default/luts
+    - <NUKE_OCIO_CONFIGS>/aces_1.2/luts
     filenames:
-    - <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+    - <NUKE_OCIO_CONFIGS>/aces_1.2/config.ocio
     - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write2/actual/ocio_stock_write2.nk
   outputs:
     directories:

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,12 @@
+assetReferences:
+  inputs:
+    directories:
+    - <NUKE_OCIO_CONFIGS>/nuke-default/luts
+    filenames:
+    - <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write2/actual/ocio_stock_write2.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write2/actual/renders/write1
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write2/actual/renders/write2
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,25 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/ocio_stock_write2/actual/ocio_stock_write2.nk
+- name: WriteNode
+  value: Write2
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: OCIOConfigPath
+  value: <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/parameter_values.yaml
@@ -14,7 +14,7 @@ parameterValues:
 - name: TargetChunkDuration
   value: 0
 - name: OCIOConfigPath
-  value: <NUKE_OCIO_CONFIGS>/nuke-default/config.ocio
+  value: <NUKE_OCIO_CONFIGS>/aces_1.2/config.ocio
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/expected/job_bundle/template.yaml
@@ -1,0 +1,163 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: OCIO Config Job Submission
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: OCIOConfigPath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The OCIO config file used by this job.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+  - Write2
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: This test includes a render that includes the use of OCIO color management.
+jobEnvironments:
+- name: Add OCIO Path to Environment Variable
+  variables:
+    OCIO: '{{Param.OCIOConfigPath}}'

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/input/configure.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Configurator for ocio_stock_write2.
+
+Second half of the Squish ocio_gui case: the same scene submitted for the
+other write node.
+"""
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("OCIO Config Job Submission")
+    dialog.set_job_description(
+        "This test includes a render that includes the use of OCIO color management."
+    )
+    dialog.switch_to_job_specific_tab()
+    dialog.select_write_node("Write2")
+    selected = dialog.selected_write_node()
+    assert selected == "Write2", f"write-node combo shows {selected!r}"

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/input/scene.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene for ocio_stock_write2, run inside GUI Nuke by the opener hook.
+
+Colour management is set to OCIO with a stock config, so the submitter adds
+the config to the job's environment and input assets. Two write nodes, as the
+Squish ocio_gui case had; ocio_stock_write1 builds the same scene and selects
+the other one.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+renders_dir = os.path.join(os.path.dirname(scene_file), "renders")
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(10)
+nuke.root()["colorManagement"].setValue("OCIO")
+
+color_wheel = nuke.nodes.ColorWheel()
+for node_name in ("Write1", "Write2"):
+    write_node = nuke.nodes.Write(name=node_name)
+    write_node.setInput(0, color_wheel)
+    write_node["file"].setValue(
+        os.path.join(renders_dir, node_name.lower(), f"{node_name.lower()}.####.exr")
+    )
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_cases/ocio_stock_write2/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/ocio_stock_write2/input/scene.py
@@ -2,7 +2,8 @@
 
 """Scene for ocio_stock_write2, run inside GUI Nuke by the opener hook.
 
-Colour management is set to OCIO with a stock config, so the submitter adds
+Colour management is set to OCIO with the aces_1.2 stock config, as the
+Squish case had, so the submitter adds
 the config to the job's environment and input assets. Two write nodes, as the
 Squish ocio_gui case had; ocio_stock_write1 builds the same scene and selects
 the other one.
@@ -18,6 +19,9 @@ renders_dir = os.path.join(os.path.dirname(scene_file), "renders")
 nuke.root()["first_frame"].setValue(1)
 nuke.root()["last_frame"].setValue(10)
 nuke.root()["colorManagement"].setValue("OCIO")
+# Pinned, not left at the default: the Squish case used aces_1.2, and its
+# larger search-path and LUT tree is what the asset scan walks.
+nuke.root()["OCIO_config"].setValue("aces_1.2")
 
 color_wheel = nuke.nodes.ColorWheel()
 for node_name in ("Write1", "Write2"):


### PR DESCRIPTION
Fourth in a series porting the Squish GUI cases to the xa11y suite from #330, after #339, #340 and #342.

### What was the problem/requirement? (What/Why)

The Squish suite needs a commercial license, a Squish-for-Qt build matching Nuke's Qt, and a real farm with credentials. This ports `ocio_gui`, leaving `manual_attachments_gui` and `invalid_conda_gui`.

### What was the solution? (How)

`ocio_gui` submitted the same OCIO-managed scene once per write node, so it becomes two cases: `ocio_stock_write1` and `ocio_stock_write2`. The scenes are identical and only the selected node differs, so the goldens isolate the selection while both prove the OCIO config reaches the job, as the `OCIOConfigPath` parameter and as an `OCIO` environment variable. I checked they discriminate: removing `colorManagement` from the scene drops both from the bundle and the cases fail.

One chassis change. Nuke's stock OCIO config lives inside the install, so its path carries the install location, the platform layout and the exact Nuke version. `_utils.py` now collapses everything above the config name, in both the comparison and the goldens it writes, leaving `<NUKE_OCIO_CONFIGS>/nuke-default/config.ocio`. Without it, every Nuke upgrade rewrites these files and they never match on Linux or Windows.

### What is the impact of this change?

Test-only and additive: two case folders, one normalization rule, a README row.

### How was this change tested?

macOS 15.7.7, Nuke 16.0v7, against current mainline: `9 passed in 125s`, no leftover Nuke processes.

Goldens were generated with `NUKE_SUBMITTER_UI_UPDATE_GOLDENS=1` and checked by hand: OCIO paths are placeholders with no version in them, and the two cases differ only in scene file and `WriteNode`.

`ruff` and `black --check` clean. `mypy` clean on the changed files. It also reports a missing return in `conftest.py`, which only happens when mypy runs without pytest installed, not in CI.

#### Please run the integration tests and paste the results below

Not applicable. This adds cases to the opt-in GUI suite, and that result is above. The suite is not in CI because it needs a licensed GUI Nuke and an idle machine.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

Not applicable, nothing under `installer/` or `src/` changed.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. Nothing under `src/` changed, so bundle output cannot differ. These goldens are exported bundles, compared on every run.

### Was this change documented?

README status row, plus each case's `scene.py` and `configure.py`.

### Is this a breaking change?

No. Test-only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
