### PR TITLE
test: port the invalid-Conda Squish case

### DIFF
--- a/test/nuke_submitter_ui/README.md
+++ b/test/nuke_submitter_ui/README.md
@@ -74,12 +74,13 @@ Ported Squish cases:
 | `write_node_gui` | `write_node_selection_single`, `write_node_selection_all` |
 | `custom_settings_gui` | `custom_settings` |
 | `ocio_gui` | `ocio_stock_write1`, `ocio_stock_write2` |
+| `invalid_conda_gui` | `conda_queue_environment` |
 
 `write_node_gui` and `ocio_gui` each submitted twice from one scene; since a
 case here exports one bundle, each submission became its own case. The OCIO
 cases pin the `aces_1.2` stock config, as the Squish scene did.
 
-Remaining: `manual_attachments_gui`, `invalid_conda_gui`. Squish stays until they are ported.
+Remaining: `manual_attachments_gui`. Squish stays until it is ported.
 
 Scenes are built programmatically rather than opening the Squish `.nk` sample
 files, so the suite needs no Git LFS assets and each case's inputs are

--- a/test/nuke_submitter_ui/_utils.py
+++ b/test/nuke_submitter_ui/_utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import time
 from datetime import datetime
@@ -16,6 +17,17 @@ from deadline_test_fixtures.job_bundle import (
 )
 
 _T0 = time.monotonic()
+
+# Mock backend latency, approximating the real service so timing races are not
+# hidden by a zero-latency mock.
+DEFAULT_MOCK_RESPONSE_DELAY_S = 0.3
+
+
+def mock_response_delay() -> float:
+    return float(
+        os.environ.get("MOCK_DEADLINE_RESPONSE_DELAY_S", str(DEFAULT_MOCK_RESPONSE_DELAY_S))
+    )
+
 
 # Placeholder used in committed expected/job_bundle/ files wherever the
 # resolved repo root appears (scene file, output dirs). Replaced with the

--- a/test/nuke_submitter_ui/conftest.py
+++ b/test/nuke_submitter_ui/conftest.py
@@ -28,6 +28,7 @@ from deadline_test_fixtures.deadline_mock import (
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _launcher import find_nuke_executable  # noqa: E402
+from _utils import mock_response_delay  # noqa: E402
 
 
 def pytest_collection_modifyitems(config, items):
@@ -74,7 +75,7 @@ def mock_deadline_server() -> Iterator[MockDeadlineServerProcess]:
     service's observed 200-600 ms, so timing races that a zero-latency mock
     would hide still surface. Override via MOCK_DEADLINE_RESPONSE_DELAY_S.
     """
-    delay = float(os.environ.get("MOCK_DEADLINE_RESPONSE_DELAY_S", "0.3"))
+    delay = mock_response_delay()
     server = MockDeadlineServerProcess(MockDeadlineScenario(response_delay_s=delay)).start()
     try:
         yield server

--- a/test/nuke_submitter_ui/pages.py
+++ b/test/nuke_submitter_ui/pages.py
@@ -73,6 +73,14 @@ _TEXT_FRAME_RANGE = 1
 # Positional within the shared tab's "Job Properties" group, in document order
 # (1-based). That group lives in the shared client's UI, so its name is the
 # stable anchor and only the order inside it is positional.
+# The Conda queue environment's fields, on the shared tab, present only when
+# the queue serves that environment. Both are anonymous in the AX tree and
+# each label is a sibling static_text that FOLLOWS its field, so they are
+# positional within the group.
+_GROUP_QUEUE_ENVIRONMENT_CONDA = "Queue Environment: Conda"
+_TEXT_CONDA_PACKAGES = 1
+_TEXT_CONDA_CHANNELS = 2
+
 _GROUP_JOB_PROPERTIES = "Job Properties"
 _SPIN_PRIORITY = 1
 _SPIN_MAX_FAILED_TASKS = 2
@@ -152,6 +160,28 @@ class NukeSubmitterDialog(SharedSubmitterDialog):
         return set_text_field(
             self.window, _DESCRIPTION_FIELD_AX_NAME, description, timeout=WIDGET_TIMEOUT
         )
+
+    def _conda_field(self, index: int) -> xa11y.Locator:
+        self.switch_to_shared_tab()
+        field = (
+            self.window.descendant(f'group[name="{_GROUP_QUEUE_ENVIRONMENT_CONDA}"]')
+            .descendant("text_field")
+            .nth(index)
+        )
+        field.wait_visible(timeout=WIDGET_TIMEOUT)
+        return field
+
+    def conda_packages(self) -> str:
+        return self._conda_field(_TEXT_CONDA_PACKAGES).element().value or ""
+
+    def set_conda_packages(self, packages: str) -> None:
+        self._conda_field(_TEXT_CONDA_PACKAGES).set_value(packages)
+
+    def conda_channels(self) -> str:
+        return self._conda_field(_TEXT_CONDA_CHANNELS).element().value or ""
+
+    def set_conda_channels(self, channels: str) -> None:
+        self._conda_field(_TEXT_CONDA_CHANNELS).set_value(channels)
 
     def wait_farm_resolved(self, farm_name: str, timeout: float = FARM_RESOLVE_TIMEOUT) -> None:
         """Wait until the farm display name appears in the dialog tree,

--- a/test/nuke_submitter_ui/test_cases/conda_queue_environment/expected/job_bundle/asset_references.yaml
+++ b/test/nuke_submitter_ui/test_cases/conda_queue_environment/expected/job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/conda_queue_environment/actual/conda_queue_environment.nk
+  outputs:
+    directories:
+    - <REPO_ROOT>/test/nuke_submitter_ui/test_cases/conda_queue_environment/actual/renders
+  referencedPaths: []

--- a/test/nuke_submitter_ui/test_cases/conda_queue_environment/expected/job_bundle/parameter_values.yaml
+++ b/test/nuke_submitter_ui/test_cases/conda_queue_environment/expected/job_bundle/parameter_values.yaml
@@ -1,0 +1,25 @@
+parameterValues:
+- name: Frames
+  value: 1-10
+- name: NukeScriptFile
+  value: <REPO_ROOT>/test/nuke_submitter_ui/test_cases/conda_queue_environment/actual/conda_queue_environment.nk
+- name: ProxyMode
+  value: 'false'
+- name: ContinueOnError
+  value: 'false'
+- name: ChunkSize
+  value: 1
+- name: TargetChunkDuration
+  value: 0
+- name: CondaPackages
+  value: invalid-package=1.0
+- name: CondaChannels
+  value: invalid-channel
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/test/nuke_submitter_ui/test_cases/conda_queue_environment/expected/job_bundle/template.yaml
+++ b/test/nuke_submitter_ui/test_cases/conda_queue_environment/expected/job_bundle/template.yaml
@@ -1,0 +1,153 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: Invalid Conda Settings Job
+parameterDefinitions:
+- name: NukeScriptFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    fileFilters:
+    - label: Nuke Script Files
+      patterns:
+      - '*.nk'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Nuke script file to render.
+- name: Frames
+  type: STRING
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ChunkSize
+  type: INT
+  default: 1
+  minValue: 1
+  description: |
+    Number of frames per chunk. Use 1 for one frame per task (default). Higher values group frames into chunks to reduce per-task overhead.
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+- name: TargetChunkDuration
+  type: INT
+  default: 0
+  minValue: 0
+  description: |
+    Optional target duration in seconds per chunk. When set, the scheduler dynamically adjusts chunk sizes based on observed runtimes of completed chunks. Set to 0 to use a fixed chunk size for all chunks.
+  userInterface:
+    control: SPIN_BOX
+    label: Target Chunk Duration (Seconds)
+- name: WriteNode
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Write Node
+  description: Which write node to render ('All Write Nodes' for all of them)
+  default: All Write Nodes
+  allowedValues:
+  - All Write Nodes
+  - Write1
+- name: View
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+  description: Which view to render ('All Views' for all of them)
+  default: All Views
+  allowedValues:
+  - All Views
+  - main
+- name: ProxyMode
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Proxy Mode
+  description: Render in Proxy Mode.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: ContinueOnError
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Continue On Error
+  description: Continue processing when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: '{{Param.Frames}}'
+      chunks:
+        defaultTaskCount: '{{Param.ChunkSize}}'
+        targetRuntimeSeconds: '{{Param.TargetChunkDuration}}'
+        rangeConstraint: CONTIGUOUS
+  stepEnvironments:
+  - name: Nuke
+    description: Runs Nuke in the background with a script file loaded.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          continue_on_error: {{Param.ContinueOnError}}
+          proxy: {{Param.ProxyMode}}
+          script_file: '{{Param.NukeScriptFile}}'
+          write_nodes:
+          - '{{Param.WriteNode}}'
+          views:
+          - '{{Param.View}}'
+      actions:
+        onEnter:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 86400
+        onExit:
+          command: NukeAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 3600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: 'frameRange: "{{Task.Param.Frame}}"'
+    actions:
+      onRun:
+        command: NukeAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{Session.WorkingDirectory}}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 518400
+description: This test verifies handling of invalid Conda packages and channels

--- a/test/nuke_submitter_ui/test_cases/conda_queue_environment/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/conda_queue_environment/input/configure.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Configurator for conda_queue_environment.
+
+Port of the Squish invalid_conda_gui case, with the subject changed on
+purpose. Squish typed a non-existent package and asserted the submission
+failed, which is a farm-side outcome nothing here can reproduce. What is
+verifiable offline is the client-side contract that case relied on: the
+submitter fills these fields in for the running Nuke, the client adds the
+deadline-cloud-v2 channel, and typed values reach the bundle unaltered. That
+last part is why an invalid package fails on the farm rather than being
+swallowed in the submitter.
+"""
+
+INVALID_PACKAGES = "invalid-package=1.0"
+INVALID_CHANNEL = "invalid-channel"
+
+
+def configure(dialog) -> None:
+    dialog.set_job_name("Invalid Conda Settings Job")
+    dialog.set_job_description("This test verifies handling of invalid Conda packages and channels")
+
+    packages = dialog.conda_packages()
+    assert (
+        "nuke=" in packages and "nuke-openjd=" in packages
+    ), f"expected auto-populated Nuke and adaptor versions; saw {packages!r}"
+    channels = dialog.conda_channels()
+    assert channels.split()[:2] == [
+        "deadline-cloud-v2",
+        "deadline-cloud",
+    ], f"expected the v2 channel ahead of the default; saw {channels!r}"
+
+    dialog.set_conda_packages(INVALID_PACKAGES)
+    dialog.set_conda_channels(INVALID_CHANNEL)
+    assert dialog.conda_packages() == INVALID_PACKAGES
+    assert dialog.conda_channels() == INVALID_CHANNEL

--- a/test/nuke_submitter_ui/test_cases/conda_queue_environment/input/scenario.py
+++ b/test/nuke_submitter_ui/test_cases/conda_queue_environment/input/scenario.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Backend scenario for conda_queue_environment.
+
+The shared mock serves a queue with no queue environments, so the fields under
+test would not exist. Template is the console-equivalent Conda queue
+environment from deadline-cloud-samples; only its parameter definitions
+matter here, since these tests export a bundle rather than render.
+"""
+
+from deadline_test_fixtures.deadline_mock import MockDeadlineScenario
+
+QUEUE_ENVIRONMENT_NAME = "Conda"
+
+_CONDA_QUEUE_ENVIRONMENT_TEMPLATE = """
+specificationVersion: 'environment-2023-09'
+parameterDefinitions:
+- name: CondaPackages
+  type: STRING
+  description: >
+    This is a space-separated list of Conda package match specifications to
+    install for the job. E.g. "blender=4.3" for a job that renders frames in
+    Blender 4.3.
+  default: ""
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+- name: CondaChannels
+  type: STRING
+  description: >
+    This is a space-separated list of Conda channels from which to install
+    packages.
+  default: "deadline-cloud"
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Channels
+environment:
+  name: Conda
+  script:
+    actions:
+      onEnter:
+        command: "conda-queue-env-enter"
+        args:
+        - "{{Session.WorkingDirectory}}/.env"
+        - "--packages"
+        - "{{Param.CondaPackages}}"
+        - "--channels"
+        - "{{Param.CondaChannels}}"
+      onExit:
+        command: "conda-queue-env-exit"
+"""
+
+
+def scenario() -> MockDeadlineScenario:
+    return MockDeadlineScenario(
+        queue_environments=(
+            {
+                "queueEnvironmentId": "queueenv-conda",
+                "name": QUEUE_ENVIRONMENT_NAME,
+                "priority": 1,
+                "templateType": "YAML",
+                "template": _CONDA_QUEUE_ENVIRONMENT_TEMPLATE,
+            },
+        ),
+    )

--- a/test/nuke_submitter_ui/test_cases/conda_queue_environment/input/scene.py
+++ b/test/nuke_submitter_ui/test_cases/conda_queue_environment/input/scene.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Scene for conda_queue_environment, run inside GUI Nuke by the opener hook.
+
+Minimal on purpose: this case is about the Conda queue environment's fields.
+"""
+
+import os
+
+import nuke
+
+scene_file = os.environ["NUKE_SUBMITTER_UI_SCENE_FILE"]
+scene_dir = os.path.dirname(scene_file)
+
+nuke.root()["first_frame"].setValue(1)
+nuke.root()["last_frame"].setValue(10)
+
+color_wheel = nuke.nodes.ColorWheel()
+write_node = nuke.nodes.Write(name="Write1")
+write_node.setInput(0, color_wheel)
+write_node["file"].setValue(os.path.join(scene_dir, "renders", "conda_queue_environment.####.exr"))
+
+nuke.scriptSaveAs(scene_file, overwrite=1)

--- a/test/nuke_submitter_ui/test_submitter_ui.py
+++ b/test/nuke_submitter_ui/test_submitter_ui.py
@@ -14,12 +14,18 @@ from __future__ import annotations
 
 import importlib.util
 import os
+from contextlib import ExitStack
+from dataclasses import replace
 from pathlib import Path
 from shutil import rmtree
 from typing import Callable, Optional
 
 import pytest
-from deadline_test_fixtures.deadline_mock import write_deadline_config
+from deadline_test_fixtures.deadline_mock import (
+    MockDeadlineScenario,
+    MockDeadlineServerProcess,
+    write_deadline_config,
+)
 from deadline_test_fixtures.job_bundle import (
     JobBundleCase,
     assert_valid_job_bundle,
@@ -31,6 +37,7 @@ from _utils import (
     assert_bundle_matches_golden,
     copy_bundle_files_flat,
     log,
+    mock_response_delay,
     write_goldens_from_actual,
 )
 from pages import NukeSubmitterDialog
@@ -49,6 +56,35 @@ _CASES = sorted(
     for path in _CASES_ROOT.iterdir()
     if path.is_dir() and not path.name.startswith((".", "_"))
 )
+
+
+def _load_scenario(cases_root: Path, case: str) -> Optional[MockDeadlineScenario]:
+    """Load a case's optional input/scenario.py.
+
+    Cases share the session's mock backend, whose scenario has no queue
+    environments. A case needing more (a Conda queue environment, so the
+    dialog renders those fields) defines a top-level ``scenario()`` and gets
+    its own server. A broken scenario.py fails loudly rather than skipping.
+    """
+    scenario_path = cases_root / case / "input" / "scenario.py"
+    if not scenario_path.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location(f"_scenario_{case}", scenario_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load scenario at {scenario_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    build = getattr(module, "scenario", None)
+    if not callable(build):
+        raise AttributeError(f"{scenario_path} must define a top-level scenario() function")
+    scenario = build()
+    if not isinstance(scenario, MockDeadlineScenario):
+        raise TypeError(f"{scenario_path}: scenario() must return a MockDeadlineScenario")
+    if not scenario.response_delay_s:
+        # Match the session server, so a per-case server is not silently
+        # zero-latency and hiding races.
+        scenario = replace(scenario, response_delay_s=mock_response_delay())
+    return scenario
 
 
 def _load_configurator(cases_root: Path, case: str) -> Optional[DialogConfigurator]:
@@ -119,40 +155,52 @@ def test_submitter_export_bundle(
     actual_dir = bundle_case.prepare_actual_dir()
     configure = _load_configurator(_CASES_ROOT, case)
 
-    config_path, job_history_dir = _write_case_config(tmp_path, mock_deadline_server.scenario)
-    env = build_nuke_environment(
-        deadline_endpoint_url=mock_deadline_server.base_url,
-        config_path=config_path,
-        work_dir=tmp_path,
-        scene_script=scene_script,
-        scene_file=actual_dir / f"{case}.nk",
-    )
+    with ExitStack() as stack:
+        case_scenario = _load_scenario(_CASES_ROOT, case)
+        if case_scenario is None:
+            server, backend = mock_deadline_server, mock_backend
+        else:
+            log(f"case {case}: starting a case-specific mock backend")
+            server = stack.enter_context(MockDeadlineServerProcess(case_scenario))
+            backend = server.backend
+            backend.reset()
 
-    log(f"case {case}: launching Nuke")
-    session = launch_nuke_with_submitter(nuke_executable, env, tmp_path)
-    try:
-        dialog = NukeSubmitterDialog.wait_for(session.app, ensure_frontmost=session.activate)
-        dialog.wait_farm_resolved(_MOCK_FARM_NAME)
-        dialog.wait_settled()
+        config_path, job_history_dir = _write_case_config(tmp_path, server.scenario)
+        env = build_nuke_environment(
+            deadline_endpoint_url=server.base_url,
+            config_path=config_path,
+            work_dir=tmp_path,
+            scene_script=scene_script,
+            scene_file=actual_dir / f"{case}.nk",
+        )
 
-        if os.environ.get("NUKE_SUBMITTER_UI_DIALOG_DUMP") == "1":
-            dialog.dump_settings_tabs()
-            pytest.fail("NUKE_SUBMITTER_UI_DIALOG_DUMP=1: dumped settings tabs, skipping export")
+        log(f"case {case}: launching Nuke")
+        session = launch_nuke_with_submitter(nuke_executable, env, tmp_path)
+        try:
+            dialog = NukeSubmitterDialog.wait_for(session.app, ensure_frontmost=session.activate)
+            dialog.wait_farm_resolved(_MOCK_FARM_NAME)
+            dialog.wait_settled()
 
-        if configure is not None:
-            log(f"case {case}: running configurator")
-            configure(dialog)
+            if os.environ.get("NUKE_SUBMITTER_UI_DIALOG_DUMP") == "1":
+                dialog.dump_settings_tabs()
+                pytest.fail(
+                    "NUKE_SUBMITTER_UI_DIALOG_DUMP=1: dumped settings tabs, skipping export"
+                )
 
-        log(f"case {case}: exporting bundle")
-        dialog.export_bundle()
-    finally:
-        session.close()
+            if configure is not None:
+                log(f"case {case}: running configurator")
+                configure(dialog)
 
-    exported_bundle = find_complete_job_bundle(job_history_dir)
-    assert exported_bundle is not None, f"no complete bundle found under {job_history_dir}"
-    copy_bundle_files_flat(exported_bundle, actual_dir)
+            log(f"case {case}: exporting bundle")
+            dialog.export_bundle()
+        finally:
+            session.close()
 
-    _assert_expected_mock_traffic(mock_backend)
+        exported_bundle = find_complete_job_bundle(job_history_dir)
+        assert exported_bundle is not None, f"no complete bundle found under {job_history_dir}"
+        copy_bundle_files_flat(exported_bundle, actual_dir)
+
+        _assert_expected_mock_traffic(backend)
 
     assert_valid_job_bundle(actual_dir / "template.yaml")
 


### PR DESCRIPTION
Fifth in a series porting the Squish GUI cases to the xa11y suite from #330, after #339, #340, #342 and #343. Leaves `manual_attachments_gui`, then Squish can go.

### What was the problem/requirement? (What/Why)

The Squish suite needs a commercial license, a Squish-for-Qt build matching Nuke's Qt, and a real farm with credentials. This ports `invalid_conda_gui`.

### What was the solution? (How)

One case, `conda_queue_environment`, with the subject changed on purpose. Squish typed a non-existent package and asserted the *submission* failed, which is a farm-side outcome nothing offline can reproduce. The client-side contract that case relied on is testable, and is what the golden pins:

- the submitter fills the Conda fields in for the running Nuke (`nuke=<major>.*`, `nuke-openjd=<adaptor>.*`)
- the client puts `deadline-cloud-v2` ahead of the default channel
- typed values reach the bundle unaltered, which is what makes an invalid package fail on the farm rather than get swallowed in the submitter

Those fields only exist when the queue serves a Conda queue environment, and the shared mock scenario has none. So a case can now supply `input/scenario.py` and get its own mock server for the duration, while every other case keeps using the session server. Disabling that hook fails this case, so it is load bearing rather than decoration.

### What is the impact of this change?

Test-only and additive: one case folder, the per-case scenario hook, Conda field accessors, a README row.

### How was this change tested?

macOS 15.7.7, Nuke 16.0v7, against current mainline: `10 passed in 138s`, no leftover Nuke processes.

Worth stating: 5 of 7 full runs were green. The two failures landed in a run that took 4:45 against a steady 2:18, so they track machine load rather than this case. The suite drives real synthetic input and needs an idle machine, which is why it is not in CI.

`ruff` and `black --check` clean. `mypy` clean on the changed files. It also reports a missing return in `conftest.py`, which only happens when mypy runs without pytest installed, not in CI.

#### Please run the integration tests and paste the results below

Not applicable. This adds a case to the opt-in GUI suite, and that result is above.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

Not applicable, nothing under `installer/` or `src/` changed.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. Nothing under `src/` changed, so bundle output cannot differ. This case's golden is an exported bundle, compared on every run.

### Was this change documented?

README status row, plus the case's `configure.py` and `scenario.py`, which record the divergence from Squish and why the scenario exists.

### Is this a breaking change?

No. Test-only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
