### PR TITLE
test: Fix the integ tests to use Save bundle as button

### DIFF
--- a/requirements-ui-testing.txt
+++ b/requirements-ui-testing.txt
@@ -1,6 +1,6 @@
 # Dependencies for the xa11y-driven GUI test suite in test/nuke_submitter_ui.
 # See test/nuke_submitter_ui/README.md for setup and usage.
-deadline-cloud-test-fixtures == 0.18.*
+deadline-cloud-test-fixtures >= 0.18.20, < 0.19
 xa11y == 0.13.*
 openjd-cli == 0.7.*
 # Verified activation of the Nuke app (see _launcher.py platform notes).

--- a/test/nuke_submitter_ui/pages.py
+++ b/test/nuke_submitter_ui/pages.py
@@ -44,7 +44,7 @@ from typing import Callable
 
 import xa11y
 from _utils import log
-from deadline_test_fixtures.xa11y import SharedSubmitterDialog
+from deadline_test_fixtures.xa11y import SharedSubmitterDialog, dismiss_bundle_saved_popup
 from deadline_test_fixtures.xa11y.controls import (
     TAB_JOB_SPECIFIC,
     TAB_SHARED,
@@ -118,7 +118,7 @@ class NukeSubmitterDialog(SharedSubmitterDialog):
         window: xa11y.Locator,
         ensure_frontmost: Callable[[], object] | None = None,
     ) -> None:
-        super().__init__(window)
+        super().__init__(window, app_root=app)
         self.app = app
         self.window = window
         self._ensure_frontmost = ensure_frontmost or (lambda: None)
@@ -487,31 +487,13 @@ class NukeSubmitterDialog(SharedSubmitterDialog):
     # ------------------------------------------------------------------
 
     def export_bundle(self, timeout: float = EXPORT_TIMEOUT) -> None:
-        """Press 'Export bundle' and dismiss the confirmation message box.
-
-        No file dialog is involved: the bundle is written to the configured
-        ``job_history_dir``. The confirmation QMessageBox is a separate
-        window whose AX name is empty on macOS, so it is matched by its
-        body text ("Saved the submission as a job bundle") before OK is
-        pressed — an app-wide bare OK match could hit an unrelated dialog.
-        """
+        """Save the bundle locally and dismiss the host-owned confirmation."""
         self._front()
-        self.button("Export bundle").press()
-        body = self.app.locator("static_text[name^='Saved the submission as a job bundle']")
-        ok = self.app.locator('button[name="OK"]')
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            self._front()
-            try:
-                if body.exists() and ok.exists():
-                    ok.press()
-                    return
-            except Exception:
-                # The message box may be mid-animation or the tree mid-churn
-                # after the export; poll again until the deadline.
-                pass
-            time.sleep(0.5)
-        raise TimeoutError(f"Export confirmation did not appear in {timeout}s\n{self.dump_tree()}")
+        self.save_bundle_locally(timeout=timeout)
+        if not dismiss_bundle_saved_popup(self.app.pid, timeout=timeout):
+            raise TimeoutError(
+                f"Bundle saved confirmation did not appear in {timeout}s\n{self.dump_tree()}"
+            )
 
     def dump_tree(self) -> str:
         self._front()

--- a/test/nuke_submitter_ui/test_cases/basic_workflow/input/configure.py
+++ b/test/nuke_submitter_ui/test_cases/basic_workflow/input/configure.py
@@ -2,7 +2,7 @@
 
 """Dialog configurator for the basic_workflow case.
 
-Runs after the submitter dialog has settled and before Export bundle is
+Runs after the submitter dialog has settled and before Save bundle as is
 pressed. Receives the suite's NukeSubmitterDialog page object (see
 test/nuke_submitter_ui/pages.py), which encodes the platform workarounds
 for combos and spin boxes. Whatever this changes must be reflected in this

--- a/test/nuke_submitter_ui/test_submitter_ui.py
+++ b/test/nuke_submitter_ui/test_submitter_ui.py
@@ -72,16 +72,19 @@ def _load_configurator(cases_root: Path, case: str) -> Optional[DialogConfigurat
 
 
 def _write_case_config(tmp_path: Path, scenario) -> tuple[Path, Path]:
-    """Write the isolated deadline config; return (config_path, history_dir)."""
+    """Write the isolated deadline config; return (config_path, export_dir)."""
     config_path = tmp_path / "deadline_config"
     job_history_dir = tmp_path / "job_history"
+    export_dir = tmp_path / "exported_bundles"
+    export_dir.mkdir()
     write_deadline_config(
         config_path,
         farm_id=scenario.farm_id,
         queue_id=scenario.queue_id,
         job_history_dir=job_history_dir,
+        job_bundle_default_directory=export_dir,
     )
-    return config_path, job_history_dir
+    return config_path, export_dir
 
 
 def _assert_expected_mock_traffic(mock_backend) -> None:
@@ -119,7 +122,7 @@ def test_submitter_export_bundle(
     actual_dir = bundle_case.prepare_actual_dir()
     configure = _load_configurator(_CASES_ROOT, case)
 
-    config_path, job_history_dir = _write_case_config(tmp_path, mock_deadline_server.scenario)
+    config_path, export_dir = _write_case_config(tmp_path, mock_deadline_server.scenario)
     env = build_nuke_environment(
         deadline_endpoint_url=mock_deadline_server.base_url,
         config_path=config_path,
@@ -143,13 +146,13 @@ def test_submitter_export_bundle(
             log(f"case {case}: running configurator")
             configure(dialog)
 
-        log(f"case {case}: exporting bundle")
+        log(f"case {case}: saving bundle locally")
         dialog.export_bundle()
     finally:
         session.close()
 
-    exported_bundle = find_complete_job_bundle(job_history_dir)
-    assert exported_bundle is not None, f"no complete bundle found under {job_history_dir}"
+    exported_bundle = find_complete_job_bundle(export_dir)
+    assert exported_bundle is not None, f"no complete bundle found under {export_dir}"
     copy_bundle_files_flat(exported_bundle, actual_dir)
 
     _assert_expected_mock_traffic(mock_backend)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The integration tests started failing because the button changed from "Export Bundle" to "Save bundle as".

See this PR: https://github.com/aws-deadline/deadline-cloud/pull/1181

### What was the solution? (How)

To ensure we reduce duplicate code, I updated the `deadline-cloud-test-fixtures` repo to have few reusable functions that we can update so that we don't need to update every DCC in the future when there's such a failure. 

This DCC just reuses the code in that repo. 

### What is the impact of this change?

The integ tests will now start succeeding again. 

### How was this change tested?

Ran the test in CI and confirmed that they now work.  https://github.com/aws-deadline/deadline-cloud-for-nuke/actions/runs/33020112850/job/98348149565

### Was this change documented?

No documentation change required. Test only changes. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
